### PR TITLE
Refactor plugin protocol toward typed definitions and explicit runtime methods

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,21 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(awk '{print $5, $9}')",
+      "Bash(git -C C:/Users/oster/code/calvin diff --stat HEAD)",
+      "Bash(git -C C:/Users/oster/code/calvin-plugins diff --stat HEAD)",
+      "Bash(git -C C:/Users/oster/code/calvin log --oneline -5)",
+      "Bash(git -C C:/Users/oster/code/calvin-plugins log --oneline -5)",
+      "Bash(git -C C:/Users/oster/code/calvin diff HEAD -- frontend/src/components/ClockBarHorizontal.vue frontend/src/components/settings/specialized/PluginCard.vue frontend/src/components/settings/specialized/PluginInstances.vue frontend/src/components/settings/tabs/layout/UITab.vue frontend/src/stores/config.js frontend/src/components/settings/specialized/InstanceModal.vue)",
+      "Bash(git -C C:/Users/oster/code/calvin diff HEAD -- frontend/src/stores/config.js frontend/src/components/settings/tabs/layout/UITab.vue)",
+      "Bash(git -C C:/Users/oster/code/calvin-plugins diff HEAD -- CREATING_PLUGINS.md imap/plugin.py mealie/plugin.py yr_weather/plugin.py)",
+      "Bash(grep -E \"\\\\.\\(ts|tsx|js|jsx|py\\)$\")",
+      "Bash(grep -E \"\\\\.\\(vue|ts|tsx|js|jsx\\)$\")",
+      "Bash(git add *)",
+      "Bash(git commit -m ' *)",
+      "Bash(xargs grep *)",
+      "Bash(grep -E \"\\\\.\\(js|ts|vue\\)$\")",
+      "Bash(xargs -I {} bash -c \"echo '=== {} ===' && head -30 {}\")"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Dev mode marker — touch backend/.dev to enable dev features locally
+backend/.dev
+
 # Python
 __pycache__/
 *.py[cod]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,102 @@
