### PR TITLE
Add service plugin SDK helpers

### DIFF
--- a/backend/app/plugins/sdk/__init__.py
+++ b/backend/app/plugins/sdk/__init__.py
@@ -1,0 +1,1 @@
+"""Shared plugin SDK helpers."""

--- a/backend/app/plugins/sdk/service.py
+++ b/backend/app/plugins/sdk/service.py
@@ -1,0 +1,154 @@
+"""Helpers for building service plugins with less boilerplate."""
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from typing import Any
+
+from app.plugins.base import PluginType
+from app.plugins.utils.config import extract_config_value
+from app.plugins.utils.instance_manager import InstanceManagerConfig
+
+
+@dataclass(frozen=True)
+class ServiceConfigField:
+    """Declarative config field definition for service plugins."""
+
+    key: str
+    default: Any = None
+    converter: Callable[[Any], Any] | None = None
+    transform: Callable[[Any], Any] | None = None
+    arg_name: str | None = None
+
+    @property
+    def target_name(self) -> str:
+        """Constructor kwarg name for this field."""
+        return self.arg_name or self.key
+
+    def extract(self, config: dict[str, Any]) -> Any:
+        """Extract and normalize this field from config."""
+        value = extract_config_value(
+            config,
+            self.key,
+            default=self.default,
+            converter=self.converter,
+        )
+        if self.transform is not None:
+            return self.transform(value)
+        return value
+
+
+def build_service_plugin_metadata(
+    *,
+    type_id: str,
+    name: str,
+    description: str,
+    plugin_class: type[Any],
+    version: str = "1.0.0",
+    supports_multiple_instances: bool = True,
+    instance_label: str | None = None,
+    common_config_schema: dict[str, Any] | None = None,
+    instance_config_schema: dict[str, Any] | None = None,
+    display_schema: dict[str, Any] | None = None,
+    statusbar_schema: dict[str, Any] | None = None,
+    ui_actions: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build standard metadata for a service plugin."""
+    metadata = {
+        "type_id": type_id,
+        "plugin_type": PluginType.SERVICE,
+        "name": name,
+        "description": description,
+        "version": version,
+        "supports_multiple_instances": supports_multiple_instances,
+        "common_config_schema": common_config_schema or {},
+        "instance_config_schema": instance_config_schema or {},
+        "plugin_class": plugin_class,
+    }
+    if instance_label is not None:
+        metadata["instance_label"] = instance_label
+    if display_schema is not None:
+        metadata["display_schema"] = display_schema
+    if statusbar_schema is not None:
+        metadata["statusbar_schema"] = statusbar_schema
+    if ui_actions is not None:
+        metadata["ui_actions"] = ui_actions
+    return metadata
+
+
+def extract_service_config(
+    config: dict[str, Any],
+    fields: Iterable[ServiceConfigField],
+    *,
+    use_arg_names: bool = True,
+) -> dict[str, Any]:
+    """Extract a typed config mapping from raw plugin config."""
+    extracted: dict[str, Any] = {}
+    for field in fields:
+        key = field.target_name if use_arg_names else field.key
+        extracted[key] = field.extract(config)
+    return extracted
+
+
+def create_service_plugin_instance(
+    plugin_class: type[Any],
+    *,
+    expected_type_id: str,
+    plugin_id: str,
+    type_id: str,
+    name: str,
+    config: dict[str, Any],
+    fields: Iterable[ServiceConfigField] = (),
+    extra_kwargs: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+    enabled_default: bool = False,
+) -> Any | None:
+    """Create a service plugin instance from normalized config fields."""
+    if type_id != expected_type_id:
+        return None
+
+    kwargs = extract_service_config(config, fields)
+    if extra_kwargs is not None:
+        kwargs.update(extra_kwargs(config))
+
+    return plugin_class(
+        plugin_id=plugin_id,
+        name=name,
+        enabled=config.get("enabled", enabled_default),
+        **kwargs,
+    )
+
+
+def build_service_manager_config(
+    *,
+    type_id: str,
+    fields: Iterable[ServiceConfigField] = (),
+    single_instance: bool = False,
+    instance_id: str | None = None,
+    validate_config: Callable[[dict[str, Any]], bool] | None = None,
+    generate_instance_id: Callable[[dict[str, Any], str], str] | None = None,
+    extra_normalize: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+    prepare_instance_config: Callable[[dict[str, Any], dict[str, Any]], dict[str, Any]]
+    | None = None,
+    on_instance_created: Callable[[Any, dict[str, Any]], None] | None = None,
+    on_instance_updated: Callable[[Any, dict[str, Any]], None] | None = None,
+    default_instance_name: str | None = None,
+) -> InstanceManagerConfig:
+    """Build InstanceManagerConfig with shared service config normalization."""
+
+    def normalize_config(config: dict[str, Any]) -> dict[str, Any]:
+        normalized = extract_service_config(config, fields, use_arg_names=False)
+        if extra_normalize is not None:
+            normalized.update(extra_normalize(config))
+        return normalized
+
+    return InstanceManagerConfig(
+        type_id=type_id,
+        single_instance=single_instance,
+        instance_id=instance_id,
+        validate_config=validate_config,
+        generate_instance_id=generate_instance_id,
+        normalize_config=normalize_config,
+        prepare_instance_config=prepare_instance_config,
+        on_instance_created=on_instance_created,
+        on_instance_updated=on_instance_updated,
+        default_instance_name=default_instance_name,
+    )

--- a/backend/tests/unit/test_service_sdk.py
+++ b/backend/tests/unit/test_service_sdk.py
@@ -1,0 +1,119 @@
+from app.plugins.sdk.service import (
+    ServiceConfigField,
+    build_service_manager_config,
+    build_service_plugin_metadata,
+    create_service_plugin_instance,
+    extract_service_config,
+)
+
+
+class DummyServicePlugin:
+    def __init__(self, plugin_id: str, name: str, enabled: bool = True, **kwargs):
+        self.plugin_id = plugin_id
+        self.name = name
+        self.enabled = enabled
+        self.kwargs = kwargs
+
+
+def test_build_service_plugin_metadata():
+    metadata = build_service_plugin_metadata(
+        type_id="dummy_service",
+        name="Dummy Service",
+        description="Dummy",
+        plugin_class=DummyServicePlugin,
+        supports_multiple_instances=False,
+        instance_label="Source",
+        display_schema={"component": "dummy/Viewer.vue"},
+    )
+
+    assert metadata["type_id"] == "dummy_service"
+    assert metadata["plugin_type"].value == "service"
+    assert metadata["supports_multiple_instances"] is False
+    assert metadata["instance_label"] == "Source"
+    assert metadata["plugin_class"] is DummyServicePlugin
+
+
+def test_extract_service_config_uses_defaults_and_transforms():
+    fields = (
+        ServiceConfigField("token", default="", converter=str, transform=str.strip),
+        ServiceConfigField("count", default=1, converter=int),
+        ServiceConfigField("alias", default="", arg_name="label"),
+    )
+
+    values = extract_service_config(
+        {"token": "  abc  ", "count": "4", "alias": "Name"},
+        fields,
+    )
+
+    assert values == {
+        "token": "abc",
+        "count": 4,
+        "label": "Name",
+    }
+
+
+def test_create_service_plugin_instance_builds_kwargs():
+    fields = (
+        ServiceConfigField("token", default="", converter=str),
+        ServiceConfigField("count", default=1, converter=int),
+    )
+
+    plugin = create_service_plugin_instance(
+        DummyServicePlugin,
+        expected_type_id="dummy_service",
+        plugin_id="dummy-instance",
+        type_id="dummy_service",
+        name="Dummy",
+        config={"enabled": True, "token": "abc", "count": "2"},
+        fields=fields,
+        extra_kwargs=lambda config: {"source": config.get("source", "default")},
+    )
+
+    assert plugin is not None
+    assert plugin.plugin_id == "dummy-instance"
+    assert plugin.enabled is True
+    assert plugin.kwargs == {"token": "abc", "count": 2, "source": "default"}
+
+
+def test_create_service_plugin_instance_returns_none_for_other_type():
+    plugin = create_service_plugin_instance(
+        DummyServicePlugin,
+        expected_type_id="dummy_service",
+        plugin_id="dummy-instance",
+        type_id="other_service",
+        name="Dummy",
+        config={},
+    )
+
+    assert plugin is None
+
+
+def test_build_service_manager_config_normalizes_fields_and_extras():
+    fields = (
+        ServiceConfigField("token", default="", converter=str, transform=str.strip),
+        ServiceConfigField("count", default=1, converter=int),
+        ServiceConfigField("alias", default="", arg_name="label"),
+    )
+
+    manager_config = build_service_manager_config(
+        type_id="dummy_service",
+        fields=fields,
+        single_instance=True,
+        instance_id="dummy-instance",
+        extra_normalize=lambda config: {"enabled_flag": config.get("enabled", False)},
+        default_instance_name="Dummy Service",
+    )
+
+    normalized = manager_config.normalize_config(
+        {"token": "  abc  ", "count": "3", "alias": "Shown", "enabled": True}
+    )
+
+    assert manager_config.single_instance is True
+    assert manager_config.instance_id == "dummy-instance"
+    assert manager_config.default_instance_name == "Dummy Service"
+    assert normalized == {
+        "token": "abc",
+        "count": 3,
+        "alias": "Shown",
+        "enabled_flag": True,
+    }


### PR DESCRIPTION
## Summary

This PR adds a small runtime SDK for service plugins under `app.plugins.sdk.service`.

## What changed

- Added `ServiceConfigField` for declarative config extraction.
- Added `build_service_plugin_metadata()` for standard service metadata assembly.
- Added `extract_service_config()` for normalized typed config extraction.
- Added `create_service_plugin_instance()` to reduce service plugin factory boilerplate.
- Added `build_service_manager_config()` to wire common service config normalization into `InstanceManagerConfig`.
- Added direct unit coverage in `backend/tests/unit/test_service_sdk.py`.

## Why

External plugins can always import `app.*` because the loader puts the backend on `sys.path`, but they cannot reliably import helpers from the `calvin-plugins` repo root.

That means the shared SDK surface needs to live in `calvin`, not in `calvin-plugins`, if we want plugin authors to have a stable runtime import path.

## Validation

Ran:

- `uv run pytest tests\\unit\\test_service_sdk.py tests\\integration\\test_api_plugins.py tests\\unit\\test_plugin_hooks.py tests\\unit\\test_plugin_protocols.py`

Result:

- `50 passed, 2 skipped`

## Follow-up

This pairs with the `calvin-plugins` PR that migrates the current service plugin set and updates the authoring docs/templates to use this SDK.