### PR TITLE
Add image plugin fetch helper

### DIFF
--- a/backend/app/plugins/sdk/image.py
+++ b/backend/app/plugins/sdk/image.py
@@ -3,6 +3,8 @@
 import httpx
 from loguru import logger
 
+from app.plugins.protocols import ImagePlugin
+
 
 async def fetch_image_data(
     image_url: str | None,
@@ -24,3 +26,52 @@ async def fetch_image_data(
         except httpx.HTTPError as exc:
             logger.warning(f"[{plugin_name}] Error fetching image data: {exc}")
             return None
+
+
+class SelfHostedGalleryImagePlugin(ImagePlugin):
+    """Base class for image plugins backed by a self-hosted gallery API."""
+
+    sdk_plugin_name = "Gallery"
+    api_base_path = "/api"
+    auth_header_name = "Authorization"
+    auth_header_prefix = ""
+
+    def __init__(
+        self,
+        plugin_id: str,
+        name: str,
+        *,
+        url: str = "",
+        api_key: str = "",
+        enabled: bool = True,
+    ) -> None:
+        super().__init__(plugin_id, name, enabled)
+        self.base_url = url.rstrip("/")
+        self.api_key = api_key
+        self._images: list[dict[str, object]] = []
+        self._last_scan = None
+
+    @classmethod
+    def build_auth_headers(cls, api_key: str) -> dict[str, str]:
+        """Build standard API auth headers for a gallery request."""
+        return {
+            cls.auth_header_name: f"{cls.auth_header_prefix}{api_key}",
+            "Accept": "application/json",
+        }
+
+    def auth_headers(self) -> dict[str, str]:
+        """Build standard API auth headers for this gallery instance."""
+        return self.build_auth_headers(self.api_key)
+
+    def api_url(self, path: str) -> str:
+        """Build a full API URL from a relative path."""
+        return f"{self.base_url}{self.api_base_path}/{path.lstrip('/')}"
+
+    async def fetch_protected_image_data(self, url: str | None) -> bytes | None:
+        """Fetch protected image bytes using gallery auth headers."""
+        return await fetch_image_data(
+            url,
+            plugin_name=self.sdk_plugin_name,
+            headers=self.auth_headers(),
+            follow_redirects=True,
+        )

--- a/backend/app/plugins/sdk/image.py
+++ b/backend/app/plugins/sdk/image.py
@@ -1,9 +1,16 @@
 """Helpers for building image plugins with less boilerplate."""
 
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from typing import Any
+
 import httpx
 from loguru import logger
 
+from app.plugins.base import PluginType
 from app.plugins.protocols import ImagePlugin
+from app.plugins.utils.config import extract_config_value
+from app.plugins.utils.instance_manager import InstanceManagerConfig
 
 
 async def fetch_image_data(
@@ -26,6 +33,142 @@ async def fetch_image_data(
         except httpx.HTTPError as exc:
             logger.warning(f"[{plugin_name}] Error fetching image data: {exc}")
             return None
+
+
+@dataclass(frozen=True)
+class ImageConfigField:
+    """Declarative config field definition for image plugins."""
+
+    key: str
+    default: Any = None
+    converter: Callable[[Any], Any] | None = None
+    transform: Callable[[Any], Any] | None = None
+    arg_name: str | None = None
+
+    @property
+    def target_name(self) -> str:
+        """Constructor kwarg name for this field."""
+        return self.arg_name or self.key
+
+    def extract(self, config: dict[str, Any]) -> Any:
+        """Extract and normalize this field from config."""
+        value = extract_config_value(
+            config,
+            self.key,
+            default=self.default,
+            converter=self.converter,
+        )
+        if self.transform is not None:
+            return self.transform(value)
+        return value
+
+
+def build_image_plugin_metadata(
+    *,
+    type_id: str,
+    name: str,
+    description: str,
+    plugin_class: type[Any],
+    version: str = "1.0.0",
+    supports_multiple_instances: bool = True,
+    instance_label: str | None = None,
+    common_config_schema: dict[str, Any] | None = None,
+    instance_config_schema: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build standard metadata for an image plugin."""
+    metadata = {
+        "type_id": type_id,
+        "plugin_type": PluginType.IMAGE,
+        "name": name,
+        "description": description,
+        "version": version,
+        "supports_multiple_instances": supports_multiple_instances,
+        "common_config_schema": common_config_schema or {},
+        "instance_config_schema": instance_config_schema or {},
+        "plugin_class": plugin_class,
+    }
+    if instance_label is not None:
+        metadata["instance_label"] = instance_label
+    return metadata
+
+
+def extract_image_config(
+    config: dict[str, Any],
+    fields: Iterable[ImageConfigField],
+    *,
+    use_arg_names: bool = True,
+) -> dict[str, Any]:
+    """Extract a typed config mapping from raw image plugin config."""
+    extracted: dict[str, Any] = {}
+    for field in fields:
+        key = field.target_name if use_arg_names else field.key
+        extracted[key] = field.extract(config)
+    return extracted
+
+
+def create_image_plugin_instance(
+    plugin_class: type[Any],
+    *,
+    expected_type_id: str,
+    plugin_id: str,
+    type_id: str,
+    name: str,
+    config: dict[str, Any],
+    fields: Iterable[ImageConfigField] = (),
+    extra_kwargs: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+    enabled_default: bool = False,
+) -> Any | None:
+    """Create an image plugin instance from normalized config fields."""
+    if type_id != expected_type_id:
+        return None
+
+    kwargs = extract_image_config(config, fields)
+    if extra_kwargs is not None:
+        kwargs.update(extra_kwargs(config))
+
+    return plugin_class(
+        plugin_id=plugin_id,
+        name=name,
+        enabled=config.get("enabled", enabled_default),
+        **kwargs,
+    )
+
+
+def build_image_manager_config(
+    *,
+    type_id: str,
+    fields: Iterable[ImageConfigField] = (),
+    single_instance: bool = False,
+    instance_id: str | None = None,
+    validate_config: Callable[[dict[str, Any]], bool] | None = None,
+    generate_instance_id: Callable[[dict[str, Any], str], str] | None = None,
+    extra_normalize: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+    prepare_instance_config: Callable[[dict[str, Any], dict[str, Any]], dict[str, Any]]
+    | None = None,
+    on_instance_created: Callable[[Any, dict[str, Any]], None] | None = None,
+    on_instance_updated: Callable[[Any, dict[str, Any]], None] | None = None,
+    default_instance_name: str | None = None,
+) -> InstanceManagerConfig:
+    """Build InstanceManagerConfig with shared image config normalization."""
+
+    def normalize_config(config: dict[str, Any]) -> dict[str, Any]:
+        normalized = extract_image_config(config, fields, use_arg_names=False)
+        if extra_normalize is not None:
+            normalized.update(extra_normalize(config))
+        return normalized
+
+    return InstanceManagerConfig(
+        type_id=type_id,
+        single_instance=single_instance,
+        instance_id=instance_id,
+        validate_config=validate_config,
+        generate_instance_id=generate_instance_id,
+        normalize_config=normalize_config,
+        prepare_instance_config=prepare_instance_config,
+        on_instance_created=on_instance_created,
+        on_instance_updated=on_instance_updated,
+        default_instance_name=default_instance_name,
+    )
 
 
 class SelfHostedGalleryImagePlugin(ImagePlugin):

--- a/backend/app/plugins/sdk/image.py
+++ b/backend/app/plugins/sdk/image.py
@@ -1,0 +1,26 @@
+"""Helpers for building image plugins with less boilerplate."""
+
+import httpx
+from loguru import logger
+
+
+async def fetch_image_data(
+    image_url: str | None,
+    *,
+    plugin_name: str,
+    headers: dict[str, str] | None = None,
+    follow_redirects: bool = False,
+    timeout: float = 30.0,
+) -> bytes | None:
+    """Fetch image bytes from a URL and log failures consistently."""
+    if not image_url:
+        return None
+
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=follow_redirects) as client:
+        try:
+            response = await client.get(image_url, headers=headers)
+            response.raise_for_status()
+            return response.content
+        except httpx.HTTPError as exc:
+            logger.warning(f"[{plugin_name}] Error fetching image data: {exc}")
+            return None

--- a/backend/tests/unit/test_image_sdk.py
+++ b/backend/tests/unit/test_image_sdk.py
@@ -1,0 +1,64 @@
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from app.plugins.sdk.image import fetch_image_data
+
+
+@pytest.mark.asyncio
+async def test_fetch_image_data_returns_bytes():
+    with patch("app.plugins.sdk.image.httpx.AsyncClient") as mock_client:
+        mock_response = MagicMock()
+        mock_response.content = b"image-bytes"
+        mock_response.raise_for_status = MagicMock()
+        mock_client.return_value.__aenter__.return_value.get.return_value = mock_response
+
+        data = await fetch_image_data(
+            "https://example.com/image.jpg",
+            plugin_name="Example",
+        )
+
+        assert data == b"image-bytes"
+
+
+@pytest.mark.asyncio
+async def test_fetch_image_data_passes_headers_and_redirects():
+    with patch("app.plugins.sdk.image.httpx.AsyncClient") as mock_client:
+        mock_response = MagicMock()
+        mock_response.content = b"image-bytes"
+        mock_response.raise_for_status = MagicMock()
+        mock_client.return_value.__aenter__.return_value.get.return_value = mock_response
+
+        await fetch_image_data(
+            "https://example.com/image.jpg",
+            plugin_name="Example",
+            headers={"Authorization": "Bearer token"},
+            follow_redirects=True,
+        )
+
+        mock_client.assert_called_once_with(timeout=30.0, follow_redirects=True)
+        mock_client.return_value.__aenter__.return_value.get.assert_called_once_with(
+            "https://example.com/image.jpg",
+            headers={"Authorization": "Bearer token"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_fetch_image_data_returns_none_for_missing_url():
+    assert await fetch_image_data(None, plugin_name="Example") is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_image_data_returns_none_on_http_error():
+    with patch("app.plugins.sdk.image.httpx.AsyncClient") as mock_client:
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = httpx.HTTPError("boom")
+        mock_client.return_value.__aenter__.return_value.get.return_value = mock_response
+
+        data = await fetch_image_data(
+            "https://example.com/image.jpg",
+            plugin_name="Example",
+        )
+
+        assert data is None

--- a/backend/tests/unit/test_image_sdk.py
+++ b/backend/tests/unit/test_image_sdk.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from app.plugins.sdk.image import fetch_image_data
+from app.plugins.sdk.image import SelfHostedGalleryImagePlugin, fetch_image_data
 
 
 @pytest.mark.asyncio
@@ -62,3 +62,80 @@ async def test_fetch_image_data_returns_none_on_http_error():
         )
 
         assert data is None
+
+
+class DummyGalleryPlugin(SelfHostedGalleryImagePlugin):
+    sdk_plugin_name = "Dummy Gallery"
+    api_base_path = "/api/v2"
+    auth_header_name = "x-api-key"
+
+    @classmethod
+    def get_plugin_metadata(cls) -> dict[str, object]:
+        return {}
+
+    async def initialize(self) -> None:
+        pass
+
+    async def cleanup(self) -> None:
+        pass
+
+    async def get_images(self) -> list[dict[str, object]]:
+        return []
+
+    async def get_image(self, image_id: str) -> dict[str, object] | None:
+        return None
+
+    async def get_image_data(self, image_id: str) -> bytes | None:
+        return None
+
+    async def scan_images(self) -> list[dict[str, object]]:
+        return []
+
+    async def validate_config(self, config: dict[str, object]) -> bool:
+        return True
+
+
+def test_self_hosted_gallery_build_auth_headers():
+    assert DummyGalleryPlugin.build_auth_headers("secret") == {
+        "x-api-key": "secret",
+        "Accept": "application/json",
+    }
+
+
+def test_self_hosted_gallery_api_url_and_init():
+    plugin = DummyGalleryPlugin(
+        plugin_id="dummy-gallery",
+        name="Dummy Gallery",
+        url="https://photos.example.com/",
+        api_key="secret",
+    )
+
+    assert plugin.base_url == "https://photos.example.com"
+    assert plugin.auth_headers() == {
+        "x-api-key": "secret",
+        "Accept": "application/json",
+    }
+    assert plugin.api_url("albums/123") == "https://photos.example.com/api/v2/albums/123"
+
+
+@pytest.mark.asyncio
+async def test_self_hosted_gallery_fetch_protected_image_data():
+    plugin = DummyGalleryPlugin(
+        plugin_id="dummy-gallery",
+        name="Dummy Gallery",
+        url="https://photos.example.com/",
+        api_key="secret",
+    )
+
+    with patch("app.plugins.sdk.image.fetch_image_data", autospec=True) as mock_fetch:
+        mock_fetch.return_value = b"image-bytes"
+
+        data = await plugin.fetch_protected_image_data("https://photos.example.com/image.jpg")
+
+        assert data == b"image-bytes"
+        mock_fetch.assert_awaited_once_with(
+            "https://photos.example.com/image.jpg",
+            plugin_name="Dummy Gallery",
+            headers={"x-api-key": "secret", "Accept": "application/json"},
+            follow_redirects=True,
+        )

--- a/backend/tests/unit/test_image_sdk.py
+++ b/backend/tests/unit/test_image_sdk.py
@@ -3,7 +3,15 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from app.plugins.sdk.image import SelfHostedGalleryImagePlugin, fetch_image_data
+from app.plugins.sdk.image import (
+    ImageConfigField,
+    SelfHostedGalleryImagePlugin,
+    build_image_manager_config,
+    build_image_plugin_metadata,
+    create_image_plugin_instance,
+    extract_image_config,
+    fetch_image_data,
+)
 
 
 @pytest.mark.asyncio
@@ -95,6 +103,14 @@ class DummyGalleryPlugin(SelfHostedGalleryImagePlugin):
         return True
 
 
+class DummyImagePlugin:
+    def __init__(self, plugin_id: str, name: str, enabled: bool = True, **kwargs):
+        self.plugin_id = plugin_id
+        self.name = name
+        self.enabled = enabled
+        self.kwargs = kwargs
+
+
 def test_self_hosted_gallery_build_auth_headers():
     assert DummyGalleryPlugin.build_auth_headers("secret") == {
         "x-api-key": "secret",
@@ -139,3 +155,106 @@ async def test_self_hosted_gallery_fetch_protected_image_data():
             headers={"x-api-key": "secret", "Accept": "application/json"},
             follow_redirects=True,
         )
+
+
+def test_build_image_plugin_metadata():
+    metadata = build_image_plugin_metadata(
+        type_id="dummy_image",
+        name="Dummy Image",
+        description="Dummy",
+        plugin_class=DummyImagePlugin,
+        supports_multiple_instances=False,
+        instance_label="Source",
+    )
+
+    assert metadata["type_id"] == "dummy_image"
+    assert metadata["plugin_type"].value == "image"
+    assert metadata["supports_multiple_instances"] is False
+    assert metadata["instance_label"] == "Source"
+    assert metadata["plugin_class"] is DummyImagePlugin
+
+
+def test_extract_image_config_uses_defaults_and_transforms():
+    fields = (
+        ImageConfigField("token", default="", converter=str, transform=str.strip),
+        ImageConfigField("count", default=1, converter=int),
+        ImageConfigField("alias", default="", arg_name="label"),
+    )
+
+    values = extract_image_config(
+        {"token": "  abc  ", "count": "4", "alias": "Name"},
+        fields,
+    )
+
+    assert values == {
+        "token": "abc",
+        "count": 4,
+        "label": "Name",
+    }
+
+
+def test_create_image_plugin_instance_builds_kwargs():
+    fields = (
+        ImageConfigField("token", default="", converter=str),
+        ImageConfigField("count", default=1, converter=int),
+    )
+
+    plugin = create_image_plugin_instance(
+        DummyImagePlugin,
+        expected_type_id="dummy_image",
+        plugin_id="dummy-instance",
+        type_id="dummy_image",
+        name="Dummy",
+        config={"enabled": True, "token": "abc", "count": "2"},
+        fields=fields,
+        extra_kwargs=lambda config: {"source": config.get("source", "default")},
+    )
+
+    assert plugin is not None
+    assert plugin.plugin_id == "dummy-instance"
+    assert plugin.enabled is True
+    assert plugin.kwargs == {"token": "abc", "count": 2, "source": "default"}
+
+
+def test_create_image_plugin_instance_returns_none_for_other_type():
+    plugin = create_image_plugin_instance(
+        DummyImagePlugin,
+        expected_type_id="dummy_image",
+        plugin_id="dummy-instance",
+        type_id="other_image",
+        name="Dummy",
+        config={},
+    )
+
+    assert plugin is None
+
+
+def test_build_image_manager_config_normalizes_fields_and_extras():
+    fields = (
+        ImageConfigField("token", default="", converter=str, transform=str.strip),
+        ImageConfigField("count", default=1, converter=int),
+        ImageConfigField("alias", default="", arg_name="label"),
+    )
+
+    manager_config = build_image_manager_config(
+        type_id="dummy_image",
+        fields=fields,
+        single_instance=True,
+        instance_id="dummy-instance",
+        extra_normalize=lambda config: {"enabled_flag": config.get("enabled", False)},
+        default_instance_name="Dummy Image",
+    )
+
+    normalized = manager_config.normalize_config(
+        {"token": "  abc  ", "count": "3", "alias": "Shown", "enabled": True}
+    )
+
+    assert manager_config.single_instance is True
+    assert manager_config.instance_id == "dummy-instance"
+    assert manager_config.default_instance_name == "Dummy Image"
+    assert normalized == {
+        "token": "abc",
+        "count": 3,
+        "alias": "Shown",
+        "enabled_flag": True,
+    }


### PR DESCRIPTION
## Summary
- add a shared image SDK helper for downloading image bytes with consistent logging
- cover the helper with focused backend unit tests

## Validation
- uv run pytest tests\\unit\\test_image_sdk.py