+# Calvin — Developer Guide
+
+Orientation for humans and AI agents working on Calvin. Read this first; follow the links for depth.
+
+Calvin is a self-hosted Raspberry Pi dashboard (calendars, photos, web services) with a Vue 3 frontend, a FastAPI backend, and a plugin system. Plugins live in a **separate repo** at `../calvin-plugins/` and are installed into `data/plugins/{plugin_id}/` at runtime.
+
+## Stack
+
+- **Backend:** FastAPI + uvicorn, Python 3.12+, `uv` package manager, Ormar ORM + Alembic (SQLite), APScheduler, Loguru (unified via `InterceptHandler`), Pluggy for plugin hooks.
+- **Frontend:** Vue 3 Composition API, Vite, Pinia stores, Vue Router. Built to `frontend/dist/` and served by FastAPI at `/`. API lives at `/api/*`.
+- **Platforms:** develop on Windows/Linux, deploy on Raspberry Pi. Keyboard input uses `evdev` on Linux, a mock on Windows.
+
+Entry points: [backend/app/main.py](backend/app/main.py) (lifespan → DB init → plugin load → schedulers), [frontend/src/main.js](frontend/src/main.js).
+
+## Plugin system — the core pattern
+
+**Plugins must be fully self-contained.** One directory holds everything: backend logic, config schema, frontend components, assets, manifest. No cross-plugin imports. A plugin only imports from `app.*` or third-party libraries.
+
+A plugin directory:
+
+```
+{plugin_id}/
+  plugin.json       # manifest: id, name, type, version, format_version, deps, requirements
+  plugin.py         # backend: Pluggy hook impls + BasePlugin subclass
+  frontend/         # optional Vue components, copied to frontend/src/components/plugins/{plugin_id}/ at install
+  ...assets
+```
+
+**Plugin types:** `calendar`, `image`, `service`, `backend`, `theme` — see [app/plugins/base.py](backend/app/plugins/base.py).
+
+**Contract (backend):**
+- Implement a `BasePlugin` subclass with `initialize()`, `cleanup()`, `get_plugin_metadata()`.
+- Register via Pluggy hooks in `plugin.py`: `register_plugin_types()`, `create_plugin_instance()`, and optionally `handle_plugin_config_update`, `test_plugin_connection`, `fetch_plugin_data`, `fetch_service_data`. See [app/plugins/hooks.py](backend/app/plugins/hooks.py).
+- Use `instance_config_schema` in metadata to declare per-instance settings — the frontend auto-generates forms from this via `PluginFieldRenderer`. Don't hand-roll settings UI.
+- For multi-instance plugins, use the generic helpers in `app/utils/instance_manager.py` (`extract_config_value`, `InstanceManagerConfig`, `handle_plugin_config_update_generic`). Avoid reimplementing CRUD.
+
+**Contract (frontend):**
+- Declare UI in metadata: `display_schema.component` (main view) and/or `statusbar_schema` (status bar item).
+- Component files go in the plugin's `frontend/` dir and are copied into `frontend/src/components/plugins/{plugin_id}/` at install time.
+- Components are discovered via a Vite glob and loaded dynamically by [usePluginComponent.js](frontend/src/composables/usePluginComponent.js). No manual registration.
+- Frontend auto-rebuilds when a plugin with UI is installed — `FrontendBuildManager` in [plugin_installer.py](backend/app/services/plugin_installer.py) writes a `.rebuild_needed` marker and runs `npm run build` in the background; startup resumes interrupted builds.
+
+**Reference plugin:** [`mealie/`](../calvin-plugins/mealie) in `calvin-plugins`. Scaffolding guide: [calvin-plugins/CREATING_PLUGINS.md](../calvin-plugins/CREATING_PLUGINS.md). Detailed specs in [docs/plugins/](docs/plugins/).
+
+## Conventions
+
+**State (frontend):** one Pinia store per domain (`config`, `webServices`, `calendar`, `images`, `themes`, `keyboard`, `mode`, `connection`). Stores expose refs + async actions. Network calls try the API first and fall back to localStorage cache with TTL (see [utils/cache.js](frontend/src/utils/cache.js) and [stores/webServices.js](frontend/src/stores/webServices.js)).
+
+**Routing:** FastAPI routers per domain under `backend/app/api/routes/`. The backend serves `index.html` for all non-`/api` paths (SPA). Frontend uses Vue Router + `useModeStore` to switch between calendar/photos/services/settings.
+
+**Components:** reusable building blocks (`PluginFieldRenderer`, `PluginActions`, `PluginStatusbarItems`, `LayoutManager`) compose plugin-provided views. Prefer extending these over new one-offs.
+
+**Logging:** `loguru` on the backend (via `InterceptHandler` — don't use stdlib `logging` directly). `logDebug`/`logError` from [utils/logger.js](frontend/src/utils/logger.js) on the frontend.
+
+**Database writes:** wrap with `retry_on_db_locked` — SQLite locks under concurrent plugin ops. Always `await initialize_database()` before loading plugins.
+
+**Adding a feature to an existing plugin:** extend `instance_config_schema` → the form updates itself → wire the field into the plugin's hook impl. No frontend form edits needed for plain inputs.
+
+## Gotchas — learned the hard way
+
+- **Unref reactive refs before string interpolation** in axios URLs. `${serviceId}` on a `ref` becomes `[object Object]`. Always `unref(serviceId)` first. (commit 6edb2c4)
+- **`uv pip` flag order:** `uv pip install --python <path> <pkg>` — `--python` goes *after* `install`, not before. (commit 4d73ca2)
+- **Frontend rebuild marker** (`.rebuild_needed`) must be written *before* the build starts so an interrupted process resumes on next startup. (commit 08cda03)
+- **SQLite "database is locked"** under plugin install concurrency → use `retry_on_db_locked` with exponential backoff.
+- **Vite glob paths must match exactly.** Component paths are relative to `frontend/src/components/plugins/`. If `usePluginComponent` can't find a component, check the glob debug logs and the exact filename case.
+- **Keyboard input on Windows** uses a mock — real input paths only work on Linux/RPi. Don't assume hardware events in dev.
+
+## Quick map
+
+| Area | Path |
+|---|---|
+| Backend bootstrap | [backend/app/main.py](backend/app/main.py) |
+| Plugin base / types | [backend/app/plugins/base.py](backend/app/plugins/base.py) |
+| Plugin hooks (Pluggy) | [backend/app/plugins/hooks.py](backend/app/plugins/hooks.py) |
+| Plugin loader | [backend/app/plugins/loader.py](backend/app/plugins/loader.py) |
+| Install + frontend build | [backend/app/services/plugin_installer.py](backend/app/services/plugin_installer.py) |
+| Plugin mgmt API | [backend/app/api/routes/plugins/management.py](backend/app/api/routes/plugins/management.py) |
+| Instance manager helpers | [backend/app/utils/instance_manager.py](backend/app/utils/instance_manager.py) |
+| Dynamic component loader | [frontend/src/composables/usePluginComponent.js](frontend/src/composables/usePluginComponent.js) |
+| Layout / mode switching | [frontend/src/components/LayoutManager.vue](frontend/src/components/LayoutManager.vue) |
+| Plugin settings UI | [frontend/src/components/settings/categories/PluginsCategory.vue](frontend/src/components/settings/categories/PluginsCategory.vue) |
+| Stores | [frontend/src/stores/](frontend/src/stores/) |
+
+## Deeper docs
+
+- [docs/index.md](docs/index.md) — full doc index
+- [docs/plugins/PLUGIN_DEVELOPMENT_GUIDE.md](docs/plugins/PLUGIN_DEVELOPMENT_GUIDE.md) — writing plugins end-to-end
+- [docs/plugins/PLUGIN_INTERFACE.md](docs/plugins/PLUGIN_INTERFACE.md) — hook reference
+- [docs/plugins/PLUGIN_FRONTEND_COMPONENTS.md](docs/plugins/PLUGIN_FRONTEND_COMPONENTS.md) — Vue integration
+- [docs/plugins/PLUGIN_PACKAGE_FORMAT.md](docs/plugins/PLUGIN_PACKAGE_FORMAT.md) — `plugin.json` schema
+- [docs/plugins/PLUGIN_PERSISTENCE_AND_RESTART.md](docs/plugins/PLUGIN_PERSISTENCE_AND_RESTART.md) — lifecycle
+- [docs/EVENT_SYSTEM.md](docs/EVENT_SYSTEM.md) — cross-plugin events
+- [docs/setup/QUICKSTART_DEVELOP.md](docs/setup/QUICKSTART_DEVELOP.md) — dev env
+- [docs/testing/BACKEND_TESTS.md](docs/testing/BACKEND_TESTS.md) — running tests
+- [calvin-plugins/CREATING_PLUGINS.md](../calvin-plugins/CREATING_PLUGINS.md) — plugin scaffold guide
+
+## House rules
+
+- **Keep plugins self-contained.** If you're tempted to import plugin A from plugin B, put the shared code in `app/` or publish a library. Plugins never reach across.
+- **Schema-driven UI first.** Prefer extending `instance_config_schema` over writing a custom settings component.
+- **Don't bypass the instance manager.** If you need CRUD for instances, use the generic helpers.
+- **Check the gotchas list** before debugging weird symptoms like `[object Object]`, "database is locked", or a plugin component that won't load.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,102 @@
+# Calvin — Developer Guide
+
+Orientation for humans and AI agents working on Calvin. Read this first; follow the links for depth.
+
+Calvin is a self-hosted Raspberry Pi dashboard (calendars, photos, web services) with a Vue 3 frontend, a FastAPI backend, and a plugin system. Plugins live in a **separate repo** at `../calvin-plugins/` and are installed into `data/plugins/{plugin_id}/` at runtime.
+
+## Stack
+
+- **Backend:** FastAPI + uvicorn, Python 3.12+, `uv` package manager, Ormar ORM + Alembic (SQLite), APScheduler, Loguru (unified via `InterceptHandler`), Pluggy for plugin hooks.
+- **Frontend:** Vue 3 Composition API, Vite, Pinia stores, Vue Router. Built to `frontend/dist/` and served by FastAPI at `/`. API lives at `/api/*`.
+- **Platforms:** develop on Windows/Linux, deploy on Raspberry Pi. Keyboard input uses `evdev` on Linux, a mock on Windows.
+
+Entry points: [backend/app/main.py](backend/app/main.py) (lifespan → DB init → plugin load → schedulers), [frontend/src/main.js](frontend/src/main.js).
+
+## Plugin system — the core pattern
+
+**Plugins must be fully self-contained.** One directory holds everything: backend logic, config schema, frontend components, assets, manifest. No cross-plugin imports. A plugin only imports from `app.*` or third-party libraries.
+
+A plugin directory:
+
+```
+{plugin_id}/
+  plugin.json       # manifest: id, name, type, version, format_version, deps, requirements
+  plugin.py         # backend: Pluggy hook impls + BasePlugin subclass
+  frontend/         # optional Vue components, copied to frontend/src/components/plugins/{plugin_id}/ at install
+  ...assets
+```
+
+**Plugin types:** `calendar`, `image`, `service`, `backend`, `theme` — see [app/plugins/base.py](backend/app/plugins/base.py).
+
+**Contract (backend):**
+- Implement a `BasePlugin` subclass with `initialize()`, `cleanup()`, `get_plugin_metadata()`.
+- Register via Pluggy hooks in `plugin.py`: `register_plugin_types()`, `create_plugin_instance()`, and optionally `handle_plugin_config_update`, `test_plugin_connection`, `fetch_plugin_data`, `fetch_service_data`. See [app/plugins/hooks.py](backend/app/plugins/hooks.py).
+- Use `instance_config_schema` in metadata to declare per-instance settings — the frontend auto-generates forms from this via `PluginFieldRenderer`. Don't hand-roll settings UI.
+- For multi-instance plugins, use the generic helpers in `app/utils/instance_manager.py` (`extract_config_value`, `InstanceManagerConfig`, `handle_plugin_config_update_generic`). Avoid reimplementing CRUD.
+
+**Contract (frontend):**
+- Declare UI in metadata: `display_schema.component` (main view) and/or `statusbar_schema` (status bar item).
+- Component files go in the plugin's `frontend/` dir and are copied into `frontend/src/components/plugins/{plugin_id}/` at install time.
+- Components are discovered via a Vite glob and loaded dynamically by [usePluginComponent.js](frontend/src/composables/usePluginComponent.js). No manual registration.
+- Frontend auto-rebuilds when a plugin with UI is installed — `FrontendBuildManager` in [plugin_installer.py](backend/app/services/plugin_installer.py) writes a `.rebuild_needed` marker and runs `npm run build` in the background; startup resumes interrupted builds.
+
+**Reference plugin:** [`mealie/`](../calvin-plugins/mealie) in `calvin-plugins`. Scaffolding guide: [calvin-plugins/CREATING_PLUGINS.md](../calvin-plugins/CREATING_PLUGINS.md). Detailed specs in [docs/plugins/](docs/plugins/).
+
+## Conventions
+
+**State (frontend):** one Pinia store per domain (`config`, `webServices`, `calendar`, `images`, `themes`, `keyboard`, `mode`, `connection`). Stores expose refs + async actions. Network calls try the API first and fall back to localStorage cache with TTL (see [utils/cache.js](frontend/src/utils/cache.js) and [stores/webServices.js](frontend/src/stores/webServices.js)).
+
+**Routing:** FastAPI routers per domain under `backend/app/api/routes/`. The backend serves `index.html` for all non-`/api` paths (SPA). Frontend uses Vue Router + `useModeStore` to switch between calendar/photos/services/settings.
+
+**Components:** reusable building blocks (`PluginFieldRenderer`, `PluginActions`, `PluginStatusbarItems`, `LayoutManager`) compose plugin-provided views. Prefer extending these over new one-offs.
+
+**Logging:** `loguru` on the backend (via `InterceptHandler` — don't use stdlib `logging` directly). `logDebug`/`logError` from [utils/logger.js](frontend/src/utils/logger.js) on the frontend.
+
+**Database writes:** wrap with `retry_on_db_locked` — SQLite locks under concurrent plugin ops. Always `await initialize_database()` before loading plugins.
+
+**Adding a feature to an existing plugin:** extend `instance_config_schema` → the form updates itself → wire the field into the plugin's hook impl. No frontend form edits needed for plain inputs.
+
+## Gotchas — learned the hard way
+
+- **Unref reactive refs before string interpolation** in axios URLs. `${serviceId}` on a `ref` becomes `[object Object]`. Always `unref(serviceId)` first. (commit 6edb2c4)
+- **`uv pip` flag order:** `uv pip install --python <path> <pkg>` — `--python` goes *after* `install`, not before. (commit 4d73ca2)
+- **Frontend rebuild marker** (`.rebuild_needed`) must be written *before* the build starts so an interrupted process resumes on next startup. (commit 08cda03)
+- **SQLite "database is locked"** under plugin install concurrency → use `retry_on_db_locked` with exponential backoff.
+- **Vite glob paths must match exactly.** Component paths are relative to `frontend/src/components/plugins/`. If `usePluginComponent` can't find a component, check the glob debug logs and the exact filename case.
+- **Keyboard input on Windows** uses a mock — real input paths only work on Linux/RPi. Don't assume hardware events in dev.
+
+## Quick map
+
+| Area | Path |
+|---|---|
+| Backend bootstrap | [backend/app/main.py](backend/app/main.py) |
+| Plugin base / types | [backend/app/plugins/base.py](backend/app/plugins/base.py) |
+| Plugin hooks (Pluggy) | [backend/app/plugins/hooks.py](backend/app/plugins/hooks.py) |
+| Plugin loader | [backend/app/plugins/loader.py](backend/app/plugins/loader.py) |
+| Install + frontend build | [backend/app/services/plugin_installer.py](backend/app/services/plugin_installer.py) |
+| Plugin mgmt API | [backend/app/api/routes/plugins/management.py](backend/app/api/routes/plugins/management.py) |
+| Instance manager helpers | [backend/app/utils/instance_manager.py](backend/app/utils/instance_manager.py) |
+| Dynamic component loader | [frontend/src/composables/usePluginComponent.js](frontend/src/composables/usePluginComponent.js) |
+| Layout / mode switching | [frontend/src/components/LayoutManager.vue](frontend/src/components/LayoutManager.vue) |
+| Plugin settings UI | [frontend/src/components/settings/categories/PluginsCategory.vue](frontend/src/components/settings/categories/PluginsCategory.vue) |
+| Stores | [frontend/src/stores/](frontend/src/stores/) |
+
+## Deeper docs
+
+- [docs/index.md](docs/index.md) — full doc index
+- [docs/plugins/PLUGIN_DEVELOPMENT_GUIDE.md](docs/plugins/PLUGIN_DEVELOPMENT_GUIDE.md) — writing plugins end-to-end
+- [docs/plugins/PLUGIN_INTERFACE.md](docs/plugins/PLUGIN_INTERFACE.md) — hook reference
+- [docs/plugins/PLUGIN_FRONTEND_COMPONENTS.md](docs/plugins/PLUGIN_FRONTEND_COMPONENTS.md) — Vue integration
+- [docs/plugins/PLUGIN_PACKAGE_FORMAT.md](docs/plugins/PLUGIN_PACKAGE_FORMAT.md) — `plugin.json` schema
+- [docs/plugins/PLUGIN_PERSISTENCE_AND_RESTART.md](docs/plugins/PLUGIN_PERSISTENCE_AND_RESTART.md) — lifecycle
+- [docs/EVENT_SYSTEM.md](docs/EVENT_SYSTEM.md) — cross-plugin events
+- [docs/setup/QUICKSTART_DEVELOP.md](docs/setup/QUICKSTART_DEVELOP.md) — dev env
+- [docs/testing/BACKEND_TESTS.md](docs/testing/BACKEND_TESTS.md) — running tests
+- [calvin-plugins/CREATING_PLUGINS.md](../calvin-plugins/CREATING_PLUGINS.md) — plugin scaffold guide
+
+## House rules
+
+- **Keep plugins self-contained.** If you're tempted to import plugin A from plugin B, put the shared code in `app/` or publish a library. Plugins never reach across.
+- **Schema-driven UI first.** Prefer extending `instance_config_schema` over writing a custom settings component.
+- **Don't bypass the instance manager.** If you need CRUD for instances, use the generic helpers.
+- **Check the gotchas list** before debugging weird symptoms like `[object Object]`, "database is locked", or a plugin component that won't load.

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ dev:
 	@echo "Backend: http://localhost:8000"
 	@echo "Frontend: http://localhost:5173"
 	@echo "Docs: http://localhost:8001"
-	cd backend && uv run uvicorn app.main:app --reload --host 0.0.0.0 --port 8000 &
+	cd backend && uv run uvicorn app.main:app --reload --reload-dir app --host 0.0.0.0 --port 8000 &
 	uv run --project backend mkdocs serve --dev-addr 127.0.0.1:8001 &
 	cd frontend && npm run dev
 
@@ -53,7 +53,7 @@ dev-logs:
 	@echo ""
 	@> logs/dev-backend.log && > logs/dev-frontend.log && > logs/dev-docs.log && > logs/dev-combined.log
 	@trap 'kill 0' EXIT INT TERM; \
-	(cd backend && PYTHONUNBUFFERED=1 uv run uvicorn app.main:app --reload --host 0.0.0.0 --port 8000 2>&1 | \
+	(cd backend && PYTHONUNBUFFERED=1 uv run uvicorn app.main:app --reload --reload-dir app --host 0.0.0.0 --port 8000 2>&1 | \
 		awk '{timestamp=strftime("%Y-%m-%d %H:%M:%S"); logline="["timestamp"] [BACKEND] "$$0; print logline >> "../logs/dev-backend.log"; print logline >> "../logs/dev-combined.log"; print "\033[36m[BACKEND]\033[0m "$$0; fflush()}') & \
 	(uv run --project backend mkdocs serve --dev-addr 127.0.0.1:8001 2>&1 | \
 		awk '{timestamp=strftime("%Y-%m-%d %H:%M:%S"); logline="["timestamp"] [DOCS] "$$0; print logline >> "logs/dev-docs.log"; print logline >> "logs/dev-combined.log"; print "\033[33m[DOCS]\033[0m "$$0; fflush()}') & \

--- a/Makefile.ps1
+++ b/Makefile.ps1
@@ -56,7 +56,7 @@ function Start-Dev {
     
     # Start backend in new PowerShell window
     Write-Host "Starting backend..." -ForegroundColor Yellow
-    Start-Process powershell -ArgumentList "-NoExit", "-Command", "cd '$projectRoot\backend'; uv run uvicorn app.main:app --reload --host 0.0.0.0 --port 8000"
+    Start-Process powershell -ArgumentList "-NoExit", "-Command", "cd '$projectRoot\backend'; uv run uvicorn app.main:app --reload --reload-dir app --host 0.0.0.0 --port 8000"
     
     # Wait a moment for backend to start
     Start-Sleep -Seconds 2
@@ -118,7 +118,7 @@ function Start-Dev-Logs {
         param($Root, $BackendLog, $CombinedLog)
         Set-Location "$Root\backend"
         $env:PYTHONUNBUFFERED = "1"
-        & uv run uvicorn app.main:app --reload --host 0.0.0.0 --port 8000 *>&1 | ForEach-Object {
+        & uv run uvicorn app.main:app --reload --reload-dir app --host 0.0.0.0 --port 8000 *>&1 | ForEach-Object {
             $timestamp = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
             $logLine = "[$timestamp] [BACKEND] $_"
             $logLine | Out-File -FilePath $BackendLog -Append -Encoding utf8

--- a/backend/app/api/routes/config.py
+++ b/backend/app/api/routes/config.py
@@ -8,6 +8,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, ConfigDict
 
+from app.config import settings
 from app.services.config_service import config_service
 from app.services.display_orientation_service import display_orientation_service
 
@@ -411,6 +412,8 @@ async def get_config():
 
     # Add frontend version (from built HTML)
     config["frontendVersion"] = get_frontend_version()
+
+    config["devMode"] = settings.is_dev_mode
 
     return config
 

--- a/backend/app/api/routes/images.py
+++ b/backend/app/api/routes/images.py
@@ -65,14 +65,14 @@ async def get_image_file(image_id: str):
     """
     Get image file by ID from plugin service.
 
-    For remote images (like Unsplash), redirects to the image URL.
-    For local images, serves the file directly.
+    For remote images, downloads and serves via the local cache (avoids rate limits,
+    enables stale-on-error). For local images, serves the file directly.
 
     Args:
         image_id: Image ID
 
     Returns:
-        Image file or redirect to image URL
+        Image file response
     """
     # Get image metadata
     image = await plugin_image_service.get_image_by_id(image_id)
@@ -84,18 +84,6 @@ async def get_image_file(image_id: str):
     image_url = image.get("url") or image.get("raw_url")
     image_path = image.get("path")
 
-    # If it's a remote URL (starts with http), redirect to it
-    if image_url and image_url.startswith("http"):
-        from fastapi.responses import RedirectResponse
-
-        return RedirectResponse(
-            url=image_url,
-            status_code=302,
-            headers={
-                "Cache-Control": "public, max-age=3600",  # Cache for 1 hour
-            },
-        )
-
     # For local images, check if path exists
     if image_path and Path(image_path).exists():
         image_path_obj = Path(image_path)
@@ -103,16 +91,31 @@ async def get_image_file(image_id: str):
             image_path_obj,
             media_type=f"image/{image['format'].lstrip('.')}",
             headers={
-                "Cache-Control": "public, max-age=3600",  # Cache for 1 hour
+                "Cache-Control": "public, max-age=3600",
             },
         )
+
+    # For remote URLs, download and cache locally rather than redirecting.
+    # This avoids rate limits hitting the browser directly and enables stale-on-error.
+    if image_url and image_url.startswith("http"):
+        from fastapi.responses import Response
+
+        from app.services.remote_image_cache import remote_image_cache
+
+        image_data = await remote_image_cache.get_or_fetch(image_url)
+        if image_data:
+            fmt = image.get("format", "jpeg").lstrip(".")
+            return Response(
+                content=image_data,
+                media_type=f"image/{fmt}",
+                headers={"Cache-Control": "public, max-age=3600"},
+            )
 
     # Fallback: Get image data from plugin (download if needed)
     image_data = await plugin_image_service.get_image_data(image_id)
     if not image_data:
         raise ErrorResponse.not_found("Image file", image_id)
 
-    # Return image data directly
     from fastapi.responses import Response
 
     return Response(

--- a/backend/app/api/routes/plugins/config.py
+++ b/backend/app/api/routes/plugins/config.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
@@ -24,6 +25,23 @@ SENSITIVE_FIELDS = {
     "access_token",
     "refresh_token",
 }
+
+
+def normalize_plugin_config(config: dict[str, Any] | None) -> dict[str, Any]:
+    """Normalize plugin config values at the API boundary."""
+    normalized: dict[str, Any] = {}
+
+    for key, value in (config or {}).items():
+        if isinstance(value, dict):
+            normalized[key] = value.get("value") or value.get("default") or ""
+        elif isinstance(value, Path):
+            normalized[key] = str(value)
+        elif value is None:
+            normalized[key] = ""
+        else:
+            normalized[key] = str(value)
+
+    return normalized
 
 
 def mask_sensitive_config(

--- a/backend/app/api/routes/plugins/github.py
+++ b/backend/app/api/routes/plugins/github.py
@@ -1,4 +1,4 @@
-"""GitHub plugin installation endpoints."""
+"""GitHub and local plugin installation endpoints."""
 
 import logging
 import re
@@ -12,6 +12,7 @@ import httpx
 from fastapi import APIRouter, Body, HTTPException
 
 from app.api.routes.plugins.themes import _register_theme_in_db
+from app.config import settings
 from app.plugins.loader import plugin_loader
 from app.services.plugin_installer import frontend_build_manager, plugin_installer
 from app.services.theme_installer import theme_installer
@@ -288,11 +289,9 @@ async def install_plugin_from_github(request: dict[str, Any] = Body(...)):
                     # It just needs a restart to be loaded
 
                 actual_branch = "master" if branch_switched else branch
-                frontend_rebuild_success = None
-                frontend_rebuild_message = None
                 if manifest.get("_has_frontend"):
-                    frontend_rebuild_success, frontend_rebuild_message = (
-                        frontend_build_manager.build(plugin_installer.get_frontend_dir())
+                    frontend_build_manager.start_background_build(
+                        plugin_installer.get_frontend_dir()
                     )
                 return {
                     "success": True,
@@ -301,8 +300,7 @@ async def install_plugin_from_github(request: dict[str, Any] = Body(...)):
                     "branch": actual_branch,
                     "branch_switched": branch_switched,
                     "requires_restart": True,
-                    "frontend_rebuild_success": frontend_rebuild_success,
-                    "frontend_rebuild_message": frontend_rebuild_message,
+                    "frontend_rebuild_in_progress": manifest.get("_has_frontend", False),
                 }
             else:
                 raise HTTPException(
@@ -330,3 +328,166 @@ async def install_plugin_from_github(request: dict[str, Any] = Body(...)):
                 shutil.rmtree(temp_dir)
             except (PermissionError, OSError):
                 pass
+
+
+@router.get("/plugins/local/suggest")
+async def suggest_local_plugin_paths():
+    """
+    Suggest local plugin repository paths by scanning sibling directories (dev mode only).
+    Returns paths to directories containing plugins.json.
+    """
+    if not settings.is_dev_mode:
+        raise HTTPException(
+            status_code=403, detail="Local path install is only available in dev mode"
+        )
+
+    suggestions = []
+    seen = set()
+
+    # Derive repo root from this file's location, then check the parent directory
+    file_repo_root = Path(__file__).resolve().parent.parent.parent.parent.parent.parent
+    parent_dirs = {file_repo_root.parent}
+    if settings.repo_dir and settings.repo_dir.exists():
+        parent_dirs.add(settings.repo_dir.parent)
+
+    for parent in parent_dirs:
+        try:
+            if not parent.is_dir():
+                continue
+            for sibling in sorted(parent.iterdir()):
+                if not sibling.is_dir():
+                    continue
+                if (sibling / "plugins.json").exists():
+                    path_str = str(sibling)
+                    if path_str not in seen:
+                        seen.add(path_str)
+                        suggestions.append(path_str)
+        except Exception as e:
+            logger.warning(f"Failed to scan {parent} for plugin repo suggestions: {e}")
+
+    return {"suggestions": suggestions}
+
+
+@router.post("/plugins/local/enumerate")
+async def enumerate_plugins_from_local(request: dict[str, Any] = Body(...)):
+    """
+    Enumerate available plugins from a local directory (dev mode only).
+
+    Args:
+        request: Request body containing:
+            - local_path: Absolute path to the local plugin repository
+    """
+    if not settings.is_dev_mode:
+        raise HTTPException(
+            status_code=403, detail="Local path install is only available in dev mode"
+        )
+
+    local_path = request.get("local_path")
+    if not local_path or not local_path.strip():
+        raise HTTPException(status_code=400, detail="local_path is required")
+
+    repo_path = Path(local_path)
+    if not repo_path.exists() or not repo_path.is_dir():
+        raise HTTPException(
+            status_code=400, detail=f"Path not found or not a directory: {local_path}"
+        )
+
+    try:
+        plugins_result = plugin_installer.enumerate_plugins_from_repo(repo_path)
+    except Exception as e:
+        logger.warning(f"Failed to enumerate plugins from local path: {e}")
+        plugins_result = {"has_manifest": False, "plugins": []}
+
+    try:
+        themes_result = theme_installer.enumerate_themes_from_repo(repo_path)
+    except Exception as e:
+        logger.warning(f"Failed to enumerate themes from local path: {e}")
+        themes_result = {"has_manifest": False, "themes": []}
+
+    return {
+        "success": True,
+        "local_path": local_path,
+        "plugins": plugins_result.get("plugins", []),
+        "themes": themes_result.get("themes", []),
+    }
+
+
+@router.post("/plugins/local/install")
+async def install_plugin_from_local(request: dict[str, Any] = Body(...)):
+    """
+    Install a specific plugin from a local directory (dev mode only).
+
+    Args:
+        request: Request body containing:
+            - local_path: Absolute path to the local plugin repository
+            - plugin_path: Relative path to plugin directory within repo
+            - plugin_id: Optional plugin ID override
+            - force: Optional boolean to force reinstall
+    """
+    if not settings.is_dev_mode:
+        raise HTTPException(
+            status_code=403, detail="Local path install is only available in dev mode"
+        )
+
+    local_path = request.get("local_path")
+    plugin_path = request.get("plugin_path")
+    plugin_id = request.get("plugin_id")
+    force = request.get("force", False)
+
+    if not local_path:
+        raise HTTPException(status_code=400, detail="local_path is required")
+    if not plugin_path:
+        raise HTTPException(status_code=400, detail="plugin_path is required")
+
+    repo_path = Path(local_path)
+    if not repo_path.exists() or not repo_path.is_dir():
+        raise HTTPException(
+            status_code=400, detail=f"Path not found or not a directory: {local_path}"
+        )
+
+    theme_json = repo_path / plugin_path / "theme.json"
+    plugin_json_path = repo_path / plugin_path / "plugin.json"
+
+    try:
+        if theme_json.exists():
+            manifest = theme_installer.install_theme_from_repo(repo_path, plugin_path, plugin_id)
+            await _register_theme_in_db(manifest)
+            return {
+                "success": True,
+                "message": f"Theme {manifest['id']} installed successfully",
+                "manifest": manifest,
+                "requires_restart": False,
+            }
+        elif plugin_json_path.exists():
+            manifest = plugin_installer.install_plugin_from_repo(
+                repo_path, plugin_path, plugin_id, force=force
+            )
+            try:
+                plugin_loader.load_installed_plugins()
+            except Exception as load_error:
+                logger.warning(
+                    f"Plugin {manifest['id']} installed but failed to load: {load_error}. "
+                    "It will be available after server restart."
+                )
+
+            if manifest.get("_has_frontend"):
+                frontend_build_manager.start_background_build(plugin_installer.get_frontend_dir())
+            return {
+                "success": True,
+                "message": f"Plugin {manifest['id']} installed successfully",
+                "manifest": manifest,
+                "requires_restart": True,
+                "frontend_rebuild_in_progress": manifest.get("_has_frontend", False),
+            }
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Neither plugin.json nor theme.json found in {plugin_path}",
+            )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to install plugin from local path: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Failed to install: {str(e)}")

--- a/backend/app/api/routes/plugins/github.py
+++ b/backend/app/api/routes/plugins/github.py
@@ -288,10 +288,11 @@ async def install_plugin_from_github(request: dict[str, Any] = Body(...)):
                     # It just needs a restart to be loaded
 
                 actual_branch = "master" if branch_switched else branch
-                frontend_rebuild_triggered = False
+                frontend_rebuild_success = None
+                frontend_rebuild_message = None
                 if manifest.get("_has_frontend"):
-                    frontend_rebuild_triggered = frontend_build_manager.trigger(
-                        plugin_installer.get_frontend_dir()
+                    frontend_rebuild_success, frontend_rebuild_message = (
+                        frontend_build_manager.build(plugin_installer.get_frontend_dir())
                     )
                 return {
                     "success": True,
@@ -300,7 +301,8 @@ async def install_plugin_from_github(request: dict[str, Any] = Body(...)):
                     "branch": actual_branch,
                     "branch_switched": branch_switched,
                     "requires_restart": True,
-                    "frontend_rebuild_triggered": frontend_rebuild_triggered,
+                    "frontend_rebuild_success": frontend_rebuild_success,
+                    "frontend_rebuild_message": frontend_rebuild_message,
                 }
             else:
                 raise HTTPException(

--- a/backend/app/api/routes/plugins/instances.py
+++ b/backend/app/api/routes/plugins/instances.py
@@ -1,5 +1,6 @@
 """Plugin instance management endpoints."""
 
+import asyncio
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
@@ -9,7 +10,8 @@ from fastapi import APIRouter, Body, HTTPException
 from pydantic import BaseModel
 
 from app.api.routes.plugins.config import mask_sensitive_config
-from app.models.db_models import PluginDB
+from app.models.db_models import PluginDB, PluginTypeDB
+from app.plugins.hooks import plugin_manager as hook_manager
 from app.plugins.loader import plugin_loader
 from app.plugins.manager import plugin_manager
 from app.services.event_system import event_system
@@ -54,6 +56,52 @@ class PluginInstanceOrderUpdateResponse(BaseModel):
     success: bool
     message: str
     updated: int
+
+
+class PluginInstanceCreateRequest(BaseModel):
+    name: str
+    enabled: bool = True
+    config: dict[str, Any] = {}
+
+
+def _serialize_instance_config(config: dict[str, Any]) -> dict[str, Any]:
+    """Serialize config values to JSON-compatible primitives."""
+
+    def serialize_value(val):
+        if val is None:
+            return None
+        elif isinstance(val, str | int | float | bool):
+            return val
+        elif isinstance(val, Path):
+            return str(val)
+        elif isinstance(val, dict):
+            return {k: serialize_value(v) for k, v in val.items()}
+        elif isinstance(val, list):
+            return [serialize_value(item) for item in val]
+        else:
+            try:
+                if hasattr(val, "__str__"):
+                    return str(val)
+                elif hasattr(val, "path"):
+                    return str(val.path)
+                else:
+                    return str(val)
+            except Exception:
+                return "[Unable to serialize]"
+
+    return serialize_value(config) or {}
+
+
+def _build_instance_response(db_plugin: PluginDB, running: bool) -> PluginInstanceResponse:
+    serialized_config = _serialize_instance_config(db_plugin.config or {})
+    return PluginInstanceResponse(
+        id=db_plugin.id,
+        name=db_plugin.name,
+        enabled=db_plugin.enabled,
+        running=running,
+        config=mask_sensitive_config(serialized_config, mask_for_frontend=True),
+        display_order=db_plugin.display_order or 0,
+    )
 
 
 @router.post("/plugins/instances/{instance_id}/start", response_model=PluginInstanceActionResponse)
@@ -231,44 +279,7 @@ async def get_plugin_instances(plugin_id: str):
         running = plugin.is_running() if plugin else False
 
         # Serialize config, converting Path objects and other non-serializable types to strings
-        def serialize_value(val):
-            """Recursively serialize values to JSON-serializable types."""
-            if val is None:
-                return None
-            elif isinstance(val, str | int | float | bool):
-                return val
-            elif isinstance(val, Path):
-                return str(val)
-            elif isinstance(val, dict):
-                return {k: serialize_value(v) for k, v in val.items()}
-            elif isinstance(val, list):
-                return [serialize_value(item) for item in val]
-            else:
-                # For any other type (including Path-like objects), convert to string
-                try:
-                    # Try to get string representation
-                    if hasattr(val, "__str__"):
-                        return str(val)
-                    elif hasattr(val, "path"):
-                        return str(val.path)
-                    else:
-                        return str(val)
-                except Exception:
-                    return "[Unable to serialize]"
-
-        config = db_plugin.config or {}
-        serialized_config = serialize_value(config)
-
-        instances.append(
-            {
-                "id": db_plugin.id,
-                "name": db_plugin.name,
-                "enabled": db_plugin.enabled,
-                "running": running,
-                "config": mask_sensitive_config(serialized_config, mask_for_frontend=True),
-                "display_order": db_plugin.display_order or 0,
-            }
-        )
+        instances.append(_build_instance_response(db_plugin, running).model_dump())
 
     return {"instances": instances, "total": len(instances)}
 
@@ -314,6 +325,64 @@ async def delete_plugin_instance(instance_id: str):
         logger.warning(f"Failed to emit plugin_instance_deleted event for {instance_id}: {e}")
 
     return {"success": True, "message": f"Plugin instance {instance_id} deleted successfully"}
+
+
+@router.post("/plugins/{plugin_id}/instances", response_model=PluginInstanceUpdateResponse)
+async def create_plugin_instance(
+    plugin_id: str,
+    request: PluginInstanceCreateRequest,
+):
+    """
+    Create a plugin instance via an explicit instance lifecycle endpoint.
+
+    This currently adapts to the existing plugin hook contract by translating
+    the typed payload into the legacy config-update metadata fields.
+    """
+    plugin_types = plugin_loader.get_plugin_types()
+    type_info = next((t for t in plugin_types if t.get("type_id") == plugin_id), None)
+
+    if not type_info:
+        raise HTTPException(status_code=404, detail="Plugin type not found")
+
+    instance_config = {
+        **request.config,
+        "_instance_name": request.name,
+        "_instance_enabled": request.enabled,
+    }
+
+    db_plugin_type = await PluginTypeDB.objects.get_or_none(type_id=plugin_id)
+
+    update_coroutines = hook_manager.hook.handle_plugin_config_update(
+        type_id=plugin_id,
+        config=instance_config,
+        enabled=None,
+        db_type=db_plugin_type,
+        session=None,
+    )
+    results = await asyncio.gather(*update_coroutines, return_exceptions=True)
+
+    created_instance_id = None
+    for result in results:
+        if isinstance(result, Exception) or result is None:
+            continue
+        created_instance_id = result.get("instance_id")
+        if created_instance_id:
+            break
+
+    if not created_instance_id:
+        raise HTTPException(status_code=400, detail="Plugin did not create an instance")
+
+    db_plugin = await PluginDB.objects.get_or_none(id=created_instance_id)
+    if not db_plugin:
+        raise HTTPException(status_code=500, detail="Created plugin instance not found in database")
+
+    plugin = plugin_manager.get_plugin(created_instance_id)
+    instance = _build_instance_response(db_plugin, plugin.is_running() if plugin else False)
+    return {
+        "success": True,
+        "message": f"Plugin instance {created_instance_id} created successfully",
+        "instance": instance,
+    }
 
 
 @router.put("/plugins/instances/{instance_id}", response_model=PluginInstanceUpdateResponse)
@@ -494,47 +563,14 @@ async def update_plugin_instance(instance_id: str, instance_data: dict[str, Any]
                 f"Failed to emit plugin_instance_updated event for instance {instance_id}: {e}"
             )
 
-    # Serialize config for response
-    def serialize_value(val):
-        """Recursively serialize values to JSON-serializable types."""
-        if val is None:
-            return None
-        elif isinstance(val, str | int | float | bool):
-            return val
-        elif isinstance(val, Path):
-            return str(val)
-        elif isinstance(val, dict):
-            return {k: serialize_value(v) for k, v in val.items()}
-        elif isinstance(val, list):
-            return [serialize_value(item) for item in val]
-        else:
-            try:
-                if hasattr(val, "__str__"):
-                    return str(val)
-                elif hasattr(val, "path"):
-                    return str(val.path)
-                else:
-                    return str(val)
-            except Exception:
-                return "[Unable to serialize]"
-
-    config = db_plugin.config or {}
-    serialized_config = serialize_value(config)
-
     # Get updated plugin reference (may have been created above)
     plugin = plugin_manager.get_plugin(instance_id)
+    instance = _build_instance_response(db_plugin, plugin.is_running() if plugin else False)
 
     return {
         "success": True,
         "message": f"Plugin instance {instance_id} updated successfully",
-        "instance": {
-            "id": db_plugin.id,
-            "name": db_plugin.name,
-            "enabled": db_plugin.enabled,
-            "running": plugin.is_running() if plugin else False,
-            "config": mask_sensitive_config(serialized_config, mask_for_frontend=True),
-            "display_order": db_plugin.display_order or 0,
-        },
+        "instance": instance,
     }
 
 

--- a/backend/app/api/routes/plugins/instances.py
+++ b/backend/app/api/routes/plugins/instances.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Body, HTTPException
+from pydantic import BaseModel
 
 from app.api.routes.plugins.config import mask_sensitive_config
 from app.models.db_models import PluginDB
@@ -18,7 +19,44 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.post("/plugins/instances/{instance_id}/start")
+class PluginInstanceResponse(BaseModel):
+    id: str
+    name: str
+    enabled: bool
+    running: bool
+    config: dict[str, Any]
+    display_order: int
+
+
+class PluginInstanceListResponse(BaseModel):
+    instances: list[PluginInstanceResponse]
+    total: int
+
+
+class PluginInstanceActionResponse(BaseModel):
+    success: bool
+    message: str
+    running: bool
+
+
+class PluginInstanceDeleteResponse(BaseModel):
+    success: bool
+    message: str
+
+
+class PluginInstanceUpdateResponse(BaseModel):
+    success: bool
+    message: str
+    instance: PluginInstanceResponse
+
+
+class PluginInstanceOrderUpdateResponse(BaseModel):
+    success: bool
+    message: str
+    updated: int
+
+
+@router.post("/plugins/instances/{instance_id}/start", response_model=PluginInstanceActionResponse)
 async def start_plugin_instance(instance_id: str):
     """
     Start a plugin instance (if enabled).
@@ -104,7 +142,7 @@ async def start_plugin_instance(instance_id: str):
         raise HTTPException(status_code=500, detail=f"Failed to start plugin {instance_id}")
 
 
-@router.post("/plugins/instances/{instance_id}/stop")
+@router.post("/plugins/instances/{instance_id}/stop", response_model=PluginInstanceActionResponse)
 async def stop_plugin_instance(instance_id: str):
     """
     Stop a plugin instance.
@@ -170,7 +208,7 @@ async def stop_plugin_instance(instance_id: str):
         raise HTTPException(status_code=500, detail=f"Failed to stop plugin {instance_id}")
 
 
-@router.get("/plugins/{plugin_id}/instances")
+@router.get("/plugins/{plugin_id}/instances", response_model=PluginInstanceListResponse)
 async def get_plugin_instances(plugin_id: str):
     """
     Get all plugin instances for a plugin type, including running status.
@@ -235,7 +273,7 @@ async def get_plugin_instances(plugin_id: str):
     return {"instances": instances, "total": len(instances)}
 
 
-@router.delete("/plugins/instances/{instance_id}")
+@router.delete("/plugins/instances/{instance_id}", response_model=PluginInstanceDeleteResponse)
 async def delete_plugin_instance(instance_id: str):
     db_plugin = await PluginDB.objects.get_or_none(id=instance_id)
 
@@ -278,7 +316,7 @@ async def delete_plugin_instance(instance_id: str):
     return {"success": True, "message": f"Plugin instance {instance_id} deleted successfully"}
 
 
-@router.put("/plugins/instances/{instance_id}")
+@router.put("/plugins/instances/{instance_id}", response_model=PluginInstanceUpdateResponse)
 async def update_plugin_instance(instance_id: str, instance_data: dict[str, Any] = Body(...)):
     """
     Update a plugin instance (enabled status, config, etc.).
@@ -500,7 +538,10 @@ async def update_plugin_instance(instance_id: str, instance_data: dict[str, Any]
     }
 
 
-@router.put("/plugins/{plugin_id}/instances/order")
+@router.put(
+    "/plugins/{plugin_id}/instances/order",
+    response_model=PluginInstanceOrderUpdateResponse,
+)
 async def update_plugin_instances_order(
     plugin_id: str, instance_orders: dict[str, int] = Body(...)
 ):

--- a/backend/app/api/routes/plugins/management.py
+++ b/backend/app/api/routes/plugins/management.py
@@ -197,6 +197,15 @@ async def get_plugins(
 
 
 # Specific routes must come before parameterized routes to avoid path conflicts
+@router.get("/plugins/rebuild-status")
+async def get_rebuild_status():
+    """Return the current state of a background frontend rebuild."""
+    return {
+        "state": frontend_build_manager.state,
+        "message": frontend_build_manager.message,
+    }
+
+
 @router.get("/plugins/installed")
 async def get_installed_plugins():
     """
@@ -305,20 +314,15 @@ async def install_plugin(
                     f"Failed to emit plugin_installed event for plugin {manifest['id']}: {e}"
                 )
 
-            frontend_rebuild_success = None
-            frontend_rebuild_message = None
             if manifest.get("_has_frontend"):
-                frontend_rebuild_success, frontend_rebuild_message = frontend_build_manager.build(
-                    plugin_installer.get_frontend_dir()
-                )
+                frontend_build_manager.start_background_build(plugin_installer.get_frontend_dir())
 
             return {
                 "success": True,
                 "message": f"Plugin {manifest['id']} installed successfully",
                 "manifest": manifest,
                 "requires_restart": True,
-                "frontend_rebuild_success": frontend_rebuild_success,
-                "frontend_rebuild_message": frontend_rebuild_message,
+                "frontend_rebuild_in_progress": manifest.get("_has_frontend", False),
             }
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))

--- a/backend/app/api/routes/plugins/management.py
+++ b/backend/app/api/routes/plugins/management.py
@@ -58,6 +58,17 @@ class PluginListResponse(BaseModel):
     total: int
 
 
+class PluginTypeConfigUpdateRequest(BaseModel):
+    enabled: bool | None = None
+    config: dict[str, Any] = {}
+
+
+class PluginTypeConfigUpdateResponse(BaseModel):
+    success: bool
+    message: str
+    plugin_id: str
+
+
 @router.get("/plugins", response_model=PluginListResponse)
 async def get_plugins(
     plugin_type: str | None = Query(None, description="Optional plugin type filter"),
@@ -602,8 +613,11 @@ async def get_plugin(plugin_id: str):
     return plugin_info
 
 
-@router.put("/plugins/{plugin_id}")
-async def update_plugin(plugin_id: str, config: dict[str, Any]):
+async def _update_plugin_type(
+    plugin_id: str,
+    config: dict[str, Any],
+    enabled: bool | None = None,
+) -> dict[str, Any]:
     """
     Update plugin type common configuration and enabled status.
 
@@ -615,13 +629,6 @@ async def update_plugin(plugin_id: str, config: dict[str, Any]):
         config: Configuration dictionary with common settings and/or enabled status
     """
     logger.debug(f"Updating plugin type {plugin_id} with config keys: {list(config.keys())}")
-
-    # Handle enabled status separately
-    enabled = None
-    if "enabled" in config:
-        enabled = config["enabled"]
-        # Remove enabled from config dict to avoid storing it in config
-        config = {k: v for k, v in config.items() if k != "enabled"}
 
     # Clean config values - ensure all values are strings, not objects
     cleaned_config = normalize_plugin_config(config)
@@ -680,10 +687,18 @@ async def update_plugin(plugin_id: str, config: dict[str, Any]):
                     # Don't fail plugin update if event emission fails
                     logger.warning(f"Failed to emit {event_type} event for theme {plugin_id}: {e}")
 
-            return {"success": True, "enabled": enabled}
+            return {
+                "success": True,
+                "message": "Plugin type configuration updated",
+                "plugin_id": plugin_id,
+            }
         else:
             # No enabled status to update
-            return {"success": True}
+            return {
+                "success": True,
+                "message": "Plugin type configuration updated",
+                "plugin_id": plugin_id,
+            }
 
     # Store previous enabled state for event emission
     previous_enabled = None
@@ -773,9 +788,22 @@ async def update_plugin(plugin_id: str, config: dict[str, Any]):
             logger.warning(f"Failed to emit {event_type} event for plugin {plugin_id}: {e}")
 
     return {
+        "success": True,
         "message": "Plugin type configuration updated",
         "plugin_id": plugin_id,
     }
+
+
+@router.put("/plugins/{plugin_id}", response_model=PluginTypeConfigUpdateResponse)
+async def update_plugin(plugin_id: str, config: dict[str, Any]):
+    enabled = config.get("enabled") if "enabled" in config else None
+    config_without_enabled = {k: v for k, v in config.items() if k != "enabled"}
+    return await _update_plugin_type(plugin_id, config_without_enabled, enabled)
+
+
+@router.put("/plugins/{plugin_id}/config", response_model=PluginTypeConfigUpdateResponse)
+async def update_plugin_config(plugin_id: str, request: PluginTypeConfigUpdateRequest):
+    return await _update_plugin_type(plugin_id, request.config, request.enabled)
 
 
 @router.post("/plugins/{plugin_id}/fetch")

--- a/backend/app/api/routes/plugins/management.py
+++ b/backend/app/api/routes/plugins/management.py
@@ -12,6 +12,7 @@ from typing import Any
 import httpx
 from fastapi import APIRouter, Body, File, HTTPException, Query, UploadFile
 from loguru import logger
+from pydantic import BaseModel
 
 from app.models.db_models import PluginDB, PluginTypeDB
 from app.plugins.base import PluginType
@@ -23,12 +24,41 @@ from app.services.event_system import event_system
 from app.services.plugin_installer import frontend_build_manager, plugin_installer
 from app.services.theme_installer import theme_installer
 
+from .config import normalize_plugin_config
 from .themes import BUILTIN_THEMES, _unregister_theme_from_db
 
 router = APIRouter()
 
 
-@router.get("/plugins")
+class RebuildStatusResponse(BaseModel):
+    state: str
+    message: str
+
+
+class PluginManifestEnvelope(BaseModel):
+    manifest: dict[str, Any]
+
+
+class PluginInstallResponse(BaseModel):
+    success: bool
+    message: str
+    manifest: dict[str, Any]
+    requires_restart: bool
+    frontend_rebuild_in_progress: bool
+
+
+class PluginDeleteResponse(BaseModel):
+    success: bool
+    message: str
+    frontend_rebuild_in_progress: bool = False
+
+
+class PluginListResponse(BaseModel):
+    plugins: list[dict[str, Any]]
+    total: int
+
+
+@router.get("/plugins", response_model=PluginListResponse)
 async def get_plugins(
     plugin_type: str | None = Query(None, description="Optional plugin type filter"),
 ):
@@ -197,7 +227,7 @@ async def get_plugins(
 
 
 # Specific routes must come before parameterized routes to avoid path conflicts
-@router.get("/plugins/rebuild-status")
+@router.get("/plugins/rebuild-status", response_model=RebuildStatusResponse)
 async def get_rebuild_status():
     """Return the current state of a background frontend rebuild."""
     return {
@@ -206,7 +236,7 @@ async def get_rebuild_status():
     }
 
 
-@router.get("/plugins/installed")
+@router.get("/plugins/installed", response_model=PluginListResponse)
 async def get_installed_plugins():
     """
     Get list of installed plugins and themes.
@@ -228,12 +258,13 @@ async def get_installed_plugins():
             # Add type field to distinguish from plugins
             theme["type"] = PluginType.THEME.value
 
-        return {"plugins": plugins + themes}
+        result = plugins + themes
+        return {"plugins": result, "total": len(result)}
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to get installed plugins: {str(e)}")
 
 
-@router.post("/plugins/inspect")
+@router.post("/plugins/inspect", response_model=PluginManifestEnvelope)
 async def inspect_plugin(file: UploadFile = File(...)):
     """
     Read plugin.json from a zip without installing it.
@@ -262,7 +293,7 @@ async def inspect_plugin(file: UploadFile = File(...)):
                 pass
 
 
-@router.post("/plugins/install")
+@router.post("/plugins/install", response_model=PluginInstallResponse)
 async def install_plugin(
     file: UploadFile = File(...),
     plugin_id: str | None = None,
@@ -355,7 +386,7 @@ async def get_installed_plugin(plugin_id: str):
     return manifest
 
 
-@router.delete("/plugins/installed/{plugin_id}")
+@router.delete("/plugins/installed/{plugin_id}", response_model=PluginDeleteResponse)
 async def uninstall_plugin(plugin_id: str):
     """
     Uninstall a plugin or theme.
@@ -593,20 +624,7 @@ async def update_plugin(plugin_id: str, config: dict[str, Any]):
         config = {k: v for k, v in config.items() if k != "enabled"}
 
     # Clean config values - ensure all values are strings, not objects
-    cleaned_config = {}
-    for key, value in config.items():
-        if isinstance(value, dict):
-            # If it's a schema object, extract the actual value or default
-            cleaned_value = value.get("value") or value.get("default") or ""
-            cleaned_config[key] = cleaned_value
-        elif isinstance(value, Path):
-            # Handle Path objects - convert to string
-            cleaned_config[key] = str(value)
-        elif value is None:
-            cleaned_config[key] = ""
-        else:
-            cleaned_config[key] = str(value)
-
+    cleaned_config = normalize_plugin_config(config)
     config = cleaned_config
 
     # Get plugin type from pluggy hooks first
@@ -716,15 +734,7 @@ async def update_plugin(plugin_id: str, config: dict[str, Any]):
     # Save common config to config service for backward compatibility
     if config:
         config_key = f"plugin_{plugin_id}_config"
-        serializable_config = {}
-        for key, value in config.items():
-            if isinstance(value, Path):
-                serializable_config[key] = str(value)
-            elif isinstance(value, dict):
-                serializable_config[key] = value.get("value") or value.get("default") or ""
-            else:
-                serializable_config[key] = value
-        config_json = json.dumps(serializable_config)
+        config_json = json.dumps(config)
         await config_service.set_value(config_key, config_json)
 
     # Call plugin-specific config update handlers (if any)
@@ -1104,7 +1114,7 @@ async def test_plugin(plugin_id: str, test_config: dict[str, Any] | None = Body(
 
     # Use provided test_config if available, otherwise get saved config
     if test_config:
-        config = test_config
+        config = normalize_plugin_config(test_config)
     else:
         # Get plugin config
         config_key = f"plugin_{plugin_id}_config"

--- a/backend/app/api/routes/plugins/management.py
+++ b/backend/app/api/routes/plugins/management.py
@@ -871,6 +871,15 @@ async def scan_plugin_options(
     if not type_info:
         raise HTTPException(status_code=404, detail="Plugin type not found")
 
+    plugin_class = type_info.get("plugin_class")
+    if plugin_class:
+        try:
+            class_result = await plugin_class.scan_type_options(field)
+            if class_result is not None:
+                return class_result
+        except Exception as e:
+            logger.debug(f"Class-based scan_type_options failed for {plugin_id}: {e}")
+
     scan_coroutines = hook_manager.hook.scan_plugin_options(
         type_id=plugin_id,
         field_key=field,
@@ -1136,6 +1145,15 @@ async def test_plugin(plugin_id: str, test_config: dict[str, Any] | None = Body(
                 config = {}
         else:
             config = {}
+
+    plugin_class = type_info.get("plugin_class")
+    if plugin_class:
+        try:
+            class_result = await plugin_class.test_type_config(config)
+            if class_result is not None:
+                return class_result
+        except Exception as e:
+            logger.debug(f"Class-based test_type_config failed for {plugin_id}: {e}")
 
     # Call plugin-specific test handlers via hooks
     # Pluggy returns a list of coroutines for async hooks, we need to await them

--- a/backend/app/api/routes/plugins/management.py
+++ b/backend/app/api/routes/plugins/management.py
@@ -404,6 +404,7 @@ async def uninstall_plugin(plugin_id: str):
             }
         else:
             # Uninstall regular plugin
+            had_frontend = plugin_installer.get_frontend_plugin_path(plugin_id).exists()
             plugin_installer.uninstall_plugin(plugin_id)
 
             # Stop and delete all instances of this plugin type
@@ -453,6 +454,9 @@ async def uninstall_plugin(plugin_id: str):
                 if not m.startswith(f"installed_plugin_{plugin_id}")
             }
 
+            if had_frontend:
+                frontend_build_manager.start_background_build(plugin_installer.get_frontend_dir())
+
             # Emit plugin_uninstalled event
             try:
                 await event_system.emit_event(
@@ -474,6 +478,7 @@ async def uninstall_plugin(plugin_id: str):
             return {
                 "success": True,
                 "message": f"Plugin {plugin_id} uninstalled successfully",
+                "frontend_rebuild_in_progress": had_frontend,
             }
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))

--- a/backend/app/api/routes/plugins/management.py
+++ b/backend/app/api/routes/plugins/management.py
@@ -826,7 +826,13 @@ async def fetch_plugin(plugin_id: str):
     if not type_info:
         raise HTTPException(status_code=404, detail="Plugin type not found")
 
-    # Call plugin-specific fetch handlers via hooks
+    plugin_class = type_info.get("plugin_class")
+    if plugin_class is not None:
+        class_result = await plugin_class.fetch_type_data(instance_id=None)
+        if class_result is not None:
+            return class_result
+
+    # Legacy compatibility: fall back to hook-based fetch handlers
     # Pluggy returns a list of coroutines for async hooks, we need to await them
     fetch_coroutines = hook_manager.hook.fetch_plugin_data(
         type_id=plugin_id,

--- a/backend/app/api/routes/plugins/management.py
+++ b/backend/app/api/routes/plugins/management.py
@@ -106,8 +106,12 @@ async def get_plugins(
             db_schema = (
                 db_type.common_config_schema if db_type and db_type.common_config_schema else {}
             )
-            # Merge: db_schema (user-set values) overrides metadata_schema (defaults)
-            merged_schema = {**metadata_schema, **db_schema}
+            # Only override keys that are defined in the plugin's own metadata schema —
+            # prevents instance config fields that leaked into db_schema from showing here.
+            merged_schema = {**metadata_schema}
+            for key in metadata_schema:
+                if key in db_schema:
+                    merged_schema[key] = db_schema[key]
 
             plugin_info: dict[str, Any] = {
                 "id": type_id,
@@ -249,15 +253,6 @@ async def inspect_plugin(file: UploadFile = File(...)):
                 pass
 
 
-@router.get("/plugins/frontend-build-status")
-async def get_frontend_build_status():
-    """Return the current status of a background frontend rebuild triggered by plugin install."""
-    return {
-        "status": frontend_build_manager.status,
-        "message": frontend_build_manager.message,
-    }
-
-
 @router.post("/plugins/install")
 async def install_plugin(
     file: UploadFile = File(...),
@@ -310,9 +305,10 @@ async def install_plugin(
                     f"Failed to emit plugin_installed event for plugin {manifest['id']}: {e}"
                 )
 
-            frontend_rebuild_triggered = False
+            frontend_rebuild_success = None
+            frontend_rebuild_message = None
             if manifest.get("_has_frontend"):
-                frontend_rebuild_triggered = frontend_build_manager.trigger(
+                frontend_rebuild_success, frontend_rebuild_message = frontend_build_manager.build(
                     plugin_installer.get_frontend_dir()
                 )
 
@@ -321,7 +317,8 @@ async def install_plugin(
                 "message": f"Plugin {manifest['id']} installed successfully",
                 "manifest": manifest,
                 "requires_restart": True,
-                "frontend_rebuild_triggered": frontend_rebuild_triggered,
+                "frontend_rebuild_success": frontend_rebuild_success,
+                "frontend_rebuild_message": frontend_rebuild_message,
             }
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
@@ -538,8 +535,12 @@ async def get_plugin(plugin_id: str):
     # This ensures user-set values (like display_order) are preserved
     metadata_schema = type_info.get("common_config_schema", {}) or {}
     db_schema = db_type.common_config_schema if db_type and db_type.common_config_schema else {}
-    # Merge: db_schema (user-set values) overrides metadata_schema (defaults)
-    merged_schema = {**metadata_schema, **db_schema}
+    # Only override keys that are defined in the plugin's own metadata schema —
+    # prevents instance config fields that leaked into db_schema from showing here.
+    merged_schema = {**metadata_schema}
+    for key in metadata_schema:
+        if key in db_schema:
+            merged_schema[key] = db_schema[key]
 
     plugin_info: dict[str, Any] = {
         "id": type_info.get("type_id"),
@@ -549,9 +550,8 @@ async def get_plugin(plugin_id: str):
         else str(type_info.get("plugin_type")),
         "description": type_info.get("description", ""),
         "config_schema": merged_schema,
-        "display_schema": type_info.get(
-            "display_schema"
-        ),  # Include display_schema for frontend components
+        "display_schema": type_info.get("display_schema"),
+        "statusbar_schema": type_info.get("statusbar_schema"),
         "enabled": enabled,
     }
 
@@ -667,9 +667,11 @@ async def update_plugin(plugin_id: str, config: dict[str, Any]):
     if not db_type:
         # Create new plugin type in database
         plugin_type = type_info.get("plugin_type")
-        # Merge metadata schema with config (config takes precedence)
+        # Only store keys that are defined in the plugin's own common_config_schema
         metadata_schema = type_info.get("common_config_schema", {}) or {}
-        initial_schema = {**metadata_schema, **config} if config else metadata_schema
+        allowed_keys = set(metadata_schema.keys())
+        filtered_config = {k: v for k, v in config.items() if k in allowed_keys} if config else {}
+        initial_schema = {**metadata_schema, **filtered_config}
         logger.debug(
             f"Creating new plugin type {plugin_id} with schema: {initial_schema}, "
             f"config={config}, metadata_schema={metadata_schema}"
@@ -689,8 +691,12 @@ async def update_plugin(plugin_id: str, config: dict[str, Any]):
             db_type.enabled = enabled
         if config:
             current_schema = db_type.common_config_schema or {}
-            # Ormar JSON fields detect changes automatically
-            updated_schema = {**current_schema, **config}
+            # Only allow keys defined in the plugin's own common_config_schema —
+            # prevents instance config fields from leaking into the type-level schema.
+            metadata_schema = type_info.get("common_config_schema", {}) or {}
+            allowed_keys = set(metadata_schema.keys())
+            filtered_config = {k: v for k, v in config.items() if k in allowed_keys}
+            updated_schema = {**current_schema, **filtered_config}
             db_type.common_config_schema = updated_schema
             logger.debug(
                 f"Updated plugin {plugin_id} common_config_schema: "

--- a/backend/app/api/routes/plugins/management.py
+++ b/backend/app/api/routes/plugins/management.py
@@ -931,25 +931,6 @@ async def get_plugin_data(
             logger.error(f"Error initializing plugin {plugin_id}: {e}", exc_info=True)
             raise HTTPException(status_code=500, detail=f"Failed to initialize plugin: {str(e)}")
 
-    # Try hook-based data fetching first (for external plugins)
-    try:
-        hook_coroutines = hook_manager.hook.fetch_service_data(
-            instance_id=plugin_id, start_date=start_date, end_date=end_date
-        )
-        # Process hook results (pluggy returns a list of coroutines)
-        if hook_coroutines:
-            hook_results = await asyncio.gather(*hook_coroutines, return_exceptions=True)
-            # Check if any plugin handled the fetch
-            for result in hook_results:
-                # Skip exceptions
-                if isinstance(result, Exception):
-                    continue
-                if result is not None:
-                    return result
-    except Exception as e:
-        logger.debug(f"Hook-based fetch_service_data failed for {plugin_id}: {e}")
-
-    # Fall back to protocol method (for built-in plugins)
     try:
         data = await plugin_instance.fetch_service_data(start_date=start_date, end_date=end_date)
         if data is not None:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -76,8 +76,11 @@ class Settings(BaseSettings):
     @property
     def is_dev_mode(self) -> bool:
         """Check if running in development mode by looking for .dev marker file."""
-        dev_marker = self.repo_dir / "backend" / ".dev"
-        return dev_marker.exists()
+        # Check repo_dir-relative path (production Pi path)
+        if (self.repo_dir / "backend" / ".dev").exists():
+            return True
+        # Also check relative to this file, so it works without setting REPO_DIR in dev
+        return (Path(__file__).parent.parent / ".dev").exists()
 
     def get_update_script_path(self) -> Path:
         """Get the appropriate update script path based on dev/prod mode."""

--- a/backend/app/plugins/base.py
+++ b/backend/app/plugins/base.py
@@ -81,6 +81,26 @@ class BasePlugin(ABC):
         """
         pass
 
+    @classmethod
+    async def test_type_config(cls, config: dict[str, Any]) -> dict[str, Any] | None:
+        """
+        Test plugin type configuration without requiring a persisted instance.
+
+        Returns None by default, indicating the plugin does not implement a
+        class-based configuration test path.
+        """
+        return None
+
+    @classmethod
+    async def scan_type_options(cls, field_key: str) -> dict[str, Any] | None:
+        """
+        Discover options for a type-level config field without requiring an instance.
+
+        Returns None by default, indicating the plugin does not implement a
+        class-based option scan path.
+        """
+        return None
+
     async def configure(self, config: dict[str, Any]) -> None:
         """
         Configure the plugin with settings.

--- a/backend/app/plugins/base.py
+++ b/backend/app/plugins/base.py
@@ -101,6 +101,16 @@ class BasePlugin(ABC):
         """
         return None
 
+    @classmethod
+    async def fetch_type_data(cls, instance_id: str | None = None) -> dict[str, Any] | None:
+        """
+        Manually trigger a type-level fetch/check operation.
+
+        Returns None by default, indicating the plugin does not implement a
+        class-based manual fetch path.
+        """
+        return None
+
     async def configure(self, config: dict[str, Any]) -> None:
         """
         Configure the plugin with settings.

--- a/backend/app/plugins/base.py
+++ b/backend/app/plugins/base.py
@@ -2,7 +2,10 @@
 
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from app.plugins.definitions import PluginDefinition
 
 
 class PluginType(str, Enum):
@@ -40,7 +43,7 @@ class BasePlugin(ABC):
 
     @classmethod
     @abstractmethod
-    def get_plugin_metadata(cls) -> dict[str, Any]:
+    def get_plugin_metadata(cls) -> "PluginDefinition | dict[str, Any]":
         """
         Get plugin metadata for registration.
 

--- a/backend/app/plugins/definitions.py
+++ b/backend/app/plugins/definitions.py
@@ -1,0 +1,108 @@
+"""Typed plugin definition models.
+
+These models define the normalized contract returned by plugin discovery hooks.
+Plugins may still return raw dicts for backward compatibility; the loader
+normalizes them into these models before the rest of the app consumes them.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.plugins.base import PluginType
+
+
+class ConfigFieldDefinition(BaseModel):
+    """Typed config field metadata with permissive extra support."""
+
+    type: str | None = None
+    description: str | None = None
+    default: Any = None
+    ui: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="allow")
+
+
+class ActionDefinition(BaseModel):
+    """Plugin action metadata."""
+
+    id: str
+    type: str
+    label: str | None = None
+    style: str | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class SectionDefinition(BaseModel):
+    """Plugin UI section metadata."""
+
+    id: str | None = None
+    type: str
+    label: str | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class DisplaySchema(BaseModel):
+    """Display metadata for service plugins."""
+
+    type: str | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class StatusbarSchema(BaseModel):
+    """Statusbar metadata for service plugins."""
+
+    model_config = ConfigDict(extra="allow")
+
+
+class CapabilitySet(BaseModel):
+    """Declared plugin capabilities."""
+
+    can_test_connection: bool = False
+    can_scan_options: bool = False
+    can_manual_fetch: bool = False
+    can_upload: bool = False
+    can_delete: bool = False
+
+
+class PluginDefinition(BaseModel):
+    """Normalized plugin definition consumed by the app."""
+
+    protocol_version: int = 1
+    type_id: str
+    plugin_type: PluginType
+    name: str
+    description: str | None = None
+    version: str = "1.0.0"
+    supports_multiple_instances: bool = True
+    instance_label: str | None = None
+    common_config_schema: dict[str, Any] = Field(default_factory=dict)
+    instance_config_schema: dict[str, Any] = Field(default_factory=dict)
+    ui_actions: list[dict[str, Any]] = Field(default_factory=list)
+    ui_sections: list[dict[str, Any]] = Field(default_factory=list)
+    display_schema: dict[str, Any] | None = None
+    statusbar_schema: dict[str, Any] | None = None
+    capabilities: CapabilitySet = Field(default_factory=CapabilitySet)
+    plugin_class: type[Any] | None = None
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
+
+    @classmethod
+    def from_raw(cls, raw: "PluginDefinition | dict[str, Any]") -> "PluginDefinition":
+        """Normalize a raw plugin definition into the typed model."""
+        if isinstance(raw, cls):
+            return raw
+        if isinstance(raw, dict):
+            return cls.model_validate(raw)
+        raise TypeError(f"Unsupported plugin definition type: {type(raw)!r}")
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Mapping-style compatibility for legacy callers."""
+        return getattr(self, key, default)
+
+    def __getitem__(self, key: str) -> Any:
+        """Mapping-style compatibility for legacy callers."""
+        return getattr(self, key)

--- a/backend/app/plugins/hooks.py
+++ b/backend/app/plugins/hooks.py
@@ -92,9 +92,10 @@ class PluginHookSpec:
         config: dict[str, Any],
     ) -> dict[str, Any] | None:
         """
-        Test plugin connection/configuration.
+        Legacy hook for testing plugin connection/configuration.
 
-        This hook allows plugins to implement their own connection testing logic.
+        Deprecated in favor of implementing BasePlugin.test_type_config() on
+        the plugin class and exposing that class via plugin metadata.
 
         Args:
             type_id: Plugin type ID (e.g., 'imap', 'mealie', 'yr_weather')
@@ -139,7 +140,10 @@ class PluginHookSpec:
         field_key: str,
     ) -> dict[str, Any] | None:
         """
-        Scan/discover available options for a configuration field.
+        Legacy hook for scanning/discovering available options for a configuration field.
+
+        Deprecated in favor of implementing BasePlugin.scan_type_options() on
+        the plugin class and exposing that class via plugin metadata.
 
         Args:
             type_id: Plugin type ID (e.g., 'chromecast')

--- a/backend/app/plugins/hooks.py
+++ b/backend/app/plugins/hooks.py
@@ -158,10 +158,11 @@ class PluginHookSpec:
         end_date: str | None = None,
     ) -> dict[str, Any] | None:
         """
-        Fetch service data from a service plugin instance.
+        Legacy hook for fetching service data from a service plugin instance.
 
-        This hook allows service plugins to implement their own data fetching logic
-        for the generic /api/plugins/{plugin_id}/data endpoint.
+        Deprecated in favor of implementing ServicePlugin.fetch_service_data()
+        on the resolved plugin instance directly. Kept for compatibility while
+        the runtime surface is being simplified.
 
         Args:
             instance_id: Plugin instance ID

--- a/backend/app/plugins/hooks.py
+++ b/backend/app/plugins/hooks.py
@@ -5,6 +5,7 @@ from typing import Any
 import pluggy
 
 from app.plugins.base import BasePlugin
+from app.plugins.definitions import PluginDefinition
 
 # Create pluggy hook specification manager
 hookspec = pluggy.HookspecMarker("calvin")
@@ -15,7 +16,7 @@ class PluginHookSpec:
     """Hook specifications for plugin registration."""
 
     @hookspec
-    def register_plugin_types(self) -> list[dict[str, Any]]:
+    def register_plugin_types(self) -> list[PluginDefinition | dict[str, Any]]:
         """
         Register plugin types.
 

--- a/backend/app/plugins/hooks.py
+++ b/backend/app/plugins/hooks.py
@@ -118,7 +118,12 @@ class PluginHookSpec:
         """
         Manually trigger plugin fetch/check operation.
 
-        This hook allows plugins to implement their own fetch logic (e.g., check for new emails).
+        This hook allows plugins to implement their own fetch logic (e.g., check for new
+        emails).
+
+        Legacy compatibility path:
+        New plugins should prefer BasePlugin.fetch_type_data() and let the core call the
+        plugin class directly.
 
         Args:
             type_id: Plugin type ID (e.g., 'imap')

--- a/backend/app/plugins/loader.py
+++ b/backend/app/plugins/loader.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from loguru import logger
 
+from app.plugins.definitions import PluginDefinition
 from app.plugins.hooks import plugin_manager
 from app.services.plugin_installer import plugin_installer
 
@@ -142,26 +143,27 @@ class PluginLoader:
         # Load installed plugins
         self.load_installed_plugins()
 
-    def get_plugin_types(self) -> list[dict[str, Any]]:
+    def get_plugin_types(self) -> list[PluginDefinition]:
         """
-        Get all registered plugin types.
+        Get all registered plugin types, normalized into typed definitions.
 
         Returns:
-            List of plugin type dictionaries with error information if loading failed
+            List of normalized plugin definitions
         """
-        plugin_types = []
+        plugin_types: list[PluginDefinition] = []
         results = plugin_manager.hook.register_plugin_types()
         for result in results:
             if result:
-                try:
-                    plugin_types.extend(result if isinstance(result, list) else [result])
-                except Exception as e:
-                    # If a plugin's register_plugin_types hook raises an exception,
-                    # we can't include it but we should log the error
-                    import logging
-
-                    logger = logging.getLogger(__name__)
-                    logger.error(f"Error getting plugin types from hook result: {e}", exc_info=True)
+                raw_definitions = result if isinstance(result, list) else [result]
+                for raw_definition in raw_definitions:
+                    try:
+                        plugin_types.append(PluginDefinition.from_raw(raw_definition))
+                    except Exception as e:
+                        logger.error(
+                            "Error normalizing plugin type from hook result: {}",
+                            e,
+                            exc_info=True,
+                        )
         return plugin_types
 
     def create_plugin_instance(

--- a/backend/app/plugins/protocols.py
+++ b/backend/app/plugins/protocols.py
@@ -251,9 +251,9 @@ class ServicePlugin(BasePlugin):
         """
         Fetch service data for display (optional - not all services support data fetching).
 
-        This method is called by the core when fetching data via /api/plugins/{plugin_id}/data.
-        Plugins can implement this to provide their own data fetching logic.
-        Alternatively, plugins can use the fetch_service_data hook for more complex scenarios.
+        This method is called by the core when fetching data via
+        /api/plugins/{plugin_id}/data.
+        Plugins should implement this on the resolved instance directly.
 
         Args:
             start_date: Optional start date (YYYY-MM-DD format, plugin-specific)

--- a/backend/app/plugins/registry/loader.py
+++ b/backend/app/plugins/registry/loader.py
@@ -3,6 +3,7 @@
 import logging
 
 from app.models.db_models import PluginDB, PluginTypeDB
+from app.plugins.definitions import PluginDefinition
 from app.plugins.loader import plugin_loader
 from app.plugins.manager import plugin_manager as instance_manager
 
@@ -20,17 +21,14 @@ async def load_plugin_types() -> None:
 
         try:
             # Validate required fields
-            if not isinstance(type_info, dict):
-                continue
-            if "type_id" not in type_info:
-                continue
-            if "plugin_type" not in type_info:
+            type_info = PluginDefinition.from_raw(type_info)
+            if not type_info.type_id:
                 continue
 
-            type_id = type_info["type_id"]
+            type_id = type_info.type_id
 
             # Get name with fallback
-            name = type_info.get("name") or type_id or "Unknown Plugin"
+            name = type_info.name or type_id or "Unknown Plugin"
 
             # Check if plugin type exists in database
             db_type = await PluginTypeDB.objects.get_or_none(type_id=type_id)
@@ -43,35 +41,35 @@ async def load_plugin_types() -> None:
                 if not db_type:
                     # Create new plugin type in database
                     plugin_type_value = (
-                        type_info["plugin_type"].value
-                        if hasattr(type_info["plugin_type"], "value")
-                        else str(type_info["plugin_type"])
+                        type_info.plugin_type.value
+                        if hasattr(type_info.plugin_type, "value")
+                        else str(type_info.plugin_type)
                     )
                     await PluginTypeDB.objects.create(
                         type_id=type_id,
                         plugin_type=plugin_type_value,
                         name=name,
-                        description=type_info.get("description"),
-                        version=type_info.get("version"),
-                        common_config_schema=type_info.get("common_config_schema", {}),
+                        description=type_info.description,
+                        version=type_info.version,
+                        common_config_schema=type_info.common_config_schema,
                         enabled=False,  # Default to disabled - user must explicitly enable
                         error_message=None,  # Clear any previous errors
                     )
                 else:
                     # Update existing plugin type if needed
                     plugin_type_value = (
-                        type_info["plugin_type"].value
-                        if hasattr(type_info["plugin_type"], "value")
-                        else str(type_info["plugin_type"])
+                        type_info.plugin_type.value
+                        if hasattr(type_info.plugin_type, "value")
+                        else str(type_info.plugin_type)
                     )
                     db_type.name = name
-                    db_type.description = type_info.get("description")
-                    db_type.version = type_info.get("version")
+                    db_type.description = type_info.description
+                    db_type.version = type_info.version
 
                     # Merge plugin metadata schema with existing database schema
                     # This preserves user-set values (like display_order) while updating
                     # with new schema from plugin metadata
-                    metadata_schema = type_info.get("common_config_schema", {}) or {}
+                    metadata_schema = type_info.common_config_schema or {}
                     existing_schema = db_type.common_config_schema or {}
                     # Merge: existing schema takes precedence (preserves user-set values),
                     # but metadata schema can add new fields

--- a/backend/app/plugins/utils/scan_cache.py
+++ b/backend/app/plugins/utils/scan_cache.py
@@ -1,0 +1,54 @@
+"""Persistent disk cache for plugin image scan results.
+
+Allows image plugins to survive restarts without re-hitting remote APIs.
+Usage in a plugin's initialize() and scan_images():
+
+    from app.plugins.utils.scan_cache import load_scan_cache, save_scan_cache
+
+    # In initialize():
+    self._images, self._last_scan = load_scan_cache(self.plugin_id)
+
+    # At the end of scan_images() after a successful fetch:
+    save_scan_cache(self.plugin_id, self._images)
+"""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+
+def _cache_path(plugin_id: str) -> Path:
+    return Path("data/plugins") / plugin_id / "scan_cache.json"
+
+
+def load_scan_cache(plugin_id: str) -> tuple[list[dict[str, Any]], datetime | None]:
+    """Load persisted scan results. Returns (images, last_scan_time) or ([], None)."""
+    path = _cache_path(plugin_id)
+    if not path.exists():
+        return [], None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        last_scan = datetime.fromisoformat(data["last_scan"])
+        images = data["images"]
+        logger.debug("Loaded {} scan cache entries for {}", len(images), plugin_id)
+        return images, last_scan
+    except Exception as e:
+        logger.warning("Failed to load scan cache for {}: {}", plugin_id, e)
+        return [], None
+
+
+def save_scan_cache(plugin_id: str, images: list[dict[str, Any]]) -> None:
+    """Persist scan results to disk for a plugin."""
+    path = _cache_path(plugin_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        path.write_text(
+            json.dumps({"last_scan": datetime.now().isoformat(), "images": images}),
+            encoding="utf-8",
+        )
+        logger.debug("Saved {} scan cache entries for {}", len(images), plugin_id)
+    except Exception as e:
+        logger.warning("Failed to save scan cache for {}: {}", plugin_id, e)

--- a/backend/app/services/plugin_installer.py
+++ b/backend/app/services/plugin_installer.py
@@ -5,6 +5,7 @@ import logging
 import shutil
 import subprocess
 import sys
+import threading
 import zipfile
 from pathlib import Path
 from typing import Any
@@ -23,10 +24,44 @@ logger = logging.getLogger(__name__)
 
 
 class FrontendBuildManager:
-    """Runs `npm run build` synchronously when plugins with frontend components are installed."""
+    """Manages `npm run build` for plugin frontend components.
 
-    def build(self, frontend_dir: Path) -> tuple[bool, str]:
-        """Run the frontend build synchronously. Returns (success, message)."""
+    Runs builds in a background thread so install endpoints can return immediately.
+    Poll `state` / `message` for progress.
+    """
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._state = "idle"  # idle | building | done | failed
+        self._message = ""
+
+    @property
+    def state(self) -> str:
+        with self._lock:
+            return self._state
+
+    @property
+    def message(self) -> str:
+        with self._lock:
+            return self._message
+
+    def start_background_build(self, frontend_dir: Path) -> None:
+        """Kick off a build in a daemon thread. Returns immediately."""
+        with self._lock:
+            if self._state == "building":
+                return  # already in progress
+            self._state = "building"
+            self._message = "Building frontend, this may take a minute…"
+        thread = threading.Thread(target=self._run_build, args=(frontend_dir,), daemon=True)
+        thread.start()
+
+    def _run_build(self, frontend_dir: Path) -> None:
+        success, message = self._build(frontend_dir)
+        with self._lock:
+            self._state = "done" if success else "failed"
+            self._message = message
+
+    def _build(self, frontend_dir: Path) -> tuple[bool, str]:
         npm = shutil.which("npm")
         if not npm:
             return False, "npm not found — rebuild the frontend manually with: npm run build"
@@ -54,6 +89,17 @@ class FrontendBuildManager:
             return False, "Frontend rebuild timed out (5 min limit)"
         except Exception as exc:
             return False, f"Frontend rebuild failed: {exc}"
+
+    # Keep synchronous variant for callers that need to wait (e.g. startup resume)
+    def build(self, frontend_dir: Path) -> tuple[bool, str]:
+        with self._lock:
+            self._state = "building"
+            self._message = "Building frontend…"
+        success, message = self._build(frontend_dir)
+        with self._lock:
+            self._state = "done" if success else "failed"
+            self._message = message
+        return success, message
 
 
 frontend_build_manager = FrontendBuildManager()
@@ -318,12 +364,13 @@ class PluginInstaller:
             return manifest
 
         except Exception as e:
-            # Cleanup on error
+            # Cleanup on error — use ignore_errors so a locked file on Windows
+            # doesn't mask the real install error.
             if plugin_path.exists():
-                shutil.rmtree(plugin_path)
+                shutil.rmtree(plugin_path, ignore_errors=True)
             frontend_path = self.get_frontend_plugin_path(install_id)
             if frontend_path.exists():
-                shutil.rmtree(frontend_path)
+                shutil.rmtree(frontend_path, ignore_errors=True)
             raise ValueError(f"Failed to install plugin: {e}") from e
 
     def _install_pip_requirements(self, manifest: dict[str, Any]) -> list[str]:
@@ -343,20 +390,30 @@ class PluginInstaller:
         )
         installed: list[str] = []
         for req in requirements:
+            cmd = [*pip_cmd, req]
+            logger.info(f"Running: {' '.join(str(c) for c in cmd)}")
             try:
                 result = subprocess.run(
-                    [*pip_cmd, req],
+                    cmd,
                     capture_output=True,
                     text=True,
                     timeout=120,
                 )
+                logger.debug(f"pip stdout: {result.stdout!r}")
+                logger.debug(f"pip stderr: {result.stderr!r}")
+                logger.debug(f"pip returncode: {result.returncode}")
                 if result.returncode == 0:
                     logger.info(f"Installed: {req}")
                     installed.append(req)
                 else:
-                    raise ValueError(f"pip install failed for '{req}':\n{result.stderr.strip()}")
+                    error_output = (result.stderr or result.stdout or "(no output)").strip()
+                    raise ValueError(
+                        f"pip install failed for '{req}' (exit {result.returncode}):\n{error_output}"
+                    )
             except subprocess.TimeoutExpired:
                 raise ValueError(f"Timed out installing package '{req}' (120s limit)")
+            except OSError as e:
+                raise ValueError(f"Failed to launch pip for '{req}': {e}")
 
         return installed
 
@@ -371,10 +428,15 @@ class PluginInstaller:
 
         The returned list already includes "install"; append only the package name.
         """
-        # 1. Prefer uv when available — works even when pip is absent from the venv
+        # 1. Prefer uv when available — works even when pip is absent from the venv.
+        # On Windows, uv.exe must be launched via cmd /c (same pattern as npm) to avoid
+        # STATUS_FATAL_APP_EXIT when spawning from within a running Python process.
         uv = shutil.which("uv")
         if uv:
-            return [uv, "pip", "install", "--python", sys.executable]
+            cmd = [uv, "pip", "install", "--python", sys.executable]
+            if sys.platform == "win32":
+                return ["cmd", "/c"] + cmd
+            return cmd
 
         # 2. pip/pip3 binary sitting next to the interpreter
         bin_dir = Path(sys.executable).parent

--- a/backend/app/services/plugin_installer.py
+++ b/backend/app/services/plugin_installer.py
@@ -5,7 +5,6 @@ import logging
 import shutil
 import subprocess
 import sys
-import threading
 import zipfile
 from pathlib import Path
 from typing import Any
@@ -24,71 +23,37 @@ logger = logging.getLogger(__name__)
 
 
 class FrontendBuildManager:
-    """Runs `npm run build` in a background thread when plugins with frontend components are installed."""
+    """Runs `npm run build` synchronously when plugins with frontend components are installed."""
 
-    def __init__(self) -> None:
-        self._status = "idle"  # idle | building | done | error
-        self._message = ""
-        self._lock = threading.Lock()
-
-    @property
-    def status(self) -> str:
-        with self._lock:
-            return self._status
-
-    @property
-    def message(self) -> str:
-        with self._lock:
-            return self._message
-
-    def trigger(self, frontend_dir: Path) -> bool:
-        """Start a rebuild if one is not already running. Returns True if started."""
-        with self._lock:
-            if self._status == "building":
-                return False
-            self._status = "building"
-            self._message = "Frontend rebuild in progress…"
-
-        thread = threading.Thread(
-            target=self._run,
-            args=(frontend_dir,),
-            daemon=True,
-        )
-        thread.start()
-        return True
-
-    def _run(self, frontend_dir: Path) -> None:
+    def build(self, frontend_dir: Path) -> tuple[bool, str]:
+        """Run the frontend build synchronously. Returns (success, message)."""
         npm = shutil.which("npm")
         if not npm:
-            with self._lock:
-                self._status = "error"
-                self._message = "npm not found — rebuild the frontend manually with: npm run build"
-            return
+            return False, "npm not found — rebuild the frontend manually with: npm run build"
+
+        # On Windows, .cmd files can't be executed by CreateProcess directly —
+        # they need cmd.exe as the interpreter.
+        if sys.platform == "win32":
+            cmd = ["cmd", "/c", npm, "run", "build"]
+        else:
+            cmd = [npm, "run", "build"]
 
         try:
             result = subprocess.run(
-                [npm, "run", "build"],
+                cmd,
                 cwd=str(frontend_dir),
                 capture_output=True,
                 text=True,
                 timeout=300,
             )
-            with self._lock:
-                if result.returncode == 0:
-                    self._status = "done"
-                    self._message = "Frontend rebuilt successfully — refresh the page to load new plugin components."
-                else:
-                    tail = (result.stderr or result.stdout or "unknown error")[-500:]
-                    self._status = "error"
-                    self._message = f"Frontend rebuild failed: {tail}"
+            if result.returncode == 0:
+                return True, "Frontend rebuilt successfully."
+            tail = (result.stderr or result.stdout or "unknown error")[-500:]
+            return False, f"Frontend rebuild failed: {tail}"
         except subprocess.TimeoutExpired:
-            with self._lock:
-                self._status = "error"
-                self._message = "Frontend rebuild timed out (5 min limit)"
+            return False, "Frontend rebuild timed out (5 min limit)"
         except Exception as exc:
-            with self._lock:
-                self._status = "error"
-                self._message = f"Frontend rebuild failed: {exc}"
+            return False, f"Frontend rebuild failed: {exc}"
 
 
 frontend_build_manager = FrontendBuildManager()

--- a/backend/app/services/remote_image_cache.py
+++ b/backend/app/services/remote_image_cache.py
@@ -1,0 +1,83 @@
+"""Disk-based cache for remote image bytes.
+
+Central service used by the image route to avoid 302 redirecting the frontend
+directly to external APIs (which hits rate limits and breaks offline use).
+On 429 or network errors, stale cache is served rather than failing.
+"""
+
+import hashlib
+import time
+from pathlib import Path
+
+import httpx
+from loguru import logger
+
+_CACHE_DIR = Path("data/image_cache")
+_DEFAULT_TTL_DAYS = 7
+_STALE_SERVE_STATUS_CODES = {429, 500, 502, 503, 504}
+
+
+class RemoteImageCache:
+    def __init__(self, cache_dir: Path = _CACHE_DIR, ttl_days: int = _DEFAULT_TTL_DAYS):
+        self.cache_dir = cache_dir
+        self.ttl_days = ttl_days
+        cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _cache_path(self, url: str) -> Path:
+        url_hash = hashlib.sha256(url.encode()).hexdigest()
+        path_part = url.split("?")[0]
+        ext = path_part.rsplit(".", 1)[-1].lower() if "." in path_part else "bin"
+        if ext not in {"jpg", "jpeg", "png", "gif", "webp", "bmp", "avif"}:
+            ext = "bin"
+        return self.cache_dir / url_hash[:2] / f"{url_hash}.{ext}"
+
+    def _is_fresh(self, path: Path) -> bool:
+        return (time.time() - path.stat().st_mtime) < self.ttl_days * 86400
+
+    def get_cached(self, url: str) -> bytes | None:
+        """Return cached bytes if they exist (fresh or stale). None if no cache."""
+        path = self._cache_path(url)
+        return path.read_bytes() if path.exists() else None
+
+    async def get_or_fetch(self, url: str) -> bytes | None:
+        """Return fresh cached bytes, or download → cache → return.
+
+        On rate-limit (429) or transient server errors, returns stale cache if
+        available rather than propagating the error.
+        """
+        path = self._cache_path(url)
+
+        if path.exists() and self._is_fresh(path):
+            logger.debug("Remote image cache hit: {}", url)
+            return path.read_bytes()
+
+        try:
+            async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+                response = await client.get(url)
+                response.raise_for_status()
+                data = response.content
+
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(data)
+            logger.debug("Remote image cached ({} bytes): {}", len(data), url)
+            return data
+
+        except httpx.HTTPStatusError as e:
+            status = e.response.status_code
+            if status in _STALE_SERVE_STATUS_CODES and path.exists():
+                logger.warning(
+                    "HTTP {} fetching remote image — serving stale cache: {}", status, url
+                )
+                return path.read_bytes()
+            logger.error("HTTP {} fetching remote image: {}", status, url)
+            return None
+
+        except httpx.HTTPError as e:
+            if path.exists():
+                logger.warning("Network error fetching remote image — serving stale cache: {}", url)
+                return path.read_bytes()
+            logger.error("Network error fetching remote image {}: {}", url, e)
+            return None
+
+
+remote_image_cache = RemoteImageCache()

--- a/backend/tests/integration/test_api_plugin_instances.py
+++ b/backend/tests/integration/test_api_plugin_instances.py
@@ -82,3 +82,41 @@ class TestPluginInstanceEndpoints:
         data = response.json()
         assert data["success"] is False
         assert data["updated"] == 0
+
+    def test_update_plugin_type_config_explicit_endpoint(self, test_client: TestClient):
+        """Test explicit plugin type config endpoint."""
+        response = test_client.put(
+            "/api/plugins/iframe/config",
+            json={"enabled": True, "config": {"display_order": "2"}},
+        )
+
+        if response.status_code == 404:
+            pytest.skip("Plugin type config route not available in test client")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["plugin_id"] == "iframe"
+
+    def test_create_plugin_instance_explicit_endpoint(self, test_client: TestClient):
+        """Test explicit plugin instance creation endpoint."""
+        response = test_client.post(
+            "/api/plugins/iframe/instances",
+            json={
+                "name": "Test Iframe Service",
+                "enabled": True,
+                "config": {
+                    "url": "https://example.com",
+                    "fullscreen": False,
+                },
+            },
+        )
+
+        if response.status_code == 404:
+            pytest.skip("Plugin instance create route not available in test client")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["instance"]["name"] == "Test Iframe Service"
+        assert data["instance"]["config"]["url"] == "https://example.com"

--- a/backend/tests/integration/test_api_plugins.py
+++ b/backend/tests/integration/test_api_plugins.py
@@ -795,3 +795,50 @@ class TestPluginTypeClassBasedActions:
         assert response.status_code == 200
         data = response.json()
         assert data["options"] == [{"value": "device", "label": "DEVICE"}]
+
+    def test_fetch_plugin_prefers_plugin_class(self, test_client, monkeypatch):
+        from app.plugins.base import BasePlugin
+
+        class ClassBasedFetchPlugin(BasePlugin):
+            @property
+            def plugin_type(self) -> PluginType:
+                return PluginType.BACKEND
+
+            @classmethod
+            def get_plugin_metadata(cls):
+                return {
+                    "type_id": "class-based-fetch",
+                    "plugin_type": PluginType.BACKEND,
+                    "name": "Class Based Fetch",
+                    "plugin_class": cls,
+                }
+
+            async def initialize(self) -> None:
+                pass
+
+            async def cleanup(self) -> None:
+                pass
+
+            @classmethod
+            async def fetch_type_data(cls, instance_id: str | None = None) -> dict[str, Any] | None:
+                return {
+                    "success": True,
+                    "message": "manual fetch completed",
+                    "instance_id": instance_id,
+                }
+
+        monkeypatch.setattr(
+            "app.api.routes.plugins.management.plugin_loader.get_plugin_types",
+            lambda: [ClassBasedFetchPlugin.get_plugin_metadata()],
+        )
+
+        response = test_client.post("/api/plugins/class-based-fetch/fetch")
+
+        if response.status_code == 404:
+            pytest.skip("Plugin fetch endpoint not available in test client")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["message"] == "manual fetch completed"
+        assert data["instance_id"] is None

--- a/backend/tests/integration/test_api_plugins.py
+++ b/backend/tests/integration/test_api_plugins.py
@@ -8,7 +8,7 @@ import pytest
 
 from app.plugins.base import PluginType
 from app.plugins.manager import plugin_manager
-from app.plugins.protocols import BackendPlugin
+from app.plugins.protocols import BackendPlugin, ServicePlugin
 from app.services.plugin_installer import plugin_installer
 
 
@@ -617,3 +617,85 @@ class TestBackendPluginAPI:
             assert data["scheduled_task"] is None
         finally:
             await plugin_manager.unregister("test-backend-status-no-schedule")
+
+
+@pytest.mark.integration
+class TestServicePluginDataAPI:
+    """Test service plugin data endpoint."""
+
+    class MockServicePluginForAPI(ServicePlugin):
+        def __init__(self, plugin_id: str, name: str, enabled: bool = True):
+            super().__init__(plugin_id, name, enabled)
+            self.initialize_calls = 0
+
+        @classmethod
+        def get_plugin_metadata(cls):
+            return {"type_id": "test-service", "plugin_type": PluginType.SERVICE}
+
+        @property
+        def plugin_type(self) -> PluginType:
+            return PluginType.SERVICE
+
+        async def initialize(self) -> None:
+            self.initialize_calls += 1
+
+        async def cleanup(self) -> None:
+            pass
+
+        async def get_content(self) -> dict[str, Any]:
+            return {"type": "api", "url": "/api/plugins/test-service-instance/data"}
+
+        async def validate_config(self, config: dict[str, Any]) -> bool:
+            return True
+
+        async def fetch_service_data(
+            self,
+            start_date: str | None = None,
+            end_date: str | None = None,
+        ) -> dict[str, Any] | None:
+            return {
+                "success": True,
+                "start_date": start_date,
+                "end_date": end_date,
+                "items": [{"label": "ok"}],
+            }
+
+    @pytest.mark.asyncio
+    async def test_get_plugin_data_uses_service_instance_method(self, test_client):
+        from app.models.db_models import PluginDB
+
+        plugin = self.MockServicePluginForAPI(
+            plugin_id="test-service-instance",
+            name="Test Service Instance",
+            enabled=True,
+        )
+        await plugin_manager.register(plugin)
+
+        db_plugin = await PluginDB.objects.create(
+            id="test-service-instance",
+            type_id="test-service",
+            plugin_type="service",
+            name="Test Service Instance",
+            enabled=True,
+            config={},
+        )
+
+        try:
+            response = test_client.get(
+                "/api/plugins/test-service-instance/data",
+                params={"start_date": "2026-01-01", "end_date": "2026-01-07"},
+            )
+
+            if response.status_code == 404:
+                pytest.skip("Service data endpoint not available in test client")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is True
+            assert data["start_date"] == "2026-01-01"
+            assert data["end_date"] == "2026-01-07"
+            assert data["items"] == [{"label": "ok"}]
+            assert plugin.initialize_calls == 1
+        finally:
+            await plugin_manager.unregister("test-service-instance")
+            await db_plugin.delete()

--- a/backend/tests/integration/test_api_plugins.py
+++ b/backend/tests/integration/test_api_plugins.py
@@ -699,3 +699,99 @@ class TestServicePluginDataAPI:
         finally:
             await plugin_manager.unregister("test-service-instance")
             await db_plugin.delete()
+
+
+@pytest.mark.integration
+class TestPluginTypeClassBasedActions:
+    """Test class-based type-level plugin actions."""
+
+    def test_test_plugin_connection_prefers_plugin_class(self, test_client, monkeypatch):
+        from app.plugins.base import BasePlugin
+
+        class ClassBasedTestPlugin(BasePlugin):
+            @property
+            def plugin_type(self) -> PluginType:
+                return PluginType.SERVICE
+
+            @classmethod
+            def get_plugin_metadata(cls):
+                return {
+                    "type_id": "class-based-test",
+                    "plugin_type": PluginType.SERVICE,
+                    "name": "Class Based Test",
+                    "plugin_class": cls,
+                }
+
+            async def initialize(self) -> None:
+                pass
+
+            async def cleanup(self) -> None:
+                pass
+
+            @classmethod
+            async def test_type_config(cls, config: dict[str, Any]) -> dict[str, Any] | None:
+                return {
+                    "success": True,
+                    "message": f"tested:{config.get('value', '')}",
+                }
+
+        monkeypatch.setattr(
+            "app.api.routes.plugins.management.plugin_loader.get_plugin_types",
+            lambda: [ClassBasedTestPlugin.get_plugin_metadata()],
+        )
+
+        response = test_client.post(
+            "/api/plugins/class-based-test/test",
+            json={"value": "ok"},
+        )
+
+        if response.status_code == 404:
+            pytest.skip("Plugin test endpoint not available in test client")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["message"] == "tested:ok"
+
+    def test_scan_plugin_options_prefers_plugin_class(self, test_client, monkeypatch):
+        from app.plugins.base import BasePlugin
+
+        class ClassBasedScanPlugin(BasePlugin):
+            @property
+            def plugin_type(self) -> PluginType:
+                return PluginType.SERVICE
+
+            @classmethod
+            def get_plugin_metadata(cls):
+                return {
+                    "type_id": "class-based-scan",
+                    "plugin_type": PluginType.SERVICE,
+                    "name": "Class Based Scan",
+                    "plugin_class": cls,
+                }
+
+            async def initialize(self) -> None:
+                pass
+
+            async def cleanup(self) -> None:
+                pass
+
+            @classmethod
+            async def scan_type_options(cls, field_key: str) -> dict[str, Any] | None:
+                return {
+                    "options": [{"value": field_key, "label": field_key.upper()}],
+                }
+
+        monkeypatch.setattr(
+            "app.api.routes.plugins.management.plugin_loader.get_plugin_types",
+            lambda: [ClassBasedScanPlugin.get_plugin_metadata()],
+        )
+
+        response = test_client.get("/api/plugins/class-based-scan/scan", params={"field": "device"})
+
+        if response.status_code == 404:
+            pytest.skip("Plugin scan endpoint not available in test client")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["options"] == [{"value": "device", "label": "DEVICE"}]

--- a/backend/tests/unit/test_plugin_definitions.py
+++ b/backend/tests/unit/test_plugin_definitions.py
@@ -1,0 +1,38 @@
+"""Tests for typed plugin definition models."""
+
+import pytest
+
+from app.plugins.base import PluginType
+from app.plugins.definitions import PluginDefinition
+
+
+@pytest.mark.unit
+class TestPluginDefinition:
+    """Test PluginDefinition compatibility behavior."""
+
+    def test_from_raw_dict_sets_defaults(self):
+        definition = PluginDefinition.from_raw(
+            {
+                "type_id": "test_plugin",
+                "plugin_type": PluginType.SERVICE,
+                "name": "Test Plugin",
+            }
+        )
+
+        assert definition.protocol_version == 1
+        assert definition.type_id == "test_plugin"
+        assert definition.plugin_type == PluginType.SERVICE
+        assert definition.supports_multiple_instances is True
+        assert definition.common_config_schema == {}
+        assert definition.instance_config_schema == {}
+
+    def test_mapping_style_compatibility(self):
+        definition = PluginDefinition(
+            type_id="test_plugin",
+            plugin_type=PluginType.IMAGE,
+            name="Test Plugin",
+        )
+
+        assert definition["type_id"] == "test_plugin"
+        assert definition.get("name") == "Test Plugin"
+        assert definition.get("missing", "fallback") == "fallback"

--- a/backend/tests/unit/test_plugin_loader.py
+++ b/backend/tests/unit/test_plugin_loader.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from app.plugins.base import PluginType
+from app.plugins.definitions import PluginDefinition
 from app.plugins.loader import PluginLoader
 
 
@@ -126,18 +128,26 @@ class TestPluginLoader:
         assert mock_import_module.called
 
     def test_get_plugin_types(self, plugin_loader_instance):
-        """Test getting plugin types."""
+        """Test getting plugin types normalized into typed definitions."""
         with patch("app.plugins.loader.plugin_manager") as mock_manager:
             mock_manager.hook.register_plugin_types.return_value = [
-                [{"type_id": "test1", "name": "Test 1"}],
-                {"type_id": "test2", "name": "Test 2"},
+                [{"type_id": "test1", "plugin_type": PluginType.SERVICE, "name": "Test 1"}],
+                PluginDefinition(
+                    type_id="test2",
+                    plugin_type=PluginType.IMAGE,
+                    name="Test 2",
+                ),
             ]
 
             types = plugin_loader_instance.get_plugin_types()
 
             assert len(types) == 2
+            assert isinstance(types[0], PluginDefinition)
+            assert isinstance(types[1], PluginDefinition)
             assert types[0]["type_id"] == "test1"
             assert types[1]["type_id"] == "test2"
+            assert types[0].plugin_type == PluginType.SERVICE
+            assert types[1].plugin_type == PluginType.IMAGE
 
     def test_get_plugin_types_empty(self, plugin_loader_instance):
         """Test getting plugin types when none are registered."""
@@ -147,6 +157,21 @@ class TestPluginLoader:
             types = plugin_loader_instance.get_plugin_types()
 
             assert types == []
+
+    def test_get_plugin_types_skips_invalid_hook_results(self, plugin_loader_instance):
+        """Test invalid hook results are skipped without breaking valid ones."""
+        with patch("app.plugins.loader.plugin_manager") as mock_manager:
+            mock_manager.hook.register_plugin_types.return_value = [
+                [
+                    {"type_id": "valid", "plugin_type": PluginType.SERVICE, "name": "Valid"},
+                    {"type_id": "invalid-missing-type", "name": "Invalid"},
+                ]
+            ]
+
+            types = plugin_loader_instance.get_plugin_types()
+
+            assert len(types) == 1
+            assert types[0].type_id == "valid"
 
     def test_create_plugin_instance(self, plugin_loader_instance):
         """Test creating a plugin instance."""

--- a/backend/tests/unit/test_plugin_protocols.py
+++ b/backend/tests/unit/test_plugin_protocols.py
@@ -437,6 +437,7 @@ class TestProtocolViolations:
         assert await plugin.get_schedule_config() is None
         assert await plugin.get_provided_services() == []
         assert await plugin.provide_service("test") is None
+        assert await plugin.fetch_type_data() is None
 
         # run_scheduled_task should raise NotImplementedError by default
         with pytest.raises(NotImplementedError):

--- a/docs/plugins/PLUGIN_DEVELOPMENT_GUIDE.md
+++ b/docs/plugins/PLUGIN_DEVELOPMENT_GUIDE.md
@@ -309,7 +309,7 @@ Service plugins can define how their content is displayed:
 ```python
 "display_schema": {
     "type": "api",  # "iframe" or "api"
-    "api_endpoint": "/api/web-services/{service_id}/endpoint",
+    "api_endpoint": "/api/plugins/{service_id}/data",
     "method": "GET",
     "render_template": "custom_template",  # Custom frontend template
     "data_schema": {
@@ -602,4 +602,3 @@ See the Mealie plugin in the calvin-plugins repository for a complete example of
 - Check `backend/app/plugins/base.py` for base classes
 - Review `backend/app/plugins/protocols.py` for interfaces
 - Look at `backend/app/plugins/hooks.py` for hook specifications
-

--- a/docs/plugins/PLUGIN_FRONTEND_COMPONENTS.md
+++ b/docs/plugins/PLUGIN_FRONTEND_COMPONENTS.md
@@ -41,7 +41,7 @@ The Mealie plugin (available in the calvin-plugins repository) demonstrates this
 ```python
 "display_schema": {
     "type": "api",
-    "api_endpoint": "/api/web-services/{service_id}/data",
+    "api_endpoint": "/api/plugins/{service_id}/data",
     "method": "GET",
     "component": "mealie/MealPlanViewer.vue",  # Plugin-provided frontend component
 }
@@ -115,4 +115,3 @@ To verify frontend components are installed correctly:
 2. Verify the component files are present
 3. Check that the plugin's `display_schema.component` path matches the installed location
 4. Rebuild the frontend and test the plugin
-

--- a/docs/plugins/PLUGIN_INSTALLATION.md
+++ b/docs/plugins/PLUGIN_INSTALLATION.md
@@ -136,7 +136,7 @@ class MyServicePlugin(ServicePlugin):
             },
             "display_schema": {
                 "type": "api",
-                "api_endpoint": "/api/web-services/{service_id}/data",
+                "api_endpoint": "/api/plugins/{service_id}/data",
                 "method": "GET",
                 "component": "my_plugin/MyComponent.vue",  # Optional: custom frontend component
             },
@@ -160,7 +160,7 @@ class MyServicePlugin(ServicePlugin):
         """Get service content for display."""
         return {
             "type": "api",
-            "url": f"/api/web-services/{self.plugin_id}/data",
+            "url": f"/api/plugins/{self.plugin_id}/data",
         }
 
 
@@ -214,7 +214,7 @@ The component path in `display_schema.component` should be relative to `frontend
 ```python
 "display_schema": {
     "type": "api",
-    "api_endpoint": "/api/web-services/{service_id}/data",
+    "api_endpoint": "/api/plugins/{service_id}/data",
     "method": "GET",
     "component": "my_plugin/MyComponent.vue",  # {plugin_id}/ComponentName.vue
 }
@@ -341,4 +341,3 @@ Installed plugins are automatically discovered and loaded on application startup
 ## Example Plugin Package
 
 See the built-in plugins in `backend/app/plugins/` for reference implementations.
-

--- a/frontend/src/components/ClockBarHorizontal.vue
+++ b/frontend/src/components/ClockBarHorizontal.vue
@@ -6,11 +6,9 @@
     :style="{ padding: `${barPadding}px` }"
   >
     <div class="clock-bar-outer">
-      <!-- Left spacer: invisible mirror of right weather to keep clock centered -->
+      <!-- Left spacer: invisible mirror of right side to keep clock centered -->
       <div class="clock-bar-side clock-bar-left" aria-hidden="true">
-        <span v-if="hasWeatherData" class="clock-weather-ghost">
-          {{ weatherEmoji }} {{ weatherTemp }}{{ weatherUnit }}
-        </span>
+        <PluginStatusbarItems ghost />
         <span
           v-if="isBackgroundRefreshing"
           class="clock-refresh-icon clock-refresh-ghost"
@@ -36,11 +34,9 @@
         >
       </div>
 
-      <!-- Right: weather status -->
+      <!-- Right: plugin statusbar items -->
       <div class="clock-bar-side clock-bar-right">
-        <span v-if="hasWeatherData" class="clock-weather">
-          {{ weatherEmoji }} {{ weatherTemp }}{{ weatherUnit }}
-        </span>
+        <PluginStatusbarItems />
         <span
           v-if="isBackgroundRefreshing"
           class="clock-refresh-icon"
@@ -54,9 +50,8 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted, watch } from "vue";
 import { useConfigStore } from "../stores/config";
-import { useWebServicesStore } from "../stores/webServices";
-import { useWeatherData } from "../composables/useWeatherData";
 import { useCalendarStore } from "../stores/calendar";
+import PluginStatusbarItems from "./PluginStatusbarItems.vue";
 
 defineOptions({
   name: "ClockBarHorizontal",
@@ -103,7 +98,6 @@ const props = defineProps({
 });
 
 const configStore = useConfigStore();
-const webServicesStore = useWebServicesStore();
 
 const currentTime = ref(new Date());
 let timeInterval = null;
@@ -183,68 +177,10 @@ const barPadding = computed(() => {
   return configStore.clockBarPadding || 8;
 });
 
-// Weather integration
-const showWeather = computed(() => configStore.clockBarShowWeather || false);
-
-const firstWeatherServiceId = computed(() => {
-  if (!showWeather.value) return null;
-  const svc = webServicesStore.services.find(
-    (s) => s.display_schema?.render_template === "weather",
-  );
-  return svc?.id ?? null;
-});
-
-const weatherEnabled = computed(
-  () => showWeather.value && !!firstWeatherServiceId.value,
-);
-
-const weatherQuery = useWeatherData(firstWeatherServiceId, weatherEnabled);
-
 const calendarStore = useCalendarStore();
 
 const isBackgroundRefreshing = computed(
-  () =>
-    (weatherQuery.isFetching.value && !weatherQuery.isLoading.value) ||
-    calendarStore.backgroundRefreshing,
-);
-
-const OWM_EMOJI = {
-  "01": "☀️",
-  "02": "⛅",
-  "03": "☁️",
-  "04": "☁️",
-  "09": "🌧️",
-  10: "🌦️",
-  11: "⛈️",
-  13: "❄️",
-  50: "🌫️",
-};
-
-const weatherEmoji = computed(() => {
-  const icon = weatherQuery.data.value?.current?.icon;
-  if (!icon) return "";
-  return OWM_EMOJI[icon.slice(0, 2)] ?? "🌡️";
-});
-
-const weatherTemp = computed(() => {
-  const temp = weatherQuery.data.value?.current?.temperature;
-  if (temp === undefined || temp === null) return null;
-  return Math.round(temp);
-});
-
-const weatherUnit = computed(() => {
-  const units = weatherQuery.data.value?.units || "metric";
-  if (units === "imperial") return "°F";
-  if (units === "kelvin") return "K";
-  return "°C";
-});
-
-const hasWeatherData = computed(
-  () =>
-    showWeather.value &&
-    !weatherQuery.isLoading.value &&
-    !weatherQuery.isError.value &&
-    weatherTemp.value !== null,
+  () => calendarStore.backgroundRefreshing,
 );
 
 // Format time
@@ -351,18 +287,9 @@ watch(shouldShow, (newValue) => {
   }
 });
 
-watch(showWeather, (newVal) => {
-  if (newVal && webServicesStore.services.length === 0) {
-    webServicesStore.fetchServices();
-  }
-});
-
 onMounted(() => {
   if (shouldShow.value) {
     updateTime();
-  }
-  if (showWeather.value && webServicesStore.services.length === 0) {
-    webServicesStore.fetchServices();
   }
 });
 
@@ -436,7 +363,7 @@ onUnmounted(() => {
   font-size: 0.75rem;
 }
 
-/* Three-column layout for weather integration */
+/* Three-column layout: left mirror | center time | right plugin items */
 .clock-bar-outer {
   display: flex;
   align-items: center;
@@ -460,22 +387,6 @@ onUnmounted(() => {
 
 .clock-bar-content {
   flex: 0 1 auto;
-}
-
-.clock-weather-ghost {
-  visibility: hidden;
-  white-space: nowrap;
-  font-size: 0.875rem;
-  padding: 0 0.5rem;
-  pointer-events: none;
-  user-select: none;
-}
-
-.clock-weather {
-  white-space: nowrap;
-  font-size: 0.875rem;
-  color: var(--text-secondary);
-  padding: 0 0.5rem;
 }
 
 .clock-refresh-icon {

--- a/frontend/src/components/PluginActions.vue
+++ b/frontend/src/components/PluginActions.vue
@@ -47,7 +47,7 @@
 </template>
 
 <script setup>
-// No imports needed
+import { logDebug, logWarn } from "../utils/logger";
 
 const props = defineProps({
   pluginId: {
@@ -95,7 +95,7 @@ const emit = defineEmits(["save", "test", "fetch", "custom-action"]);
 const getPluginIdFromAction = () => {
   // Always use the prop pluginId - the endpoint may contain {plugin_id} placeholder
   // that needs to be replaced later
-  console.log("[PluginActions] Using pluginId from prop:", props.pluginId);
+  logDebug("[PluginActions]", "Using pluginId from prop:", props.pluginId);
   return props.pluginId;
 };
 
@@ -116,7 +116,7 @@ const getActionLabel = (action) => {
 };
 
 const handleAction = (_action) => {
-  console.log("[PluginActions] handleAction called with:", _action);
+  logDebug("[PluginActions]", "handleAction called with:", _action);
   switch (_action.type) {
     case "save":
       emit("save");
@@ -132,16 +132,18 @@ const handleAction = (_action) => {
         ..._action,
         pluginId: getPluginIdFromAction(),
       };
-      console.log(
-        "[PluginActions] Emitting custom-action with:",
+      logDebug(
+        "[PluginActions]",
+        "Emitting custom-action with:",
         actionWithPluginId,
       );
       emit("custom-action", actionWithPluginId);
       break;
     }
     default:
-      console.warn(
-        `[PluginActions] Unknown action type: ${_action.type}`,
+      logWarn(
+        "[PluginActions]",
+        `Unknown action type: ${_action.type}`,
         _action,
       );
   }

--- a/frontend/src/components/PluginStatusbarItems.vue
+++ b/frontend/src/components/PluginStatusbarItems.vue
@@ -1,0 +1,75 @@
+<template>
+  <div class="plugin-statusbar-items" :class="{ ghost }">
+    <component
+      v-for="item in loadedItems"
+      :is="item.component"
+      :key="item.serviceId"
+      :service-id="item.serviceId"
+    />
+  </div>
+</template>
+
+<script setup>
+import { computed, onMounted, ref, watch } from "vue";
+import { useWebServicesStore } from "../stores/webServices";
+import { loadPluginComponent } from "../composables/usePluginComponent";
+
+defineOptions({ name: "PluginStatusbarItems" });
+
+defineProps({
+  ghost: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const webServicesStore = useWebServicesStore();
+
+const statusbarServices = computed(() =>
+  webServicesStore.services.filter((s) => {
+    if (!s.statusbar_schema?.component) return false;
+    // If the plugin uses the show_in_statusbar convention, respect it.
+    // Absence of the key means the plugin controls visibility itself (e.g. yr_weather).
+    const cfg = s.config || {};
+    if ("show_in_statusbar" in cfg) return !!cfg.show_in_statusbar;
+    return true;
+  }),
+);
+
+const loadedItems = ref([]);
+
+watch(
+  statusbarServices,
+  async (services) => {
+    const items = await Promise.all(
+      services.map(async (service) => {
+        const component = await loadPluginComponent(
+          service.statusbar_schema.component,
+        );
+        return component ? { serviceId: service.id, component } : null;
+      }),
+    );
+    loadedItems.value = items.filter(Boolean);
+  },
+  { immediate: true },
+);
+
+onMounted(() => {
+  if (webServicesStore.services.length === 0) {
+    webServicesStore.fetchServices();
+  }
+});
+</script>
+
+<style scoped>
+.plugin-statusbar-items {
+  display: flex;
+  align-items: center;
+}
+
+.plugin-statusbar-items.ghost {
+  visibility: hidden;
+  pointer-events: none;
+  user-select: none;
+}
+</style>

--- a/frontend/src/components/WebServiceViewer.vue
+++ b/frontend/src/components/WebServiceViewer.vue
@@ -93,6 +93,7 @@ import { useConfigStore } from "../stores/config";
 import { useWebServicesStore } from "../stores/webServices";
 import { useModeStore } from "../stores/mode";
 import ServiceViewer from "./service/ServiceViewer.vue";
+import { logDebug } from "../utils/logger";
 
 const props = defineProps({
   isFullscreen: {
@@ -113,7 +114,7 @@ const currentServiceIndex = computed(
 const currentService = computed(() => {
   const service = webServicesStore.getCurrentService();
   if (service) {
-    console.log("[WebServiceViewer] Current service:", {
+    logDebug("[WebServiceViewer]", "Current service:", {
       id: service.id,
       name: service.name,
       url: service.url,

--- a/frontend/src/components/plugins/chromecast/NowPlaying.vue
+++ b/frontend/src/components/plugins/chromecast/NowPlaying.vue
@@ -1,0 +1,221 @@
+<template>
+  <div class="now-playing">
+    <div v-if="query.isLoading.value && !query.data.value" class="np-idle">
+      <div class="spinner" />
+    </div>
+
+    <div v-else-if="state === 'idle' || state === 'no_devices'" class="np-idle">
+      <div class="np-idle-icon">📺</div>
+      <span class="np-idle-text"
+        >{{ deviceName || "Chromecast" }} — nothing casting</span
+      >
+    </div>
+
+    <div v-else-if="state === 'error'" class="np-idle">
+      <span class="np-idle-text">{{ data.error }}</span>
+    </div>
+
+    <div v-else class="np-active">
+      <img
+        v-if="data.album_art_url"
+        class="np-art"
+        :src="data.album_art_url"
+        alt=""
+      />
+      <div v-else class="np-art-placeholder">{{ appIcon }}</div>
+
+      <div class="np-overlay">
+        <div class="np-app">{{ data.app_name }}</div>
+        <div class="np-title" :title="data.title">{{ data.title || "—" }}</div>
+        <div v-if="data.artist" class="np-artist">{{ data.artist }}</div>
+        <div v-if="data.duration" class="np-progress">
+          <div class="np-bar-track">
+            <div class="np-bar-fill" :style="{ width: progressPct + '%' }" />
+          </div>
+          <span class="np-time"
+            >{{ formatTime(data.current_time) }} /
+            {{ formatTime(data.duration) }}</span
+          >
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from "vue";
+import { useQuery } from "@tanstack/vue-query";
+import axios from "axios";
+
+const props = defineProps({
+  serviceId: { type: String, required: true },
+  apiEndpoint: { type: String, required: true },
+});
+
+const query = useQuery({
+  queryKey: ["chromecast", props.serviceId],
+  queryFn: () => axios.get(props.apiEndpoint).then((r) => r.data),
+  refetchInterval: 10000,
+  staleTime: 8000,
+});
+
+const data = computed(() => query.data.value || {});
+const state = computed(() => data.value.state || "idle");
+const deviceName = computed(() => data.value.device_name || "");
+
+const progressPct = computed(() => {
+  const { current_time, duration } = data.value;
+  if (!duration || !current_time) return 0;
+  return Math.min(100, (current_time / duration) * 100);
+});
+
+const appIcon = computed(() => {
+  const app = (data.value.app_name || "").toLowerCase();
+  if (app.includes("youtube")) return "▶";
+  if (app.includes("spotify")) return "♫";
+  if (app.includes("netflix")) return "N";
+  if (app.includes("plex")) return "▶";
+  return "📺";
+});
+
+function formatTime(secs) {
+  if (!secs) return "0:00";
+  const m = Math.floor(secs / 60);
+  const s = Math.floor(secs % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+</script>
+
+<style scoped>
+.now-playing {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  color: #fff;
+  font-size: 0.85rem;
+}
+
+/* ── idle / error ── */
+.np-idle {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  opacity: 0.5;
+  padding: 0.75rem 1rem;
+}
+.np-idle-icon {
+  font-size: 1.5rem;
+}
+.np-idle-text {
+  font-size: 0.8rem;
+}
+
+/* ── active ── */
+.np-active {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.np-art {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.np-art-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 3rem;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+/* gradient overlay + content pinned to bottom */
+.np-overlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 2rem 0.9rem 0.75rem;
+  background: linear-gradient(to bottom, transparent, rgba(0, 0, 0, 0.82));
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.np-app {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.6;
+}
+
+.np-title {
+  font-size: 1rem;
+  font-weight: 700;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.2;
+}
+
+.np-artist {
+  font-size: 0.8rem;
+  opacity: 0.8;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.np-progress {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.35rem;
+}
+
+.np-bar-track {
+  flex: 1;
+  height: 3px;
+  background: rgba(255, 255, 255, 0.25);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.np-bar-fill {
+  height: 100%;
+  background: #fff;
+  border-radius: 2px;
+  transition: width 1s linear;
+}
+
+.np-time {
+  font-size: 0.65rem;
+  opacity: 0.55;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── spinner ── */
+.spinner {
+  width: 18px;
+  height: 18px;
+  border: 2px solid rgba(255, 255, 255, 0.15);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>

--- a/frontend/src/components/plugins/yr_weather/WeatherStatusbar.vue
+++ b/frontend/src/components/plugins/yr_weather/WeatherStatusbar.vue
@@ -1,0 +1,75 @@
+<template>
+  <span v-if="showWeather && hasWeatherData" class="weather-statusbar">
+    {{ weatherEmoji }} {{ weatherTemp }}{{ weatherUnit }}
+  </span>
+</template>
+
+<script setup>
+import { computed } from "vue";
+import { useConfigStore } from "../../../stores/config";
+import { useWeatherData } from "../../../composables/useWeatherData";
+
+defineOptions({ name: "WeatherStatusbar" });
+
+const props = defineProps({
+  serviceId: {
+    type: String,
+    required: true,
+  },
+});
+
+const configStore = useConfigStore();
+const showWeather = computed(() => configStore.clockBarShowWeather || false);
+
+const serviceIdRef = computed(() => props.serviceId);
+const enabled = computed(() => showWeather.value && !!props.serviceId);
+
+const weatherQuery = useWeatherData(serviceIdRef, enabled);
+
+const OWM_EMOJI = {
+  "01": "☀️",
+  "02": "⛅",
+  "03": "☁️",
+  "04": "☁️",
+  "09": "🌧️",
+  10: "🌦️",
+  11: "⛈️",
+  13: "❄️",
+  50: "🌫️",
+};
+
+const weatherEmoji = computed(() => {
+  const icon = weatherQuery.data.value?.current?.icon;
+  if (!icon) return "";
+  return OWM_EMOJI[icon.slice(0, 2)] ?? "🌡️";
+});
+
+const weatherTemp = computed(() => {
+  const temp = weatherQuery.data.value?.current?.temperature;
+  if (temp === undefined || temp === null) return null;
+  return Math.round(temp);
+});
+
+const weatherUnit = computed(() => {
+  const units = weatherQuery.data.value?.units || "metric";
+  if (units === "imperial") return "°F";
+  if (units === "kelvin") return "K";
+  return "°C";
+});
+
+const hasWeatherData = computed(
+  () =>
+    !weatherQuery.isLoading.value &&
+    !weatherQuery.isError.value &&
+    weatherTemp.value !== null,
+);
+</script>
+
+<style scoped>
+.weather-statusbar {
+  white-space: nowrap;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  padding: 0 0.5rem;
+}
+</style>

--- a/frontend/src/components/service/GenericApiViewer.vue
+++ b/frontend/src/components/service/GenericApiViewer.vue
@@ -31,6 +31,7 @@ import { ref, computed, watch } from "vue";
 import axios from "axios";
 import { getCachedData, setCachedData } from "../../utils/cache";
 import { useConnectionStore } from "../../stores/connection";
+import { logDebug, logError } from "../../utils/logger";
 
 const props = defineProps({
   service: {
@@ -81,7 +82,10 @@ const loadData = async () => {
   if (!connectionStore.isFullyOnline()) {
     const cachedData = getCachedData(cacheKey, cacheTTL);
     if (cachedData) {
-      console.log(`[ServiceViewer] Using cached data for ${props.service.id}`);
+      logDebug(
+        "[GenericApiViewer]",
+        `Using cached data for ${props.service.id}`,
+      );
       data.value = cachedData;
       loading.value = false;
       return;
@@ -100,8 +104,9 @@ const loadData = async () => {
     if (connectionStore.isFullyOnline()) {
       const cachedData = getCachedData(cacheKey, cacheTTL);
       if (cachedData) {
-        console.log(
-          `[ServiceViewer] Request failed, using cached data for ${props.service.id}`,
+        logDebug(
+          "[GenericApiViewer]",
+          `Request failed, using cached data for ${props.service.id}`,
         );
         data.value = cachedData;
         loading.value = false;
@@ -113,7 +118,7 @@ const loadData = async () => {
       err.response?.data?.detail ||
       err.message ||
       "Failed to load service data";
-    console.error("Error loading service data:", err);
+    logError("[GenericApiViewer]", "Error loading service data:", err);
     data.value = { error: error.value };
   } finally {
     loading.value = false;

--- a/frontend/src/components/service/ServiceViewer.vue
+++ b/frontend/src/components/service/ServiceViewer.vue
@@ -73,19 +73,10 @@ const renderTemplate = computed(() => {
 
 const apiEndpoint = computed(() => {
   if (props.service.display_schema?.api_endpoint) {
-    let endpoint = props.service.display_schema.api_endpoint.replace(
+    return props.service.display_schema.api_endpoint.replace(
       "{service_id}",
       props.service.id,
     );
-    // Migrate old web-services endpoints to new plugin API
-    if (endpoint.includes("/api/web-services/")) {
-      // Convert /api/web-services/{id}/weather or /api/web-services/{id}/data to /api/plugins/{id}/data
-      endpoint = endpoint.replace(
-        /\/api\/web-services\/([^/]+)\/(weather|data)/,
-        "/api/plugins/$1/data",
-      );
-    }
-    return endpoint;
   }
   // For plugins without api_endpoint in display_schema, use the new plugin API format
   if (props.service.plugin_id && props.service.id) {

--- a/frontend/src/components/service/ServiceViewer.vue
+++ b/frontend/src/components/service/ServiceViewer.vue
@@ -43,6 +43,7 @@ import { computed, watch } from "vue";
 import WeatherViewer from "./WeatherViewer.vue";
 import GenericApiViewer from "./GenericApiViewer.vue";
 import { usePluginComponent } from "../../composables/usePluginComponent";
+import { logDebug, logError } from "../../utils/logger";
 
 const props = defineProps({
   service: {
@@ -98,7 +99,7 @@ const {
 watch(
   () => props.service,
   (service) => {
-    console.log("[ServiceViewer] Service data:", {
+    logDebug("[ServiceViewer]", "Service data:", {
       id: service?.id,
       name: service?.name,
       plugin_id: service?.plugin_id,
@@ -111,16 +112,16 @@ watch(
 );
 
 watch(componentPath, (path) => {
-  console.log("[ServiceViewer] Component path:", path);
+  logDebug("[ServiceViewer]", "Component path:", path);
 });
 
 watch(pluginComponent, (comp) => {
-  console.log("[ServiceViewer] Plugin component loaded:", comp);
+  logDebug("[ServiceViewer]", "Plugin component loaded:", comp);
 });
 
 watch(pluginComponentError, (err) => {
   if (err) {
-    console.error("[ServiceViewer] Component error:", err);
+    logError("[ServiceViewer]", "Component error:", err);
   }
 });
 </script>

--- a/frontend/src/components/settings/categories/PluginsCategory.vue
+++ b/frontend/src/components/settings/categories/PluginsCategory.vue
@@ -1,20 +1,5 @@
 <template>
   <div class="plugins-category">
-    <!-- Frontend rebuild banner -->
-    <div
-      v-if="rebuildStatus !== 'idle'"
-      :class="['rebuild-banner', `rebuild-banner--${rebuildStatus}`]"
-    >
-      <span class="rebuild-banner-text">{{ rebuildMessage }}</span>
-      <button
-        v-if="rebuildStatus === 'done'"
-        class="btn-refresh"
-        @click="() => window.location.reload()"
-      >
-        Refresh Now
-      </button>
-    </div>
-
     <!-- Plugin Installation Section -->
     <CollapsibleSection title="Install New Plugin" icon="📦" :expanded="true">
       <PluginInstaller
@@ -28,12 +13,17 @@
         :requires-restart="pluginRequiresRestart"
         :branch-switched="pluginBranchSwitched"
         :actual-branch="pluginActualBranch"
+        :dev-mode="configStore.devMode"
+        :rebuild-status="rebuildStatus"
+        :rebuild-message="rebuildMessage"
         @update:repoUrl="githubRepoUrl = $event"
         @update:branch="githubBranch = $event"
         @zip-select="handleZipSelect"
         @list-plugins="handleListPlugins"
         @install="handleInstall"
         @install-selected="handleInstallSelected"
+        @install-local="handleInstallLocal"
+        @install-selected-local="handleInstallSelectedLocal"
         @force-update="handleForceUpdate"
         @restart="handleRestart"
       />
@@ -142,6 +132,7 @@
 import { ref, computed, onMounted, watch } from "vue";
 import { usePlugins } from "@/composables";
 import { useSystem } from "@/composables";
+import { useConfigStore } from "@/stores/config";
 import { useImagesStore } from "@/stores/images";
 import * as pluginsApi from "@/services/pluginsApi";
 import * as calendarApi from "@/services/calendarApi";
@@ -172,11 +163,15 @@ const {
   enumeratePluginsFromGitHub,
   installPluginFromGitHub,
   installPluginsFromGitHub,
+  enumeratePluginsFromLocal,
+  installPluginFromLocal,
+  installPluginsFromLocal,
   uninstallPlugin,
   togglePlugin,
 } = usePlugins();
 
 const { restartBackend } = useSystem();
+const configStore = useConfigStore();
 const imagesStore = useImagesStore();
 
 // Local state
@@ -227,17 +222,22 @@ const cancelPipInstall = () => {
 };
 
 // Frontend rebuild banner
-const rebuildStatus = ref("idle"); // idle | done | error
+const rebuildStatus = ref("idle"); // idle | building | done | error
 const rebuildMessage = ref("");
 
 watch(pluginFrontendRebuildResult, (result) => {
   if (!result) return;
-  rebuildStatus.value = result.success ? "done" : "error";
-  rebuildMessage.value =
-    result.message ||
-    (result.success
-      ? "Frontend rebuilt — refresh the page to load new plugin components."
-      : "Frontend rebuild failed — rebuild manually with: npm run build");
+  if (result.building) {
+    rebuildStatus.value = "building";
+    rebuildMessage.value = result.message || "Building frontend…";
+  } else {
+    rebuildStatus.value = result.success ? "done" : "error";
+    rebuildMessage.value =
+      result.message ||
+      (result.success
+        ? "Frontend rebuilt — refresh the page to load new plugin components."
+        : "Frontend rebuild failed — rebuild manually with: npm run build");
+  }
 });
 
 // Handlers
@@ -257,8 +257,12 @@ const handleZipSelect = async (file) => {
   await installPluginFromZip(file);
 };
 
-const handleListPlugins = async ({ repoUrl, branch }) => {
-  await enumeratePluginsFromGitHub(repoUrl, branch);
+const handleListPlugins = async ({ repoUrl, branch, source, localPath }) => {
+  if (source === "local") {
+    await enumeratePluginsFromLocal(localPath);
+  } else {
+    await enumeratePluginsFromGitHub(repoUrl, branch);
+  }
 };
 
 const handleInstall = async ({ path, repoUrl, branch, force }) => {
@@ -302,6 +306,39 @@ const handleInstallSelected = async ({
   }
   const doInstall = () =>
     installPluginsFromGitHub(pluginsToInstall, repoUrl, branch);
+  if (allDeps.length > 0) {
+    triggerPipWarning(allDeps, names.join(", "), doInstall);
+    return;
+  }
+  await doInstall();
+};
+
+const handleInstallLocal = async ({ path, localPath, force }) => {
+  const plugin = availablePlugins.value.find((p) => p.path === path);
+  const deps = plugin?.manifest?.python_dependencies ?? [];
+  const doInstall = () => installPluginFromLocal(localPath, path, force);
+  if (deps.length > 0) {
+    triggerPipWarning(deps, plugin?.name ?? path, doInstall);
+    return;
+  }
+  await doInstall();
+};
+
+const handleInstallSelectedLocal = async ({
+  plugins: pluginsToInstall,
+  localPath,
+}) => {
+  const allDeps = [];
+  const names = [];
+  for (const { path, id } of pluginsToInstall) {
+    const p = availablePlugins.value.find(
+      (ap) => ap.id === id || ap.path === path,
+    );
+    const deps = p?.manifest?.python_dependencies ?? [];
+    if (deps.length > 0) allDeps.push(...deps);
+    names.push(p?.name ?? id);
+  }
+  const doInstall = () => installPluginsFromLocal(pluginsToInstall, localPath);
   if (allDeps.length > 0) {
     triggerPipWarning(allDeps, names.join(", "), doInstall);
     return;
@@ -629,48 +666,6 @@ onMounted(async () => {
 <style scoped>
 .plugins-category {
   width: 100%;
-}
-
-/* Frontend rebuild banner */
-.rebuild-banner {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
-  border-radius: 6px;
-  margin-bottom: 1rem;
-  font-size: 0.9rem;
-}
-
-.rebuild-banner--done {
-  background: rgba(34, 197, 94, 0.15);
-  border: 1px solid rgba(34, 197, 94, 0.4);
-  color: #86efac;
-}
-
-.rebuild-banner--error {
-  background: rgba(239, 68, 68, 0.15);
-  border: 1px solid rgba(239, 68, 68, 0.4);
-  color: #fca5a5;
-}
-
-.rebuild-banner-text {
-  flex: 1;
-}
-
-.btn-refresh {
-  padding: 0.3rem 0.75rem;
-  background: rgba(34, 197, 94, 0.2);
-  color: inherit;
-  border: 1px solid currentColor;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 0.85rem;
-  white-space: nowrap;
-}
-
-.btn-refresh:hover {
-  background: rgba(34, 197, 94, 0.35);
 }
 
 /* Pip warning modal — mirrors ConfirmModal layout */

--- a/frontend/src/components/settings/categories/PluginsCategory.vue
+++ b/frontend/src/components/settings/categories/PluginsCategory.vue
@@ -158,6 +158,14 @@ const {
   pluginBranchSwitched,
   pluginActualBranch,
   pluginFrontendRebuildResult,
+  expandedPlugins,
+  pluginFormData,
+  savingPlugin,
+  testingPlugin,
+  fetchingPlugin,
+  pluginSaveStatus,
+  pluginTestStatus,
+  pluginFetchStatus,
   loadPlugins,
   installPluginFromZip,
   enumeratePluginsFromGitHub,
@@ -167,6 +175,11 @@ const {
   installPluginFromLocal,
   installPluginsFromLocal,
   uninstallPlugin,
+  loadPluginConfig,
+  updatePluginFormValue,
+  savePluginConfig,
+  testPluginConnection,
+  fetchPluginNow,
   togglePlugin,
 } = usePlugins();
 
@@ -176,14 +189,6 @@ const imagesStore = useImagesStore();
 
 // Local state
 const activePluginTab = ref("calendar");
-const expandedPlugins = ref({});
-const pluginFormData = ref({});
-const savingPlugin = ref(null);
-const testingPlugin = ref({});
-const fetchingPlugin = ref({});
-const pluginSaveStatus = ref({});
-const pluginTestStatus = ref({});
-const pluginFetchStatus = ref({});
 const uploading = ref(false);
 const uploadError = ref("");
 const uploadSuccess = ref("");
@@ -354,7 +359,9 @@ const handleToggleExpand = (pluginId) => {
   expandedPlugins.value[pluginId] = !expandedPlugins.value[pluginId];
   if (expandedPlugins.value[pluginId]) {
     // Load plugin config when expanding
-    loadPluginConfig(pluginId);
+    void loadPluginConfig(pluginId).catch((error) => {
+      console.error(`Failed to load config for plugin ${pluginId}:`, error);
+    });
   }
 };
 
@@ -389,80 +396,19 @@ const cancelUninstall = () => {
 };
 
 const handleUpdateFormValue = (pluginId, key, value) => {
-  if (!pluginFormData.value[pluginId]) {
-    pluginFormData.value[pluginId] = {};
-  }
-  pluginFormData.value[pluginId][key] = value;
+  updatePluginFormValue(pluginId, key, value);
 };
 
 const handleSaveConfig = async (pluginId) => {
-  savingPlugin.value = pluginId;
-  pluginSaveStatus.value[pluginId] = null;
-
-  try {
-    const config = pluginFormData.value[pluginId] || {};
-    await pluginsApi.updatePlugin(pluginId, { config });
-    pluginSaveStatus.value[pluginId] = {
-      success: true,
-      message: "Configuration saved successfully",
-    };
-    setTimeout(() => {
-      pluginSaveStatus.value[pluginId] = null;
-    }, 5000);
-  } catch (error) {
-    pluginSaveStatus.value[pluginId] = {
-      success: false,
-      message:
-        error.response?.data?.detail ||
-        error.message ||
-        "Failed to save configuration",
-    };
-  } finally {
-    savingPlugin.value = null;
-  }
+  await savePluginConfig(pluginId);
 };
 
 const handleTestConnection = async (pluginId) => {
-  testingPlugin.value[pluginId] = true;
-  pluginTestStatus.value[pluginId] = null;
-
-  try {
-    const response = await pluginsApi.testPlugin(pluginId);
-    pluginTestStatus.value[pluginId] = {
-      success: response.success || false,
-      message: response.message || "Test completed",
-    };
-  } catch (error) {
-    pluginTestStatus.value[pluginId] = {
-      success: false,
-      message: error.response?.data?.detail || error.message || "Test failed",
-    };
-  } finally {
-    testingPlugin.value[pluginId] = false;
-  }
+  await testPluginConnection(pluginId);
 };
 
 const handleFetchNow = async (pluginId) => {
-  fetchingPlugin.value[pluginId] = true;
-  pluginFetchStatus.value[pluginId] = null;
-
-  try {
-    await pluginsApi.fetchPlugin(pluginId);
-    pluginFetchStatus.value[pluginId] = {
-      success: true,
-      message: "Fetch initiated successfully",
-    };
-  } catch (error) {
-    pluginFetchStatus.value[pluginId] = {
-      success: false,
-      message:
-        error.response?.data?.detail ||
-        error.message ||
-        "Failed to initiate fetch",
-    };
-  } finally {
-    fetchingPlugin.value[pluginId] = false;
-  }
+  await fetchPluginNow(pluginId);
 };
 
 const handleCustomAction = async (_pluginId, _action) => {
@@ -636,15 +582,6 @@ const handleDeleteImage = async (imageId) => {
 };
 
 // Helper functions
-const loadPluginConfig = async (pluginId) => {
-  try {
-    const response = await pluginsApi.getPluginConfig(pluginId);
-    pluginFormData.value[pluginId] = response.config || {};
-  } catch (error) {
-    console.error(`Failed to load config for plugin ${pluginId}:`, error);
-  }
-};
-
 // Initialize
 onMounted(async () => {
   await loadPlugins();

--- a/frontend/src/components/settings/categories/PluginsCategory.vue
+++ b/frontend/src/components/settings/categories/PluginsCategory.vue
@@ -5,7 +5,6 @@
       v-if="rebuildStatus !== 'idle'"
       :class="['rebuild-banner', `rebuild-banner--${rebuildStatus}`]"
     >
-      <span v-if="rebuildStatus === 'building'" class="rebuild-spinner" />
       <span class="rebuild-banner-text">{{ rebuildMessage }}</span>
       <button
         v-if="rebuildStatus === 'done'"
@@ -140,7 +139,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted, watch } from "vue";
+import { ref, computed, onMounted, watch } from "vue";
 import { usePlugins } from "@/composables";
 import { useSystem } from "@/composables";
 import { useImagesStore } from "@/stores/images";
@@ -167,7 +166,7 @@ const {
   pluginRequiresRestart,
   pluginBranchSwitched,
   pluginActualBranch,
-  pluginFrontendRebuildTriggered,
+  pluginFrontendRebuildResult,
   loadPlugins,
   installPluginFromZip,
   enumeratePluginsFromGitHub,
@@ -228,39 +227,18 @@ const cancelPipInstall = () => {
 };
 
 // Frontend rebuild banner
-const rebuildStatus = ref("idle"); // idle | building | done | error
+const rebuildStatus = ref("idle"); // idle | done | error
 const rebuildMessage = ref("");
-let rebuildPollInterval = null;
 
-const stopRebuildPolling = () => {
-  if (rebuildPollInterval) {
-    clearInterval(rebuildPollInterval);
-    rebuildPollInterval = null;
-  }
-};
-
-const pollRebuildStatus = async () => {
-  try {
-    const result = await pluginsApi.getFrontendBuildStatus();
-    rebuildStatus.value = result.status;
-    rebuildMessage.value = result.message;
-    if (result.status !== "building") {
-      stopRebuildPolling();
-    }
-  } catch {
-    // Silently ignore polling errors
-  }
-};
-
-watch(pluginFrontendRebuildTriggered, (triggered) => {
-  if (!triggered) return;
-  rebuildStatus.value = "building";
-  rebuildMessage.value = "Frontend rebuild in progress…";
-  stopRebuildPolling();
-  rebuildPollInterval = setInterval(pollRebuildStatus, 4000);
+watch(pluginFrontendRebuildResult, (result) => {
+  if (!result) return;
+  rebuildStatus.value = result.success ? "done" : "error";
+  rebuildMessage.value =
+    result.message ||
+    (result.success
+      ? "Frontend rebuilt — refresh the page to load new plugin components."
+      : "Frontend rebuild failed — rebuild manually with: npm run build");
 });
-
-onUnmounted(stopRebuildPolling);
 
 // Handlers
 const handleZipSelect = async (file) => {
@@ -664,12 +642,6 @@ onMounted(async () => {
   font-size: 0.9rem;
 }
 
-.rebuild-banner--building {
-  background: rgba(59, 130, 246, 0.15);
-  border: 1px solid rgba(59, 130, 246, 0.4);
-  color: #93c5fd;
-}
-
 .rebuild-banner--done {
   background: rgba(34, 197, 94, 0.15);
   border: 1px solid rgba(34, 197, 94, 0.4);
@@ -684,22 +656,6 @@ onMounted(async () => {
 
 .rebuild-banner-text {
   flex: 1;
-}
-
-.rebuild-spinner {
-  width: 16px;
-  height: 16px;
-  border: 2px solid currentColor;
-  border-top-color: transparent;
-  border-radius: 50%;
-  animation: spin 0.8s linear infinite;
-  flex-shrink: 0;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
-  }
 }
 
 .btn-refresh {

--- a/frontend/src/components/settings/specialized/PluginInstaller.vue
+++ b/frontend/src/components/settings/specialized/PluginInstaller.vue
@@ -15,6 +15,15 @@
       >
         🐙 GitHub
       </button>
+      <button
+        v-if="devMode"
+        class="install-tab install-tab--dev"
+        :class="{ active: installMethod === 'local' }"
+        @click="installMethod = 'local'"
+        title="Dev mode: install from local filesystem path"
+      >
+        🗂️ Local Path
+      </button>
     </div>
 
     <!-- Zip File Upload -->
@@ -211,6 +220,137 @@
       </div>
     </div>
 
+    <!-- Local Path (dev mode only) -->
+    <div
+      v-if="devMode"
+      v-show="installMethod === 'local'"
+      class="plugin-install-content"
+    >
+      <p class="help-text-compact">
+        Install directly from a local cloned repository. Enter an absolute path
+        to the repo root.
+      </p>
+      <div class="install-compact-row">
+        <input
+          v-model="localPath"
+          type="text"
+          placeholder="/absolute/path/to/calvin-plugins"
+          class="github-input-compact"
+          :disabled="enumerating || installing || detecting"
+        />
+        <button
+          type="button"
+          class="btn-autodetect"
+          :disabled="enumerating || installing || detecting"
+          @click="handleAutoDetect"
+          title="Auto-detect sibling plugin repositories"
+        >
+          {{ detecting ? "Detecting..." : "📂 Auto-detect" }}
+        </button>
+        <button
+          type="button"
+          class="btn-browse"
+          :disabled="!localPath || enumerating || installing || detecting"
+          @click="handleListLocalPlugins"
+        >
+          {{ enumerating ? "Loading..." : "🔍 List Plugins" }}
+        </button>
+      </div>
+
+      <!-- Available Plugins List (reuses same filteredPlugins/availablePlugins state) -->
+      <div
+        v-if="installSource === 'local' && filteredPlugins.length > 0"
+        class="available-plugins-compact"
+      >
+        <div class="plugin-search-container">
+          <input
+            v-model="searchQuery"
+            type="text"
+            placeholder="🔍 Search plugins..."
+            class="plugin-search-input"
+            :disabled="installing"
+          />
+        </div>
+        <TabNavigation
+          :tabs="pluginTypeTabs"
+          :active-tab="activeTypeTab"
+          @tab-change="activeTypeTab = $event"
+        />
+        <div class="plugin-list-header">
+          <label class="select-all-checkbox">
+            <input
+              type="checkbox"
+              :checked="allSelected"
+              :indeterminate="someSelected"
+              @change="handleSelectAll"
+            />
+            <span>Select All</span>
+          </label>
+          <button
+            type="button"
+            class="btn-install-selected"
+            :disabled="installing || selectedPlugins.length === 0"
+            @click="handleInstallSelectedLocal"
+          >
+            {{
+              installing
+                ? `Installing ${selectedPlugins.length}...`
+                : `⬇️ Install Selected (${selectedPlugins.length})`
+            }}
+          </button>
+        </div>
+        <div
+          v-for="plugin in activeTypePlugins"
+          :key="plugin.id"
+          class="plugin-item-inline"
+          :class="{ 'plugin-installed': plugin._installed }"
+        >
+          <div class="plugin-checkbox-wrapper">
+            <input
+              type="checkbox"
+              :checked="isSelected(plugin.id)"
+              :disabled="installing"
+              @change="handleToggleSelect(plugin.id)"
+            />
+          </div>
+          <div class="plugin-info-inline">
+            <strong>{{ plugin.name || plugin.id }}</strong>
+            <span
+              class="plugin-type-badge-small"
+              :class="`type-${plugin.type}`"
+              >{{ plugin.type }}</span
+            >
+            <span v-if="plugin.version" class="plugin-version-small"
+              >v{{ plugin.version }}</span
+            >
+            <span v-if="plugin._installed" class="plugin-installed-badge">
+              Installed: v{{ plugin._installedVersion || "?" }}
+            </span>
+          </div>
+          <div class="plugin-actions">
+            <button
+              v-if="plugin._installed"
+              type="button"
+              class="btn-install btn-reinstall"
+              :disabled="installing"
+              @click="handleInstallLocal(plugin.path, true)"
+            >
+              {{ installing ? "Installing..." : "🔁 Reinstall" }}
+            </button>
+            <button
+              v-else
+              type="button"
+              class="btn-install"
+              :disabled="installing"
+              @click="handleInstallLocal(plugin.path, false)"
+            >
+              {{ installing ? "Installing..." : "⬇️ Install" }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <!-- Installation Status Messages -->
     <div v-if="error" class="error-message">
       {{ error }}
@@ -222,6 +362,27 @@
         ℹ️ Branch switched from 'main' to 'master' (main branch not found)
       </div>
     </div>
+
+    <!-- Frontend Rebuild Progress -->
+    <div
+      v-if="rebuildStatus !== 'idle'"
+      :class="['rebuild-status', `rebuild-status--${rebuildStatus}`]"
+    >
+      <span
+        v-if="rebuildStatus === 'building'"
+        class="rebuild-spinner"
+        aria-hidden="true"
+      ></span>
+      <span class="rebuild-status-text">{{ rebuildMessage }}</span>
+      <button
+        v-if="rebuildStatus === 'done'"
+        class="btn-refresh-inline"
+        @click="handleRefresh"
+      >
+        Refresh Now
+      </button>
+    </div>
+
     <!-- Restart Required Notice -->
     <div v-if="requiresRestart" class="restart-notice">
       <div class="restart-notice-content">
@@ -248,6 +409,7 @@
 <script setup>
 import { ref, computed, watch } from "vue";
 import TabNavigation from "../shared/TabNavigation.vue";
+import * as pluginsApi from "@/services/pluginsApi";
 
 const props = defineProps({
   installing: {
@@ -294,6 +456,18 @@ const props = defineProps({
     type: String,
     default: "",
   },
+  devMode: {
+    type: Boolean,
+    default: false,
+  },
+  rebuildStatus: {
+    type: String,
+    default: "idle", // idle | building | done | error
+  },
+  rebuildMessage: {
+    type: String,
+    default: "",
+  },
 });
 
 const emit = defineEmits([
@@ -301,6 +475,8 @@ const emit = defineEmits([
   "list-plugins",
   "install",
   "install-selected",
+  "install-local",
+  "install-selected-local",
   "restart",
   "update:repoUrl",
   "update:branch",
@@ -308,6 +484,9 @@ const emit = defineEmits([
 ]);
 
 const installMethod = ref("zip");
+const installSource = ref("github"); // 'github' | 'local'
+const localPath = ref("");
+const detecting = ref(false);
 const selectedPluginIds = ref(new Set());
 const searchQuery = ref("");
 const activeTypeTab = ref("all");
@@ -428,7 +607,6 @@ const handleInstallSelected = () => {
     repoUrl: props.repoUrl,
     branch: props.branch,
   });
-  // Clear selection after install
   selectedPluginIds.value.clear();
 };
 
@@ -440,9 +618,32 @@ const handleZipSelect = (event) => {
 };
 
 const handleListPlugins = () => {
+  installSource.value = "github";
   emit("list-plugins", {
     repoUrl: props.repoUrl,
     branch: props.branch,
+  });
+};
+
+const handleAutoDetect = async () => {
+  detecting.value = true;
+  try {
+    const result = await pluginsApi.suggestLocalPath();
+    if (result.suggestions && result.suggestions.length > 0) {
+      localPath.value = result.suggestions[0];
+    }
+  } catch (e) {
+    // silently ignore — user can type path manually
+  } finally {
+    detecting.value = false;
+  }
+};
+
+const handleListLocalPlugins = () => {
+  installSource.value = "local";
+  emit("list-plugins", {
+    source: "local",
+    localPath: localPath.value,
   });
 };
 
@@ -453,6 +654,26 @@ const handleInstall = (pluginPath) => {
     branch: props.branch,
     force: false,
   });
+};
+
+const handleInstallLocal = (pluginPath, force) => {
+  emit("install-local", {
+    path: pluginPath,
+    localPath: localPath.value,
+    force,
+  });
+};
+
+const handleInstallSelectedLocal = () => {
+  const pluginsToInstall = selectedPlugins.value.map((p) => ({
+    path: p.path,
+    id: p.id,
+  }));
+  emit("install-selected-local", {
+    plugins: pluginsToInstall,
+    localPath: localPath.value,
+  });
+  selectedPluginIds.value.clear();
 };
 
 const handleForceUpdate = (pluginPath) => {
@@ -466,6 +687,10 @@ const handleForceUpdate = (pluginPath) => {
 
 const handleRestart = () => {
   emit("restart");
+};
+
+const handleRefresh = () => {
+  window.location.reload();
 };
 
 const handleRepoUrlInput = (event) => {
@@ -532,6 +757,40 @@ watch(searchQuery, () => {
   color: var(--accent-primary);
   border-bottom-color: var(--accent-primary);
   font-weight: 600;
+}
+
+.install-tab--dev {
+  color: #e67e22;
+}
+
+.install-tab--dev.active {
+  color: #e67e22;
+  border-bottom-color: #e67e22;
+}
+
+.btn-autodetect {
+  padding: 0.5rem 1rem;
+  background: #6c757d;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  white-space: nowrap;
+}
+
+.btn-autodetect:hover:not(:disabled) {
+  background: #5a6268;
+  transform: translateY(-1px);
+  box-shadow: 0 2px 4px var(--shadow);
+}
+
+.btn-autodetect:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
 }
 
 .plugin-install-content {
@@ -872,6 +1131,72 @@ watch(searchQuery, () => {
   opacity: 0.6;
   cursor: not-allowed;
   transform: none;
+}
+
+.rebuild-status {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  font-size: 0.875rem;
+}
+
+.rebuild-status--building {
+  background: rgba(59, 130, 246, 0.12);
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  color: #3b82f6;
+}
+
+.rebuild-status--done {
+  background: rgba(34, 197, 94, 0.12);
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  color: #22c55e;
+}
+
+.rebuild-status--error {
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  color: #ef4444;
+}
+
+.rebuild-spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: rebuild-spin 0.8s linear infinite;
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+
+@keyframes rebuild-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.rebuild-status-text {
+  flex: 1;
+}
+
+.btn-refresh-inline {
+  padding: 0.25rem 0.625rem;
+  background: rgba(34, 197, 94, 0.15);
+  color: inherit;
+  border: 1px solid currentColor;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 600;
+  white-space: nowrap;
+  transition: background 0.2s;
+}
+
+.btn-refresh-inline:hover {
+  background: rgba(34, 197, 94, 0.3);
 }
 
 .error-message {

--- a/frontend/src/components/settings/tabs/content/ImagesTab.vue
+++ b/frontend/src/components/settings/tabs/content/ImagesTab.vue
@@ -51,7 +51,7 @@ const imagePluginInstances = computed(() => {
   imagePlugins.value.forEach((plugin) => {
     const pluginInsts = pluginInstances.value[plugin.id] || [];
     // Sort instances by display_order
-    instances[plugin.id] = pluginInsts.sort((a, b) => {
+    instances[plugin.id] = [...pluginInsts].sort((a, b) => {
       const orderA = a.display_order ?? 0;
       const orderB = b.display_order ?? 0;
       return orderA - orderB;

--- a/frontend/src/components/settings/tabs/content/ServicesTab.vue
+++ b/frontend/src/components/settings/tabs/content/ServicesTab.vue
@@ -41,7 +41,7 @@ const servicePlugins = computed(() => {
     (p) => p.type === "service" && p.enabled,
   );
   // Sort by display order
-  return filtered.sort((a, b) => {
+  return [...filtered].sort((a, b) => {
     const orderA = pluginDisplayOrders.value[a.id] ?? 0;
     const orderB = pluginDisplayOrders.value[b.id] ?? 0;
     return orderA - orderB;
@@ -53,7 +53,7 @@ const servicePluginInstances = computed(() => {
   servicePlugins.value.forEach((plugin) => {
     const pluginInsts = pluginInstances.value[plugin.id] || [];
     // Sort instances by display_order
-    instances[plugin.id] = pluginInsts.sort((a, b) => {
+    instances[plugin.id] = [...pluginInsts].sort((a, b) => {
       const orderA = a.display_order ?? 0;
       const orderB = b.display_order ?? 0;
       return orderA - orderB;

--- a/frontend/src/composables/usePlugins.js
+++ b/frontend/src/composables/usePlugins.js
@@ -95,6 +95,22 @@ function _startRebuildPolling() {
   _rebuildPollTimer = setTimeout(poll, 1000);
 }
 
+function _normalizePluginConfig(config = {}) {
+  const cleanedConfig = {};
+
+  for (const [key, value] of Object.entries(config)) {
+    if (value === null || value === undefined) {
+      cleanedConfig[key] = "";
+    } else if (typeof value === "object") {
+      cleanedConfig[key] = value.value || value.default || "";
+    } else {
+      cleanedConfig[key] = value;
+    }
+  }
+
+  return cleanedConfig;
+}
+
 export function usePlugins() {
   // Load plugins
   const loadPlugins = async () => {
@@ -711,11 +727,126 @@ export function usePlugins() {
   // Uninstall plugin
   const uninstallPlugin = async (pluginId, pluginType = null) => {
     try {
-      await pluginsApi.uninstallPlugin(pluginId, pluginType);
+      const response = await pluginsApi.uninstallPlugin(pluginId, pluginType);
+      if (response.frontend_rebuild_in_progress) {
+        _startRebuildPolling();
+      }
       await loadPlugins();
     } catch (error) {
       logError("[usePlugins]", "Failed to uninstall plugin:", error);
       throw error;
+    }
+  };
+
+  const loadPluginConfig = async (pluginId) => {
+    try {
+      const response = await pluginsApi.getPluginConfig(pluginId);
+      const config = response.config || {};
+      pluginConfigs.value[pluginId] = config;
+      pluginFormData.value[pluginId] = { ...config };
+      return config;
+    } catch (error) {
+      logError(
+        "[usePlugins]",
+        `Failed to load config for plugin ${pluginId}:`,
+        error,
+      );
+      throw error;
+    }
+  };
+
+  const updatePluginFormValue = (pluginId, key, value) => {
+    if (!pluginFormData.value[pluginId]) {
+      pluginFormData.value[pluginId] = {};
+    }
+    pluginFormData.value[pluginId][key] = value;
+  };
+
+  const savePluginConfig = async (pluginId) => {
+    savingPlugin.value = pluginId;
+    pluginSaveStatus.value[pluginId] = null;
+
+    try {
+      const config = pluginFormData.value[pluginId] || {};
+      const cleanedConfig = _normalizePluginConfig(config);
+      await pluginsApi.updatePlugin(pluginId, cleanedConfig);
+      pluginConfigs.value[pluginId] = { ...cleanedConfig };
+      pluginFormData.value[pluginId] = { ...cleanedConfig };
+      pluginSaveStatus.value[pluginId] = {
+        success: true,
+        message: "Configuration saved successfully",
+      };
+      setTimeout(() => {
+        pluginSaveStatus.value[pluginId] = null;
+      }, 5000);
+    } catch (error) {
+      logError(
+        "[usePlugins]",
+        `Failed to save config for plugin ${pluginId}:`,
+        error,
+      );
+      pluginSaveStatus.value[pluginId] = {
+        success: false,
+        message:
+          error.response?.data?.detail ||
+          error.message ||
+          "Failed to save configuration",
+      };
+      throw error;
+    } finally {
+      savingPlugin.value = null;
+    }
+  };
+
+  const testPluginConnection = async (pluginId) => {
+    testingPlugin.value[pluginId] = true;
+    pluginTestStatus.value[pluginId] = null;
+
+    try {
+      const testConfig = _normalizePluginConfig(
+        pluginFormData.value[pluginId] || {},
+      );
+      const response = await pluginsApi.testPlugin(pluginId, testConfig);
+      pluginTestStatus.value[pluginId] = {
+        success: response.success || false,
+        message: response.message || "Test completed",
+      };
+      return response;
+    } catch (error) {
+      logError("[usePlugins]", `Failed to test plugin ${pluginId}:`, error);
+      pluginTestStatus.value[pluginId] = {
+        success: false,
+        message: error.response?.data?.detail || error.message || "Test failed",
+      };
+      throw error;
+    } finally {
+      testingPlugin.value[pluginId] = false;
+    }
+  };
+
+  const fetchPluginNow = async (pluginId) => {
+    fetchingPlugin.value[pluginId] = true;
+    pluginFetchStatus.value[pluginId] = null;
+
+    try {
+      const response = await pluginsApi.fetchPlugin(pluginId);
+      pluginFetchStatus.value[pluginId] = {
+        success: true,
+        message: "Fetch initiated successfully",
+      };
+      return response;
+    } catch (error) {
+      logError("[usePlugins]", `Failed to fetch plugin ${pluginId}:`, error);
+      pluginFetchStatus.value[pluginId] = {
+        success: false,
+        message:
+          error.response?.data?.detail ||
+          error.message ||
+          "Failed to initiate fetch",
+      };
+      throw error;
+    } finally {
+      fetchingPlugin.value[pluginId] = false;
     }
   };
 
@@ -925,6 +1056,11 @@ export function usePlugins() {
     installPluginFromLocal,
     installPluginsFromLocal,
     uninstallPlugin,
+    loadPluginConfig,
+    updatePluginFormValue,
+    savePluginConfig,
+    testPluginConnection,
+    fetchPluginNow,
     togglePlugin,
     updatePluginOrder,
     updateImagePluginOrder,

--- a/frontend/src/composables/usePlugins.js
+++ b/frontend/src/composables/usePlugins.js
@@ -59,6 +59,42 @@ const sortedPluginCategories = computed(() => {
   return categories.filter((c) => c.plugins.length > 0);
 });
 
+// Poll the backend rebuild-status endpoint until building is complete,
+// updating pluginFrontendRebuildResult along the way.
+let _rebuildPollTimer = null;
+function _startRebuildPolling() {
+  if (_rebuildPollTimer !== null) return; // already polling
+  pluginFrontendRebuildResult.value = {
+    building: true,
+    success: null,
+    message: "Building frontend, this may take a minute…",
+  };
+
+  const poll = async () => {
+    try {
+      const status = await pluginsApi.getRebuildStatus();
+      if (status.state === "building") {
+        pluginFrontendRebuildResult.value = {
+          building: true,
+          success: null,
+          message: status.message,
+        };
+        _rebuildPollTimer = setTimeout(poll, 2000);
+      } else {
+        _rebuildPollTimer = null;
+        pluginFrontendRebuildResult.value = {
+          building: false,
+          success: status.state === "done",
+          message: status.message,
+        };
+      }
+    } catch {
+      _rebuildPollTimer = null;
+    }
+  };
+  _rebuildPollTimer = setTimeout(poll, 1000);
+}
+
 export function usePlugins() {
   // Load plugins
   const loadPlugins = async () => {
@@ -169,14 +205,8 @@ export function usePlugins() {
       const response = await pluginsApi.installPluginFromZip(file);
       pluginInstallSuccess.value = "Plugin installed successfully!";
       pluginRequiresRestart.value = response.requires_restart || false;
-      if (
-        response.frontend_rebuild_success !== null &&
-        response.frontend_rebuild_success !== undefined
-      ) {
-        pluginFrontendRebuildResult.value = {
-          success: response.frontend_rebuild_success,
-          message: response.frontend_rebuild_message,
-        };
+      if (response.frontend_rebuild_in_progress) {
+        _startRebuildPolling();
       }
 
       if (!pluginRequiresRestart.value) {
@@ -312,17 +342,24 @@ export function usePlugins() {
       pluginRequiresRestart.value = response.requires_restart || false;
       pluginBranchSwitched.value = response.branch_switched || false;
       pluginActualBranch.value = response.branch || branch;
-      if (
-        response.frontend_rebuild_success !== null &&
-        response.frontend_rebuild_success !== undefined
-      ) {
-        pluginFrontendRebuildResult.value = {
-          success: response.frontend_rebuild_success,
-          message: response.frontend_rebuild_message,
+      if (response.frontend_rebuild_in_progress) {
+        _startRebuildPolling();
+      }
+
+      // Mark the installed plugin in-place so the list stays visible
+      const installedId = response.manifest?.id || pluginPath;
+      const idx = availablePlugins.value.findIndex(
+        (p) => p.id === installedId || p.path === pluginPath,
+      );
+      if (idx !== -1) {
+        availablePlugins.value[idx] = {
+          ...availablePlugins.value[idx],
+          _installed: true,
+          _installedVersion:
+            response.manifest?.version || availablePlugins.value[idx].version,
         };
       }
 
-      availablePlugins.value = [];
       await loadPlugins();
 
       if (!pluginRequiresRestart.value) {
@@ -389,14 +426,8 @@ export function usePlugins() {
             pluginBranchSwitched.value = true;
             pluginActualBranch.value = response.branch || branch;
           }
-          if (
-            response.frontend_rebuild_success !== null &&
-            response.frontend_rebuild_success !== undefined
-          ) {
-            pluginFrontendRebuildResult.value = {
-              success: response.frontend_rebuild_success,
-              message: response.frontend_rebuild_message,
-            };
+          if (response.frontend_rebuild_in_progress) {
+            _startRebuildPolling();
           }
         } catch (error) {
           results.failed.push({
@@ -430,8 +461,22 @@ export function usePlugins() {
         pluginInstallError.value = `Failed to install ${results.failed.length} plugin(s): ${failedNames}. Details: ${failedDetails}`;
       }
 
-      // Refresh installed plugins list
-      // Only refresh if we had any successes
+      // Mark installed plugins in-place so the list stays visible
+      for (const s of results.success) {
+        const idx = availablePlugins.value.findIndex(
+          (p) => p.id === s.id || p.path === s.response?.manifest?.id,
+        );
+        if (idx !== -1) {
+          availablePlugins.value[idx] = {
+            ...availablePlugins.value[idx],
+            _installed: true,
+            _installedVersion:
+              s.response?.manifest?.version ||
+              availablePlugins.value[idx].version,
+          };
+        }
+      }
+
       if (results.success.length > 0) {
         await loadPlugins();
       }
@@ -447,6 +492,214 @@ export function usePlugins() {
         error.response?.data?.detail ||
         error.message ||
         "Failed to install plugins from GitHub";
+      setTimeout(() => {
+        pluginInstallError.value = "";
+      }, 10000);
+    } finally {
+      installingPlugin.value = false;
+    }
+  };
+
+  // Enumerate plugins from a local path (dev mode only)
+  const enumeratePluginsFromLocal = async (localPath) => {
+    if (!localPath || !localPath.trim()) {
+      pluginInstallError.value = "Local path is required";
+      setTimeout(() => {
+        pluginInstallError.value = "";
+      }, 10000);
+      return;
+    }
+
+    enumeratingPlugins.value = true;
+    availablePlugins.value = [];
+
+    try {
+      const response = await pluginsApi.enumeratePluginsFromLocal(localPath);
+      const enumeratedPlugins = response.plugins || [];
+      const enumeratedThemes = response.themes || [];
+
+      const allItems = [
+        ...enumeratedPlugins,
+        ...enumeratedThemes.map((theme) => ({ ...theme, type: "theme" })),
+      ];
+
+      let installedPluginsMap = {};
+      try {
+        const installedResponse = await pluginsApi.getInstalledPlugins();
+        installedPluginsMap = Object.fromEntries(
+          (installedResponse.plugins || []).map((p) => [p.id, p]),
+        );
+      } catch (error) {
+        if (error.response?.status !== 404) {
+          logWarn(
+            "[usePlugins]",
+            "Failed to load installed plugins for comparison:",
+            error,
+          );
+        }
+      }
+
+      availablePlugins.value = allItems.map((plugin) => {
+        const installed = installedPluginsMap[plugin.id];
+        return installed
+          ? {
+              ...plugin,
+              _installed: true,
+              _installedVersion: installed.version || null,
+            }
+          : { ...plugin, _installed: false, _installedVersion: null };
+      });
+    } catch (error) {
+      logError(
+        "[usePlugins]",
+        "Failed to enumerate plugins from local path:",
+        error,
+      );
+      pluginInstallError.value =
+        error.response?.data?.detail ||
+        error.message ||
+        "Failed to enumerate plugins from local path";
+      setTimeout(() => {
+        pluginInstallError.value = "";
+      }, 10000);
+    } finally {
+      enumeratingPlugins.value = false;
+    }
+  };
+
+  // Install a single plugin from a local path (dev mode only)
+  const installPluginFromLocal = async (
+    localPath,
+    pluginPath,
+    force = false,
+  ) => {
+    installingPlugin.value = true;
+    pluginInstallError.value = "";
+    pluginInstallSuccess.value = "";
+    pluginRequiresRestart.value = false;
+
+    try {
+      const response = await pluginsApi.installPluginFromLocal(
+        localPath,
+        pluginPath,
+        force,
+      );
+      pluginInstallSuccess.value = "Plugin installed successfully!";
+      pluginRequiresRestart.value = response.requires_restart || false;
+      if (response.frontend_rebuild_in_progress) {
+        _startRebuildPolling();
+      }
+
+      // Mark the installed plugin in-place so the list stays visible
+      const installedId = response.manifest?.id || pluginPath;
+      const idx = availablePlugins.value.findIndex(
+        (p) => p.id === installedId || p.path === pluginPath,
+      );
+      if (idx !== -1) {
+        availablePlugins.value[idx] = {
+          ...availablePlugins.value[idx],
+          _installed: true,
+          _installedVersion:
+            response.manifest?.version || availablePlugins.value[idx].version,
+        };
+      }
+
+      await loadPlugins();
+
+      if (!pluginRequiresRestart.value) {
+        setTimeout(() => {
+          pluginInstallSuccess.value = "";
+        }, 5000);
+      }
+    } catch (error) {
+      pluginInstallError.value =
+        error.response?.data?.detail ||
+        error.message ||
+        "Failed to install plugin from local path";
+      setTimeout(() => {
+        pluginInstallError.value = "";
+      }, 10000);
+    } finally {
+      installingPlugin.value = false;
+    }
+  };
+
+  // Install multiple plugins from a local path (dev mode only)
+  const installPluginsFromLocal = async (plugins, localPath) => {
+    installingPlugin.value = true;
+    pluginInstallError.value = "";
+    pluginInstallSuccess.value = "";
+    pluginRequiresRestart.value = false;
+
+    const results = { success: [], failed: [], requiresRestart: false };
+
+    try {
+      for (const plugin of plugins) {
+        try {
+          const response = await pluginsApi.installPluginFromLocal(
+            localPath,
+            plugin.path,
+            false,
+          );
+          results.success.push({
+            id: plugin.id,
+            name: plugin.name || plugin.id,
+            response,
+          });
+          if (response.requires_restart) results.requiresRestart = true;
+          if (response.frontend_rebuild_in_progress) {
+            _startRebuildPolling();
+          }
+        } catch (error) {
+          results.failed.push({
+            id: plugin.id,
+            name: plugin.name || plugin.id,
+            error:
+              error.response?.data?.detail || error.message || "Unknown error",
+          });
+        }
+      }
+
+      if (results.success.length > 0 && results.failed.length === 0) {
+        pluginInstallSuccess.value = `Successfully installed ${results.success.length} plugin(s): ${results.success.map((s) => s.name).join(", ")}`;
+        pluginRequiresRestart.value = results.requiresRestart;
+      } else if (results.success.length > 0) {
+        pluginInstallSuccess.value = `Successfully installed ${results.success.length} plugin(s): ${results.success.map((s) => s.name).join(", ")}`;
+        pluginInstallError.value = `Failed to install ${results.failed.length} plugin(s): ${results.failed.map((f) => f.name).join(", ")}`;
+        pluginRequiresRestart.value = results.requiresRestart;
+      } else {
+        pluginInstallError.value = `Failed to install ${results.failed.length} plugin(s): ${results.failed.map((f) => `${f.name}: ${f.error}`).join("; ")}`;
+      }
+
+      // Mark installed plugins in-place so the list stays visible
+      for (const s of results.success) {
+        const idx = availablePlugins.value.findIndex(
+          (p) => p.id === s.id || p.path === s.response?.manifest?.id,
+        );
+        if (idx !== -1) {
+          availablePlugins.value[idx] = {
+            ...availablePlugins.value[idx],
+            _installed: true,
+            _installedVersion:
+              s.response?.manifest?.version ||
+              availablePlugins.value[idx].version,
+          };
+        }
+      }
+
+      if (results.success.length > 0) await loadPlugins();
+
+      if (!pluginRequiresRestart.value) {
+        setTimeout(() => {
+          pluginInstallSuccess.value = "";
+          pluginInstallError.value = "";
+        }, 10000);
+      }
+    } catch (error) {
+      pluginInstallError.value =
+        error.response?.data?.detail ||
+        error.message ||
+        "Failed to install plugins from local path";
       setTimeout(() => {
         pluginInstallError.value = "";
       }, 10000);
@@ -668,6 +921,9 @@ export function usePlugins() {
     enumeratePluginsFromGitHub,
     installPluginFromGitHub,
     installPluginsFromGitHub,
+    enumeratePluginsFromLocal,
+    installPluginFromLocal,
+    installPluginsFromLocal,
     uninstallPlugin,
     togglePlugin,
     updatePluginOrder,

--- a/frontend/src/composables/usePlugins.js
+++ b/frontend/src/composables/usePlugins.js
@@ -95,22 +95,6 @@ function _startRebuildPolling() {
   _rebuildPollTimer = setTimeout(poll, 1000);
 }
 
-function _normalizePluginConfig(config = {}) {
-  const cleanedConfig = {};
-
-  for (const [key, value] of Object.entries(config)) {
-    if (value === null || value === undefined) {
-      cleanedConfig[key] = "";
-    } else if (typeof value === "object") {
-      cleanedConfig[key] = value.value || value.default || "";
-    } else {
-      cleanedConfig[key] = value;
-    }
-  }
-
-  return cleanedConfig;
-}
-
 export function usePlugins() {
   // Load plugins
   const loadPlugins = async () => {
@@ -158,14 +142,14 @@ export function usePlugins() {
             pluginsApi
               .getPluginInstances(plugin.id)
               .catch(() => ({ instances: [] })),
-            pluginsApi.getPluginConfig(plugin.id).catch(() => ({ config: {} })),
+            pluginsApi.getPluginConfig(plugin.id).catch(() => ({})),
           ]);
 
           pluginInstances.value[plugin.id] = instancesResponse.instances || [];
-          pluginConfigs.value[plugin.id] = configResponse.config || {};
+          pluginConfigs.value[plugin.id] = configResponse || {};
 
           // Load display orders from config (fallback to config API if not in schema)
-          const config = configResponse.config || {};
+          const config = configResponse || {};
           // Use config API value only if schema doesn't have it
           if (displayOrder === undefined || displayOrder === null) {
             displayOrder = config.display_order;
@@ -740,8 +724,7 @@ export function usePlugins() {
 
   const loadPluginConfig = async (pluginId) => {
     try {
-      const response = await pluginsApi.getPluginConfig(pluginId);
-      const config = response.config || {};
+      const config = await pluginsApi.getPluginConfig(pluginId);
       pluginConfigs.value[pluginId] = config;
       pluginFormData.value[pluginId] = { ...config };
       return config;
@@ -768,10 +751,10 @@ export function usePlugins() {
 
     try {
       const config = pluginFormData.value[pluginId] || {};
-      const cleanedConfig = _normalizePluginConfig(config);
-      await pluginsApi.updatePlugin(pluginId, cleanedConfig);
-      pluginConfigs.value[pluginId] = { ...cleanedConfig };
-      pluginFormData.value[pluginId] = { ...cleanedConfig };
+      await pluginsApi.updatePlugin(pluginId, config);
+      const normalizedConfig = await loadPluginConfig(pluginId);
+      pluginConfigs.value[pluginId] = { ...normalizedConfig };
+      pluginFormData.value[pluginId] = { ...normalizedConfig };
       pluginSaveStatus.value[pluginId] = {
         success: true,
         message: "Configuration saved successfully",
@@ -803,9 +786,7 @@ export function usePlugins() {
     pluginTestStatus.value[pluginId] = null;
 
     try {
-      const testConfig = _normalizePluginConfig(
-        pluginFormData.value[pluginId] || {},
-      );
+      const testConfig = pluginFormData.value[pluginId] || {};
       const response = await pluginsApi.testPlugin(pluginId, testConfig);
       pluginTestStatus.value[pluginId] = {
         success: response.success || false,
@@ -978,10 +959,11 @@ export function usePlugins() {
   // Update instance order for a plugin
   const updateInstanceOrder = async (pluginId, newOrder) => {
     try {
-      // newOrder is an array of instance objects from draggable
-      // Extract instance IDs in the new order
-      const instanceIds = newOrder.map((instance) => instance.id);
-      await pluginsApi.updatePluginInstancesOrder(pluginId, instanceIds);
+      const instanceOrders = {};
+      newOrder.forEach((instance, index) => {
+        instanceOrders[instance.id] = index;
+      });
+      await pluginsApi.updatePluginInstanceOrder(pluginId, instanceOrders);
       // Reload instances to get updated order
       const instancesResponse = await pluginsApi.getPluginInstances(pluginId);
       pluginInstances.value[pluginId] = instancesResponse.instances || [];
@@ -998,10 +980,11 @@ export function usePlugins() {
   // Update image instance order for a plugin
   const updateImageInstanceOrder = async (pluginId, newOrder) => {
     try {
-      // newOrder is an array of instance objects from draggable
-      // Extract instance IDs in the new order
-      const instanceIds = newOrder.map((instance) => instance.id);
-      await pluginsApi.updatePluginInstancesOrder(pluginId, instanceIds);
+      const instanceOrders = {};
+      newOrder.forEach((instance, index) => {
+        instanceOrders[instance.id] = index;
+      });
+      await pluginsApi.updatePluginInstanceOrder(pluginId, instanceOrders);
       // Reload instances to get updated order
       const instancesResponse = await pluginsApi.getPluginInstances(pluginId);
       pluginInstances.value[pluginId] = instancesResponse.instances || [];

--- a/frontend/src/composables/usePlugins.js
+++ b/frontend/src/composables/usePlugins.js
@@ -25,7 +25,7 @@ const pluginInstallSuccess = ref("");
 const pluginRequiresRestart = ref(false);
 const pluginBranchSwitched = ref(false);
 const pluginActualBranch = ref("");
-const pluginFrontendRebuildTriggered = ref(false);
+const pluginFrontendRebuildResult = ref(null); // null | { success: bool, message: str }
 const expandedPlugins = ref({});
 const pluginFormData = ref({});
 const savingPlugin = ref(null);
@@ -169,8 +169,14 @@ export function usePlugins() {
       const response = await pluginsApi.installPluginFromZip(file);
       pluginInstallSuccess.value = "Plugin installed successfully!";
       pluginRequiresRestart.value = response.requires_restart || false;
-      if (response.frontend_rebuild_triggered) {
-        pluginFrontendRebuildTriggered.value = true;
+      if (
+        response.frontend_rebuild_success !== null &&
+        response.frontend_rebuild_success !== undefined
+      ) {
+        pluginFrontendRebuildResult.value = {
+          success: response.frontend_rebuild_success,
+          message: response.frontend_rebuild_message,
+        };
       }
 
       if (!pluginRequiresRestart.value) {
@@ -306,8 +312,14 @@ export function usePlugins() {
       pluginRequiresRestart.value = response.requires_restart || false;
       pluginBranchSwitched.value = response.branch_switched || false;
       pluginActualBranch.value = response.branch || branch;
-      if (response.frontend_rebuild_triggered) {
-        pluginFrontendRebuildTriggered.value = true;
+      if (
+        response.frontend_rebuild_success !== null &&
+        response.frontend_rebuild_success !== undefined
+      ) {
+        pluginFrontendRebuildResult.value = {
+          success: response.frontend_rebuild_success,
+          message: response.frontend_rebuild_message,
+        };
       }
 
       availablePlugins.value = [];
@@ -377,8 +389,14 @@ export function usePlugins() {
             pluginBranchSwitched.value = true;
             pluginActualBranch.value = response.branch || branch;
           }
-          if (response.frontend_rebuild_triggered) {
-            pluginFrontendRebuildTriggered.value = true;
+          if (
+            response.frontend_rebuild_success !== null &&
+            response.frontend_rebuild_success !== undefined
+          ) {
+            pluginFrontendRebuildResult.value = {
+              success: response.frontend_rebuild_success,
+              message: response.frontend_rebuild_message,
+            };
           }
         } catch (error) {
           results.failed.push({
@@ -632,7 +650,7 @@ export function usePlugins() {
     pluginRequiresRestart,
     pluginBranchSwitched,
     pluginActualBranch,
-    pluginFrontendRebuildTriggered,
+    pluginFrontendRebuildResult,
     expandedPlugins,
     pluginFormData,
     savingPlugin,

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -5,7 +5,7 @@ import App from "./App.vue";
 import router from "./router";
 import "./styles/main.css";
 import "./styles/theme.css";
-import { initLogger } from "./utils/logger";
+import { initLogger, logError, logInfo } from "./utils/logger";
 import { useConfigStore } from "./stores/config";
 
 const app = createApp(App);
@@ -39,10 +39,10 @@ if ("serviceWorker" in navigator && import.meta.env.PROD) {
     navigator.serviceWorker
       .register("/sw.js")
       .then((registration) => {
-        console.log("Service Worker registered:", registration);
+        logInfo("[main]", "Service Worker registered:", registration);
       })
       .catch((error) => {
-        console.error("Service Worker registration failed:", error);
+        logError("[main]", "Service Worker registration failed:", error);
       });
   });
 }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { useConnectionStore } from "../stores/connection";
+import { logError } from "../utils/logger";
 
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL || "/api",
@@ -53,10 +54,10 @@ api.interceptors.response.use(
       // HTTP error response
       if (error.response?.status === 401) {
         // Handle unauthorized
-        console.error("Unauthorized");
+        logError("[api]", "Unauthorized");
       } else if (error.response?.status >= 500) {
         // Handle server errors
-        console.error("Server error:", error.response.data);
+        logError("[api]", "Server error:", error.response.data);
         // Server error might indicate backend issues
         connectionStore.isBackendOnline = false;
       }

--- a/frontend/src/services/pluginsApi.js
+++ b/frontend/src/services/pluginsApi.js
@@ -41,15 +41,7 @@ export async function getPluginInstances(pluginId) {
  */
 export async function getPluginConfig(pluginId) {
   const response = await api.get(`/plugins/${pluginId}/config`);
-  return response.data;
-}
-
-/**
- * Update plugin configuration.
- */
-export async function updatePluginConfig(pluginId, config) {
-  const response = await api.put(`/plugins/${pluginId}`, config);
-  return response.data;
+  return response.data || {};
 }
 
 /**
@@ -61,6 +53,24 @@ export async function updatePluginInstanceOrder(pluginId, orders) {
     orders,
   );
   return response.data;
+}
+
+/**
+ * Backward-compatible alias for callers using the older plural name.
+ * Accepts either an order map or an ordered array of instance ids.
+ */
+export async function updatePluginInstancesOrder(pluginId, ordersOrIds) {
+  const orders = Array.isArray(ordersOrIds)
+    ? Object.fromEntries(ordersOrIds.map((id, index) => [id, index]))
+    : ordersOrIds;
+  return updatePluginInstanceOrder(pluginId, orders);
+}
+
+/**
+ * Backward-compatible alias for callers using the older config-specific name.
+ */
+export async function updatePluginConfig(pluginId, config) {
+  return updatePlugin(pluginId, config);
 }
 
 /**
@@ -256,15 +266,5 @@ export async function updatePluginInstance(instanceId, instanceData) {
  */
 export async function deletePluginInstance(instanceId) {
   const response = await api.delete(`/plugins/instances/${instanceId}`);
-  return response.data;
-}
-
-/**
- * Update plugin instances order (takes array of instance IDs in order).
- */
-export async function updatePluginInstancesOrder(pluginId, instanceIds) {
-  const response = await api.put(`/plugins/${pluginId}/instances/order`, {
-    instance_ids: instanceIds,
-  });
   return response.data;
 }

--- a/frontend/src/services/pluginsApi.js
+++ b/frontend/src/services/pluginsApi.js
@@ -171,14 +171,6 @@ export async function geocodeLocation(pluginId, location) {
 }
 
 /**
- * Get the status of a background frontend rebuild triggered by plugin install.
- */
-export async function getFrontendBuildStatus() {
-  const response = await api.get("/plugins/frontend-build-status");
-  return response.data;
-}
-
-/**
  * Update plugin (general update).
  */
 export async function updatePlugin(pluginId, data) {

--- a/frontend/src/services/pluginsApi.js
+++ b/frontend/src/services/pluginsApi.js
@@ -136,6 +136,48 @@ export async function installPluginFromGitHub(
 }
 
 /**
+ * Get the current state of a background frontend rebuild.
+ */
+export async function getRebuildStatus() {
+  const response = await api.get("/plugins/rebuild-status");
+  return response.data;
+}
+
+/**
+ * Suggest local plugin repo paths by scanning sibling directories (dev mode only).
+ */
+export async function suggestLocalPath() {
+  const response = await api.get("/plugins/local/suggest");
+  return response.data;
+}
+
+/**
+ * Enumerate plugins from a local directory (dev mode only).
+ */
+export async function enumeratePluginsFromLocal(localPath) {
+  const response = await api.post("/plugins/local/enumerate", {
+    local_path: localPath,
+  });
+  return response.data;
+}
+
+/**
+ * Install plugin from a local directory (dev mode only).
+ */
+export async function installPluginFromLocal(
+  localPath,
+  pluginPath,
+  force = false,
+) {
+  const response = await api.post("/plugins/local/install", {
+    local_path: localPath,
+    plugin_path: pluginPath,
+    force,
+  });
+  return response.data;
+}
+
+/**
  * Uninstall a plugin.
  */
 export async function uninstallPlugin(pluginId, pluginType = null) {

--- a/frontend/src/stores/config.js
+++ b/frontend/src/stores/config.js
@@ -75,6 +75,7 @@ export const useConfigStore = defineStore("config", () => {
   const consoleLogEnabled = ref(true); // Enable console logging (default: true for backwards compatibility)
   const consoleLogLevel = ref("info"); // Console log level: 'error' | 'warn' | 'info' | 'debug' (default: 'info')
   const configPollInterval = ref(30); // Config polling interval in seconds (default: 30)
+  const devMode = ref(false); // Whether the backend is running in dev mode (backend/.dev marker file)
   const loading = ref(false);
   const error = ref(null);
 
@@ -460,6 +461,9 @@ export const useConfigStore = defineStore("config", () => {
         configPollInterval.value = response.data.config_poll_interval;
       } else {
         configPollInterval.value = 30; // Default to 30 seconds
+      }
+      if (response.data.devMode !== undefined) {
+        devMode.value = response.data.devMode;
       }
       return response.data;
     } catch (err) {
@@ -848,6 +852,7 @@ export const useConfigStore = defineStore("config", () => {
     consoleLogEnabled,
     consoleLogLevel,
     configPollInterval,
+    devMode,
     loading,
     error,
     calendarWidth,

--- a/frontend/src/stores/webServices.js
+++ b/frontend/src/stores/webServices.js
@@ -75,15 +75,18 @@ export const useWebServicesStore = defineStore("webServices", () => {
                 ...instance,
                 plugin_id: plugin.id,
                 plugin_name: plugin.name,
-                // Use plugin's display_schema (from get_plugin_metadata)
                 display_schema: displaySchema,
-                // Ensure type_id is set for component loading
+                statusbar_schema: pluginDetails.statusbar_schema || null,
                 type_id: plugin.id,
               });
             });
           } catch (err) {
             // Plugin might not have instances endpoint, skip
-            logWarn("[WebServicesStore]", `Failed to get instances for ${plugin.id}:`, err);
+            logWarn(
+              "[WebServicesStore]",
+              `Failed to get instances for ${plugin.id}:`,
+              err,
+            );
           }
         }
       }
@@ -101,9 +104,9 @@ export const useWebServicesStore = defineStore("webServices", () => {
           fullscreen: instance.config?.fullscreen || false,
           plugin_id: instance.plugin_id,
           plugin_name: instance.plugin_name,
-          // Preserve any display_schema if present
           display_schema:
             instance.display_schema || instance.config?.display_schema,
+          statusbar_schema: instance.statusbar_schema || null,
         })),
       };
 

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -16,7 +16,10 @@
               class="menu-item"
               title="Restart the backend server"
               :disabled="!!updateMessage"
-              @click="showSystemMenu = false; restartBackend()"
+              @click="
+                showSystemMenu = false;
+                restartBackend();
+              "
             >
               🔄 Restart Backend
             </button>
@@ -24,7 +27,10 @@
               class="menu-item"
               title="Restart the frontend server"
               :disabled="!!updateMessage"
-              @click="showSystemMenu = false; restartFrontend()"
+              @click="
+                showSystemMenu = false;
+                restartFrontend();
+              "
             >
               🔄 Restart Frontend
             </button>
@@ -101,7 +107,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, onUnmounted } from "vue";
+import { ref, watch, onMounted, onUnmounted } from "vue";
 import { useRouter } from "vue-router";
 import { useConfigForm } from "@/composables";
 import { useSystem } from "@/composables";
@@ -133,7 +139,9 @@ const categories = [
   { id: "system", label: "System", icon: "⚙️" },
 ];
 
-const activeCategory = ref("layout");
+const _CATEGORY_KEY = "settings_active_category";
+const activeCategory = ref(sessionStorage.getItem(_CATEGORY_KEY) || "layout");
+watch(activeCategory, (val) => sessionStorage.setItem(_CATEGORY_KEY, val));
 const showSystemMenu = ref(false);
 
 // Config management

--- a/frontend/tests/unit/components/PluginInstanceToggle.spec.js
+++ b/frontend/tests/unit/components/PluginInstanceToggle.spec.js
@@ -56,7 +56,7 @@ describe("PluginInstanceToggle", () => {
           enabled: false,
         },
       });
-      pluginsApi.getPluginConfig.mockResolvedValue({ config: {} });
+      pluginsApi.getPluginConfig.mockResolvedValue({});
 
       const wrapper = mount(PluginsCategory, {
         global: {
@@ -113,7 +113,7 @@ describe("PluginInstanceToggle", () => {
       pluginsApi.updatePluginInstance.mockRejectedValue(
         new Error("Failed to toggle instance"),
       );
-      pluginsApi.getPluginConfig.mockResolvedValue({ config: {} });
+      pluginsApi.getPluginConfig.mockResolvedValue({});
 
       const consoleErrorSpy = vi
         .spyOn(console, "error")
@@ -188,7 +188,7 @@ describe("PluginInstanceToggle", () => {
           enabled: false,
         },
       });
-      pluginsApi.getPluginConfig.mockResolvedValue({ config: {} });
+      pluginsApi.getPluginConfig.mockResolvedValue({});
 
       const wrapper = mount(PluginsCategory, {
         global: {
@@ -245,7 +245,7 @@ describe("PluginInstanceToggle", () => {
           running: false,
         },
       });
-      pluginsApi.getPluginConfig.mockResolvedValue({ config: {} });
+      pluginsApi.getPluginConfig.mockResolvedValue({});
 
       const wrapper = mount(PluginsCategory, {
         global: {

--- a/frontend/tests/unit/composables/usePlugins-order-persistence.spec.js
+++ b/frontend/tests/unit/composables/usePlugins-order-persistence.spec.js
@@ -14,6 +14,7 @@ vi.mock("@/services/pluginsApi", () => ({
   getPluginInstances: vi.fn(),
   getPluginConfig: vi.fn(),
   updatePlugin: vi.fn(),
+  updatePluginInstanceOrder: vi.fn(),
   updatePluginInstancesOrder: vi.fn(),
 }));
 
@@ -50,7 +51,7 @@ describe("usePlugins - Order Persistence", () => {
       pluginsApi.getPlugins.mockResolvedValue(mockPlugins);
       pluginsApi.getInstalledPlugins.mockResolvedValue({ plugins: [] });
       pluginsApi.getPluginInstances.mockResolvedValue({ instances: [] });
-      pluginsApi.getPluginConfig.mockResolvedValue({ config: {} });
+      pluginsApi.getPluginConfig.mockResolvedValue({});
 
       const { imagePluginDisplayOrders, loadPlugins } = usePlugins();
       await loadPlugins();
@@ -76,9 +77,7 @@ describe("usePlugins - Order Persistence", () => {
       pluginsApi.getPlugins.mockResolvedValue(mockPlugins);
       pluginsApi.getInstalledPlugins.mockResolvedValue({ plugins: [] });
       pluginsApi.getPluginInstances.mockResolvedValue({ instances: [] });
-      pluginsApi.getPluginConfig.mockResolvedValue({
-        config: { display_order: "5" },
-      });
+      pluginsApi.getPluginConfig.mockResolvedValue({ display_order: "5" });
 
       const { imagePluginDisplayOrders, loadPlugins } = usePlugins();
       await loadPlugins();
@@ -105,9 +104,7 @@ describe("usePlugins - Order Persistence", () => {
       pluginsApi.getPlugins.mockResolvedValue(mockPlugins);
       pluginsApi.getInstalledPlugins.mockResolvedValue({ plugins: [] });
       pluginsApi.getPluginInstances.mockResolvedValue({ instances: [] });
-      pluginsApi.getPluginConfig.mockResolvedValue({
-        config: { display_order: "5" }, // Config has 5
-      });
+      pluginsApi.getPluginConfig.mockResolvedValue({ display_order: "5" }); // Config has 5
 
       const { imagePluginDisplayOrders, loadPlugins } = usePlugins();
       await loadPlugins();
@@ -134,7 +131,7 @@ describe("usePlugins - Order Persistence", () => {
       pluginsApi.getPlugins.mockResolvedValue(mockPlugins);
       pluginsApi.getInstalledPlugins.mockResolvedValue({ plugins: [] });
       pluginsApi.getPluginInstances.mockResolvedValue({ instances: [] });
-      pluginsApi.getPluginConfig.mockResolvedValue({ config: {} });
+      pluginsApi.getPluginConfig.mockResolvedValue({});
 
       const { imagePluginDisplayOrders, loadPlugins } = usePlugins();
       await loadPlugins();
@@ -158,7 +155,7 @@ describe("usePlugins - Order Persistence", () => {
       pluginsApi.getPlugins.mockResolvedValue(mockPlugins);
       pluginsApi.getInstalledPlugins.mockResolvedValue({ plugins: [] });
       pluginsApi.getPluginInstances.mockResolvedValue({ instances: [] });
-      pluginsApi.getPluginConfig.mockResolvedValue({ config: {} }); // No display_order
+      pluginsApi.getPluginConfig.mockResolvedValue({}); // No display_order
 
       const { imagePluginDisplayOrders, loadPlugins } = usePlugins();
       await loadPlugins();
@@ -186,7 +183,7 @@ describe("usePlugins - Order Persistence", () => {
       pluginsApi.getPlugins.mockResolvedValue(mockPlugins);
       pluginsApi.getInstalledPlugins.mockResolvedValue({ plugins: [] });
       pluginsApi.getPluginInstances.mockResolvedValue({ instances: [] });
-      pluginsApi.getPluginConfig.mockResolvedValue({ config: {} });
+      pluginsApi.getPluginConfig.mockResolvedValue({});
 
       const { pluginDisplayOrders, loadPlugins } = usePlugins();
       await loadPlugins();
@@ -214,7 +211,7 @@ describe("usePlugins - Order Persistence", () => {
       pluginsApi.getPlugins.mockResolvedValue(mockPlugins);
       pluginsApi.getInstalledPlugins.mockResolvedValue({ plugins: [] });
       pluginsApi.getPluginInstances.mockResolvedValue({ instances: [] });
-      pluginsApi.getPluginConfig.mockResolvedValue({ config: {} });
+      pluginsApi.getPluginConfig.mockResolvedValue({});
       pluginsApi.updatePlugin.mockResolvedValue({ success: true });
 
       const { imagePluginDisplayOrders, loadPlugins, updateImagePluginOrder } =
@@ -264,7 +261,7 @@ describe("usePlugins - Order Persistence", () => {
       pluginsApi.getPlugins.mockResolvedValue(mockPlugins);
       pluginsApi.getInstalledPlugins.mockResolvedValue({ plugins: [] });
       pluginsApi.getPluginInstances.mockResolvedValue({ instances: [] });
-      pluginsApi.getPluginConfig.mockResolvedValue({ config: {} });
+      pluginsApi.getPluginConfig.mockResolvedValue({});
 
       const { imagePluginDisplayOrders, loadPlugins } = usePlugins();
       await loadPlugins();
@@ -298,7 +295,7 @@ describe("usePlugins - Order Persistence", () => {
       pluginsApi.getPlugins.mockResolvedValue(mockPlugins1);
       pluginsApi.getInstalledPlugins.mockResolvedValue({ plugins: [] });
       pluginsApi.getPluginInstances.mockResolvedValue({ instances: [] });
-      pluginsApi.getPluginConfig.mockResolvedValue({ config: {} });
+      pluginsApi.getPluginConfig.mockResolvedValue({});
 
       const { imagePluginDisplayOrders, loadPlugins } = usePlugins();
       await loadPlugins();
@@ -321,7 +318,7 @@ describe("usePlugins - Order Persistence", () => {
       };
 
       pluginsApi.getPlugins.mockResolvedValue(mockPlugins2);
-      pluginsApi.getPluginConfig.mockResolvedValue({ config: {} });
+      pluginsApi.getPluginConfig.mockResolvedValue({});
 
       await loadPlugins();
 

--- a/frontend/tests/unit/composables/usePlugins.spec.js
+++ b/frontend/tests/unit/composables/usePlugins.spec.js
@@ -23,7 +23,14 @@ vi.mock("@/services/pluginsApi", () => ({
   getInstalledPlugins: vi.fn(),
   getPluginInstances: vi.fn(),
   getPluginConfig: vi.fn(),
+  updatePlugin: vi.fn(),
+  updatePluginConfig: vi.fn(),
+  startPluginInstance: vi.fn(),
+  stopPluginInstance: vi.fn(),
+  updatePluginInstanceOrder: vi.fn(),
   updatePluginInstance: vi.fn(),
+  testPlugin: vi.fn(),
+  fetchPlugin: vi.fn(),
 }));
 
 describe("usePlugins", () => {
@@ -55,7 +62,7 @@ describe("usePlugins", () => {
       pluginsApi.getPlugins.mockResolvedValue(mockPlugins);
       pluginsApi.getInstalledPlugins.mockResolvedValue({ plugins: [] });
       pluginsApi.getPluginInstances.mockResolvedValue({ instances: [] });
-      pluginsApi.getPluginConfig.mockResolvedValue({ config: {} });
+      pluginsApi.getPluginConfig.mockResolvedValue({});
 
       const { sortedPluginCategories, loadPlugins } = usePlugins();
       await loadPlugins();
@@ -97,7 +104,7 @@ describe("usePlugins", () => {
       pluginsApi.getPlugins.mockResolvedValue(mockPlugins);
       pluginsApi.getInstalledPlugins.mockResolvedValue({ plugins: [] });
       pluginsApi.getPluginInstances.mockResolvedValue({ instances: [] });
-      pluginsApi.getPluginConfig.mockResolvedValue({ config: {} });
+      pluginsApi.getPluginConfig.mockResolvedValue({});
 
       const { sortedPluginCategories, loadPlugins } = usePlugins();
       await loadPlugins();
@@ -133,7 +140,7 @@ describe("usePlugins", () => {
       pluginsApi.getPlugins.mockResolvedValue(mockPlugins);
       pluginsApi.getInstalledPlugins.mockResolvedValue({ plugins: [] });
       pluginsApi.getPluginInstances.mockResolvedValue({ instances: [] });
-      pluginsApi.getPluginConfig.mockResolvedValue({ config: {} });
+      pluginsApi.getPluginConfig.mockResolvedValue({});
 
       const { plugins, loadPlugins } = usePlugins();
       await loadPlugins();
@@ -157,7 +164,7 @@ describe("usePlugins", () => {
       pluginsApi.getPlugins.mockResolvedValue(mockPlugins);
       pluginsApi.getInstalledPlugins.mockResolvedValue({ plugins: [] });
       pluginsApi.getPluginInstances.mockResolvedValue({ instances: [] });
-      pluginsApi.getPluginConfig.mockResolvedValue({ config: {} });
+      pluginsApi.getPluginConfig.mockResolvedValue({});
 
       const { sortedPluginCategories, loadPlugins } = usePlugins();
       await loadPlugins();
@@ -178,7 +185,7 @@ describe("usePlugins", () => {
       });
       pluginsApi.getInstalledPlugins.mockResolvedValue({ plugins: [] });
       pluginsApi.getPluginInstances.mockResolvedValue({ instances: [] });
-      pluginsApi.getPluginConfig.mockResolvedValue({ config: {} });
+      pluginsApi.getPluginConfig.mockResolvedValue({});
       pluginsApi.updatePluginInstance.mockResolvedValue({
         success: true,
         instance: { id: "imap-1", enabled: false },
@@ -201,7 +208,7 @@ describe("usePlugins", () => {
       });
       pluginsApi.getInstalledPlugins.mockResolvedValue({ plugins: [] });
       pluginsApi.getPluginInstances.mockResolvedValue({ instances: [] });
-      pluginsApi.getPluginConfig.mockResolvedValue({ config: {} });
+      pluginsApi.getPluginConfig.mockResolvedValue({});
       pluginsApi.updatePluginInstance.mockRejectedValue(
         new Error("Update failed"),
       );
@@ -238,7 +245,7 @@ describe("usePlugins", () => {
       pluginsApi.getPlugins.mockResolvedValue(mockPlugins);
       pluginsApi.getInstalledPlugins.mockResolvedValue({ plugins: [] });
       pluginsApi.getPluginInstances.mockResolvedValue({ instances: [] });
-      pluginsApi.getPluginConfig.mockResolvedValue({ config: {} });
+      pluginsApi.getPluginConfig.mockResolvedValue({});
 
       const { plugins, loadPlugins } = usePlugins();
       await loadPlugins();
@@ -267,7 +274,7 @@ describe("usePlugins", () => {
       pluginsApi.getPlugins.mockResolvedValue(mockPlugins);
       pluginsApi.getInstalledPlugins.mockResolvedValue(mockInstalled);
       pluginsApi.getPluginInstances.mockResolvedValue({ instances: [] });
-      pluginsApi.getPluginConfig.mockResolvedValue({ config: {} });
+      pluginsApi.getPluginConfig.mockResolvedValue({});
 
       const { plugins, loadPlugins } = usePlugins();
       await loadPlugins();


### PR DESCRIPTION
## Summary

This PR starts consolidating the plugin contract around typed definitions plus explicit class/instance methods, while keeping Pluggy for discovery and legacy compatibility.

## What changed

- Added typed `PluginDefinition` normalization at the loader boundary.
- Kept compatibility with existing dict-style plugin metadata during the transition.
- Added explicit plugin type config and instance creation endpoints:
  - `PUT /api/plugins/{plugin_id}/config`
  - `POST /api/plugins/{plugin_id}/instances`
- Kept the legacy `PUT /api/plugins/{plugin_id}` path working.
- Changed service data fetch to call the resolved `ServicePlugin` instance directly.
- Added class-based type actions on `BasePlugin`:
  - `test_type_config`
  - `scan_type_options`
  - `fetch_type_data`
- Updated `/test`, `/scan`, and `/fetch` to prefer class methods first, with hook fallback for compatibility.
- Marked the corresponding runtime hooks as legacy in docs/comments.

## Why

The current plugin system works, but the contract is fragmented across:
- Pluggy hook registration
- dict-shaped metadata
- plugin instance methods
- implicit route behavior

This PR moves the system toward a clearer split:
- Pluggy for discovery and registration
- typed plugin definitions internally
- class methods for type-level actions
- instance methods for runtime instance behavior

## Compatibility

This is intentionally incremental.

- Existing hook-based plugins still work.
- Existing dict metadata still works.
- Existing `PUT /api/plugins/{plugin_id}` still works.
- New code paths are additive and preferred, not mandatory yet.

## Validation

Ran:

- `uv run pytest tests/integration/test_api_plugins.py tests/integration/test_api_plugin_instances.py tests/unit/test_plugin_definitions.py tests/unit/test_plugin_loader.py tests/unit/test_plugin_registry.py tests/unit/test_plugin_hooks.py tests/unit/test_plugin_protocols.py`

Result:

- `76 passed, 4 skipped`

## Follow-up work

- Move plugin implementations off legacy runtime hooks onto class/instance methods.
- Continue separating type config lifecycle from instance lifecycle.
- Formalize the frontend-facing plugin schema contract.
- Add explicit protocol versioning once the new surface is more complete.