### PR TITLE
Add backend plugin SDK helpers

### DIFF
--- a/backend/app/plugins/sdk/backend.py
+++ b/backend/app/plugins/sdk/backend.py
@@ -1,0 +1,156 @@
+"""Helpers for building backend plugins with less boilerplate."""
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from app.plugins.base import PluginType
+from app.plugins.utils.config import extract_config_value
+from app.plugins.utils.instance_manager import InstanceManagerConfig
+
+
+@dataclass(frozen=True)
+class BackendConfigField:
+    """Declarative config field definition for backend plugins."""
+
+    key: str
+    default: Any = None
+    converter: Callable[[Any], Any] | None = None
+    transform: Callable[[Any], Any] | None = None
+    arg_name: str | None = None
+
+    @property
+    def target_name(self) -> str:
+        """Constructor kwarg name for this field."""
+        return self.arg_name or self.key
+
+    def extract(self, config: dict[str, Any]) -> Any:
+        """Extract and normalize this field from config."""
+        value = extract_config_value(
+            config,
+            self.key,
+            default=self.default,
+            converter=self.converter,
+        )
+        if self.transform is not None:
+            return self.transform(value)
+        return value
+
+
+def path_or_none(value: str | None) -> Path | None:
+    """Convert a non-empty string path to Path, otherwise return None."""
+    if value and value.strip():
+        return Path(value)
+    return None
+
+
+def extract_backend_config(
+    config: dict[str, Any],
+    fields: Iterable[BackendConfigField],
+    *,
+    use_arg_names: bool = True,
+) -> dict[str, Any]:
+    """Extract a typed config mapping from raw backend plugin config."""
+    extracted: dict[str, Any] = {}
+    for field in fields:
+        key = field.target_name if use_arg_names else field.key
+        extracted[key] = field.extract(config)
+    return extracted
+
+
+def build_backend_plugin_metadata(
+    *,
+    type_id: str,
+    name: str,
+    description: str,
+    plugin_class: type[Any],
+    version: str = "1.0.0",
+    supports_multiple_instances: bool = True,
+    instance_label: str | None = None,
+    common_config_schema: dict[str, Any] | None = None,
+    instance_config_schema: dict[str, Any] | None = None,
+    ui_actions: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build standard metadata for a backend plugin."""
+    metadata = {
+        "type_id": type_id,
+        "plugin_type": PluginType.BACKEND,
+        "name": name,
+        "description": description,
+        "version": version,
+        "supports_multiple_instances": supports_multiple_instances,
+        "common_config_schema": common_config_schema or {},
+        "instance_config_schema": instance_config_schema or {},
+        "plugin_class": plugin_class,
+    }
+    if instance_label is not None:
+        metadata["instance_label"] = instance_label
+    if ui_actions is not None:
+        metadata["ui_actions"] = ui_actions
+    return metadata
+
+
+def create_backend_plugin_instance(
+    plugin_class: type[Any],
+    *,
+    expected_type_id: str,
+    plugin_id: str,
+    type_id: str,
+    name: str,
+    config: dict[str, Any],
+    fields: Iterable[BackendConfigField] = (),
+    extra_kwargs: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+    enabled_default: bool = False,
+) -> Any | None:
+    """Create a backend plugin instance from normalized config fields."""
+    if type_id != expected_type_id:
+        return None
+
+    kwargs = extract_backend_config(config, fields)
+    if extra_kwargs is not None:
+        kwargs.update(extra_kwargs(config))
+
+    return plugin_class(
+        plugin_id=plugin_id,
+        name=name,
+        enabled=config.get("enabled", enabled_default),
+        **kwargs,
+    )
+
+
+def build_backend_manager_config(
+    *,
+    type_id: str,
+    fields: Iterable[BackendConfigField] = (),
+    single_instance: bool = False,
+    instance_id: str | None = None,
+    validate_config: Callable[[dict[str, Any]], bool] | None = None,
+    generate_instance_id: Callable[[dict[str, Any], str], str] | None = None,
+    extra_normalize: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+    prepare_instance_config: Callable[[dict[str, Any], dict[str, Any]], dict[str, Any]]
+    | None = None,
+    on_instance_created: Callable[[Any, dict[str, Any]], None] | None = None,
+    on_instance_updated: Callable[[Any, dict[str, Any]], None] | None = None,
+    default_instance_name: str | None = None,
+) -> InstanceManagerConfig:
+    """Build InstanceManagerConfig with shared backend config normalization."""
+
+    def normalize_config(config: dict[str, Any]) -> dict[str, Any]:
+        normalized = extract_backend_config(config, fields, use_arg_names=False)
+        if extra_normalize is not None:
+            normalized.update(extra_normalize(config))
+        return normalized
+
+    return InstanceManagerConfig(
+        type_id=type_id,
+        single_instance=single_instance,
+        instance_id=instance_id,
+        validate_config=validate_config,
+        generate_instance_id=generate_instance_id,
+        normalize_config=normalize_config,
+        prepare_instance_config=prepare_instance_config,
+        on_instance_created=on_instance_created,
+        on_instance_updated=on_instance_updated,
+        default_instance_name=default_instance_name,
+    )

--- a/backend/tests/unit/test_backend_sdk.py
+++ b/backend/tests/unit/test_backend_sdk.py
@@ -1,0 +1,131 @@
+from pathlib import Path
+
+from app.plugins.sdk.backend import (
+    BackendConfigField,
+    build_backend_manager_config,
+    build_backend_plugin_metadata,
+    create_backend_plugin_instance,
+    extract_backend_config,
+    path_or_none,
+)
+
+
+class DummyBackendPlugin:
+    def __init__(self, plugin_id: str, name: str, enabled: bool = True, **kwargs):
+        self.plugin_id = plugin_id
+        self.name = name
+        self.enabled = enabled
+        self.kwargs = kwargs
+
+
+def test_path_or_none():
+    assert path_or_none("") is None
+    assert path_or_none("   ") is None
+    assert path_or_none("C:/tmp") == Path("C:/tmp")
+
+
+def test_build_backend_plugin_metadata():
+    metadata = build_backend_plugin_metadata(
+        type_id="dummy_backend",
+        name="Dummy Backend",
+        description="Dummy",
+        plugin_class=DummyBackendPlugin,
+        supports_multiple_instances=False,
+        instance_label="Worker",
+        ui_actions=[{"id": "fetch", "type": "fetch"}],
+    )
+
+    assert metadata["type_id"] == "dummy_backend"
+    assert metadata["plugin_type"].value == "backend"
+    assert metadata["supports_multiple_instances"] is False
+    assert metadata["instance_label"] == "Worker"
+    assert metadata["ui_actions"] == [{"id": "fetch", "type": "fetch"}]
+    assert metadata["plugin_class"] is DummyBackendPlugin
+
+
+def test_extract_backend_config_uses_defaults_and_transforms():
+    fields = (
+        BackendConfigField("token", default="", converter=str, transform=str.strip),
+        BackendConfigField("count", default=1, converter=int),
+        BackendConfigField(
+            "folder", default="", transform=path_or_none, arg_name="target_directory"
+        ),
+    )
+
+    values = extract_backend_config(
+        {"token": "  abc  ", "count": "4", "folder": "C:/tmp"},
+        fields,
+    )
+
+    assert values == {
+        "token": "abc",
+        "count": 4,
+        "target_directory": Path("C:/tmp"),
+    }
+
+
+def test_create_backend_plugin_instance_builds_kwargs():
+    fields = (
+        BackendConfigField("token", default="", converter=str),
+        BackendConfigField("count", default=1, converter=int),
+    )
+
+    plugin = create_backend_plugin_instance(
+        DummyBackendPlugin,
+        expected_type_id="dummy_backend",
+        plugin_id="dummy-instance",
+        type_id="dummy_backend",
+        name="Dummy",
+        config={"enabled": True, "token": "abc", "count": "2"},
+        fields=fields,
+        extra_kwargs=lambda config: {"source": config.get("source", "default")},
+    )
+
+    assert plugin is not None
+    assert plugin.plugin_id == "dummy-instance"
+    assert plugin.enabled is True
+    assert plugin.kwargs == {"token": "abc", "count": 2, "source": "default"}
+
+
+def test_create_backend_plugin_instance_returns_none_for_other_type():
+    plugin = create_backend_plugin_instance(
+        DummyBackendPlugin,
+        expected_type_id="dummy_backend",
+        plugin_id="dummy-instance",
+        type_id="other_backend",
+        name="Dummy",
+        config={},
+    )
+
+    assert plugin is None
+
+
+def test_build_backend_manager_config_normalizes_fields_and_extras():
+    fields = (
+        BackendConfigField("token", default="", converter=str, transform=str.strip),
+        BackendConfigField("count", default=1, converter=int),
+        BackendConfigField("folder", default="", transform=path_or_none),
+    )
+
+    manager_config = build_backend_manager_config(
+        type_id="dummy_backend",
+        fields=fields,
+        single_instance=True,
+        instance_id="dummy-instance",
+        extra_normalize=lambda config: {"enabled_flag": config.get("enabled", False)},
+        default_instance_name="Dummy Backend",
+    )
+
+    normalized = manager_config.normalize_config(
+        {"token": "  abc  ", "count": "3", "folder": "C:/tmp", "enabled": True}
+    )
+
+    assert manager_config.single_instance is True
+    assert manager_config.instance_id == "dummy-instance"
+    assert manager_config.default_instance_name == "Dummy Backend"
+    assert normalized == {
+        "token": "abc",
+        "count": 3,
+        "folder": Path("C:/tmp"),
+        "enabled_flag": True,
+    }


### PR DESCRIPTION
## Summary
- add shared backend plugin SDK helpers for metadata, config extraction, instance creation, and manager config
- cover the helper surface with focused backend unit tests

## Validation
- uv run pytest tests\\unit\\test_backend_sdk.py
