### PR TITLE
Add calendar plugin SDK helpers

### DIFF
--- a/backend/app/plugins/calendar/google.py
+++ b/backend/app/plugins/calendar/google.py
@@ -10,14 +10,16 @@ import httpx
 from loguru import logger
 
 from app.models.calendar import CalendarEvent
-from app.plugins.base import PluginType
 from app.plugins.hooks import hookimpl
 from app.plugins.protocols import CalendarPlugin
-from app.plugins.utils.config import extract_config_value, to_str
-from app.plugins.utils.instance_manager import (
-    InstanceManagerConfig,
-    handle_plugin_config_update_generic,
+from app.plugins.sdk.calendar import (
+    CalendarConfigField,
+    build_calendar_manager_config,
+    build_calendar_plugin_metadata,
+    create_calendar_plugin_instance,
 )
+from app.plugins.utils.config import extract_config_value, to_str
+from app.plugins.utils.instance_manager import handle_plugin_config_update_generic
 from app.utils.ical_parser import parse_ical_from_url
 
 # Loguru automatically includes module/function info in logs
@@ -85,17 +87,18 @@ def _normalize_google_calendar_url(url: str) -> str:
 class GoogleCalendarPlugin(CalendarPlugin):
     """Google Calendar plugin using iCal feeds."""
 
+    CALENDAR_FIELDS = (CalendarConfigField("ical_url", default="", converter=to_str),)
+
     @classmethod
     def get_plugin_metadata(cls) -> dict[str, Any]:
         """Get plugin metadata for registration."""
-        return {
-            "type_id": "google",
-            "plugin_type": PluginType.CALENDAR,
-            "name": "Google Calendar",
-            "description": "Google Calendar via iCal feed",
-            "version": "1.0.0",
-            "common_config_schema": {},
-            "instance_config_schema": {
+        return build_calendar_plugin_metadata(
+            type_id="google",
+            name="Google Calendar",
+            description="Google Calendar via iCal feed",
+            plugin_class=cls,
+            common_config_schema={},
+            instance_config_schema={
                 "ical_url": {
                     "type": "string",
                     "description": "Google Calendar iCal URL or share URL",
@@ -110,9 +113,8 @@ class GoogleCalendarPlugin(CalendarPlugin):
                     },
                 },
             },
-            "supports_multiple_instances": True,  # Multi-instance plugin
-            "plugin_class": cls,
-        }
+            supports_multiple_instances=True,
+        )
 
     def __init__(self, plugin_id: str, name: str, ical_url: str, enabled: bool = True):
         """
@@ -254,17 +256,14 @@ def create_plugin_instance(
     config: dict[str, Any],
 ) -> GoogleCalendarPlugin | None:
     """Create a GoogleCalendarPlugin instance."""
-    if type_id != "google":
-        return None
-
-    enabled = config.get("enabled", False)  # Default to disabled
-    ical_url = extract_config_value(config, "ical_url", default="", converter=to_str)
-
-    return GoogleCalendarPlugin(
+    return create_calendar_plugin_instance(
+        GoogleCalendarPlugin,
+        expected_type_ids="google",
         plugin_id=plugin_id,
+        type_id=type_id,
         name=name,
-        ical_url=ical_url,
-        enabled=enabled,
+        config=config,
+        fields=GoogleCalendarPlugin.CALENDAR_FIELDS,
     )
 
 
@@ -279,11 +278,6 @@ async def handle_plugin_config_update(
     """Handle Google Calendar plugin configuration update and instance management."""
     if type_id != "google":
         return None
-
-    def normalize_config(c: dict[str, Any]) -> dict[str, Any]:
-        """Normalize config values."""
-        ical_url = extract_config_value(c, "ical_url", converter=to_str)
-        return {"ical_url": ical_url or ""}
 
     def validate_config(c: dict[str, Any]) -> bool:
         """Validate config has required ical_url."""
@@ -307,10 +301,10 @@ async def handle_plugin_config_update(
         # Fallback ID if URL not available
         return f"{t}-instance"
 
-    manager_config = InstanceManagerConfig(
+    manager_config = build_calendar_manager_config(
         type_id="google",
+        fields=GoogleCalendarPlugin.CALENDAR_FIELDS,
         single_instance=False,  # Multi-instance plugin
-        normalize_config=normalize_config,
         validate_config=validate_config,
         generate_instance_id=generate_instance_id,
         default_instance_name="Google Calendar",

--- a/backend/app/plugins/calendar/ical.py
+++ b/backend/app/plugins/calendar/ical.py
@@ -8,14 +8,16 @@ import httpx
 from loguru import logger
 
 from app.models.calendar import CalendarEvent
-from app.plugins.base import PluginType
 from app.plugins.hooks import hookimpl
 from app.plugins.protocols import CalendarPlugin
-from app.plugins.utils.config import extract_config_value, to_str
-from app.plugins.utils.instance_manager import (
-    InstanceManagerConfig,
-    handle_plugin_config_update_generic,
+from app.plugins.sdk.calendar import (
+    CalendarConfigField,
+    build_calendar_manager_config,
+    build_calendar_plugin_metadata,
+    create_calendar_plugin_instance,
 )
+from app.plugins.utils.config import extract_config_value, to_str
+from app.plugins.utils.instance_manager import handle_plugin_config_update_generic
 from app.utils.ical_parser import parse_ical_from_url
 
 # Loguru automatically includes module/function info in logs
@@ -24,17 +26,18 @@ from app.utils.ical_parser import parse_ical_from_url
 class ICalCalendarPlugin(CalendarPlugin):
     """Generic iCal calendar plugin for any iCal-compatible source."""
 
+    CALENDAR_FIELDS = (CalendarConfigField("ical_url", default="", converter=to_str),)
+
     @classmethod
     def get_plugin_metadata(cls) -> dict[str, Any]:
         """Get plugin metadata for registration."""
-        return {
-            "type_id": "ical",
-            "plugin_type": PluginType.CALENDAR,
-            "name": "iCal Feed",
-            "description": "Generic iCal feed (Proton, Outlook, etc.)",
-            "version": "1.0.0",
-            "common_config_schema": {},
-            "instance_config_schema": {
+        return build_calendar_plugin_metadata(
+            type_id="ical",
+            name="iCal Feed",
+            description="Generic iCal feed (Proton, Outlook, etc.)",
+            plugin_class=cls,
+            common_config_schema={},
+            instance_config_schema={
                 "ical_url": {
                     "type": "string",
                     "description": "iCal feed URL",
@@ -49,9 +52,8 @@ class ICalCalendarPlugin(CalendarPlugin):
                     },
                 },
             },
-            "supports_multiple_instances": True,  # Multi-instance plugin
-            "plugin_class": cls,
-        }
+            supports_multiple_instances=True,
+        )
 
     def __init__(self, plugin_id: str, name: str, ical_url: str, enabled: bool = True):
         """
@@ -178,15 +180,14 @@ def register_plugin_types() -> list[dict[str, Any]]:
     """Register ICalCalendarPlugin types (ical and proton)."""
     ical_metadata = ICalCalendarPlugin.get_plugin_metadata()
     # Also register as proton (same plugin, different type_id)
-    proton_metadata = {
-        "type_id": "proton",
-        "plugin_type": PluginType.CALENDAR,
-        "name": "Proton Calendar",
-        "description": "Proton Calendar via iCal feed",
-        "version": "1.0.0",
-        "common_config_schema": {},
-        "plugin_class": ICalCalendarPlugin,
-    }
+    proton_metadata = build_calendar_plugin_metadata(
+        type_id="proton",
+        name="Proton Calendar",
+        description="Proton Calendar via iCal feed",
+        plugin_class=ICalCalendarPlugin,
+        common_config_schema={},
+        supports_multiple_instances=True,
+    )
     return [ical_metadata, proton_metadata]
 
 
@@ -198,17 +199,14 @@ def create_plugin_instance(
     config: dict[str, Any],
 ) -> ICalCalendarPlugin | None:
     """Create an ICalCalendarPlugin instance."""
-    if type_id not in ("ical", "proton"):
-        return None
-
-    enabled = config.get("enabled", False)  # Default to disabled
-    ical_url = extract_config_value(config, "ical_url", default="", converter=to_str)
-
-    return ICalCalendarPlugin(
+    return create_calendar_plugin_instance(
+        ICalCalendarPlugin,
+        expected_type_ids=("ical", "proton"),
         plugin_id=plugin_id,
+        type_id=type_id,
         name=name,
-        ical_url=ical_url,
-        enabled=enabled,
+        config=config,
+        fields=ICalCalendarPlugin.CALENDAR_FIELDS,
     )
 
 
@@ -223,11 +221,6 @@ async def handle_plugin_config_update(
     """Handle iCal/Proton Calendar plugin configuration update and instance management."""
     if type_id not in ("ical", "proton"):
         return None
-
-    def normalize_config(c: dict[str, Any]) -> dict[str, Any]:
-        """Normalize config values."""
-        ical_url = extract_config_value(c, "ical_url", converter=to_str)
-        return {"ical_url": ical_url or ""}
 
     def validate_config(c: dict[str, Any]) -> bool:
         """Validate config has required ical_url."""
@@ -251,10 +244,10 @@ async def handle_plugin_config_update(
         # Fallback ID if URL not available
         return f"{t}-instance"
 
-    manager_config = InstanceManagerConfig(
+    manager_config = build_calendar_manager_config(
         type_id=type_id,  # Can be "ical" or "proton"
+        fields=ICalCalendarPlugin.CALENDAR_FIELDS,
         single_instance=False,  # Multi-instance plugin
-        normalize_config=normalize_config,
         validate_config=validate_config,
         generate_instance_id=generate_instance_id,
         default_instance_name="iCal Feed" if type_id == "ical" else "Proton Calendar",

--- a/backend/app/plugins/sdk/calendar.py
+++ b/backend/app/plugins/sdk/calendar.py
@@ -1,0 +1,148 @@
+"""Helpers for building calendar plugins with less boilerplate."""
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from typing import Any
+
+from app.plugins.base import PluginType
+from app.plugins.utils.config import extract_config_value
+from app.plugins.utils.instance_manager import InstanceManagerConfig
+
+
+@dataclass(frozen=True)
+class CalendarConfigField:
+    """Declarative config field definition for calendar plugins."""
+
+    key: str
+    default: Any = None
+    converter: Callable[[Any], Any] | None = None
+    transform: Callable[[Any], Any] | None = None
+    arg_name: str | None = None
+
+    @property
+    def target_name(self) -> str:
+        """Constructor kwarg name for this field."""
+        return self.arg_name or self.key
+
+    def extract(self, config: dict[str, Any]) -> Any:
+        """Extract and normalize this field from config."""
+        value = extract_config_value(
+            config,
+            self.key,
+            default=self.default,
+            converter=self.converter,
+        )
+        if self.transform is not None:
+            return self.transform(value)
+        return value
+
+
+def build_calendar_plugin_metadata(
+    *,
+    type_id: str,
+    name: str,
+    description: str,
+    plugin_class: type[Any],
+    version: str = "1.0.0",
+    supports_multiple_instances: bool = True,
+    instance_label: str | None = None,
+    common_config_schema: dict[str, Any] | None = None,
+    instance_config_schema: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build standard metadata for a calendar plugin."""
+    metadata = {
+        "type_id": type_id,
+        "plugin_type": PluginType.CALENDAR,
+        "name": name,
+        "description": description,
+        "version": version,
+        "supports_multiple_instances": supports_multiple_instances,
+        "common_config_schema": common_config_schema or {},
+        "instance_config_schema": instance_config_schema or {},
+        "plugin_class": plugin_class,
+    }
+    if instance_label is not None:
+        metadata["instance_label"] = instance_label
+    return metadata
+
+
+def extract_calendar_config(
+    config: dict[str, Any],
+    fields: Iterable[CalendarConfigField],
+    *,
+    use_arg_names: bool = True,
+) -> dict[str, Any]:
+    """Extract a typed config mapping from raw calendar plugin config."""
+    extracted: dict[str, Any] = {}
+    for field in fields:
+        key = field.target_name if use_arg_names else field.key
+        extracted[key] = field.extract(config)
+    return extracted
+
+
+def create_calendar_plugin_instance(
+    plugin_class: type[Any],
+    *,
+    expected_type_ids: str | Iterable[str],
+    plugin_id: str,
+    type_id: str,
+    name: str,
+    config: dict[str, Any],
+    fields: Iterable[CalendarConfigField] = (),
+    extra_kwargs: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+    enabled_default: bool = False,
+) -> Any | None:
+    """Create a calendar plugin instance from normalized config fields."""
+    accepted_type_ids = (
+        {expected_type_ids} if isinstance(expected_type_ids, str) else set(expected_type_ids)
+    )
+    if type_id not in accepted_type_ids:
+        return None
+
+    kwargs = extract_calendar_config(config, fields)
+    if extra_kwargs is not None:
+        kwargs.update(extra_kwargs(config))
+
+    return plugin_class(
+        plugin_id=plugin_id,
+        name=name,
+        enabled=config.get("enabled", enabled_default),
+        **kwargs,
+    )
+
+
+def build_calendar_manager_config(
+    *,
+    type_id: str,
+    fields: Iterable[CalendarConfigField] = (),
+    single_instance: bool = False,
+    instance_id: str | None = None,
+    validate_config: Callable[[dict[str, Any]], bool] | None = None,
+    generate_instance_id: Callable[[dict[str, Any], str], str] | None = None,
+    extra_normalize: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+    prepare_instance_config: Callable[[dict[str, Any], dict[str, Any]], dict[str, Any]]
+    | None = None,
+    on_instance_created: Callable[[Any, dict[str, Any]], None] | None = None,
+    on_instance_updated: Callable[[Any, dict[str, Any]], None] | None = None,
+    default_instance_name: str | None = None,
+) -> InstanceManagerConfig:
+    """Build InstanceManagerConfig with shared calendar config normalization."""
+
+    def normalize_config(config: dict[str, Any]) -> dict[str, Any]:
+        normalized = extract_calendar_config(config, fields, use_arg_names=False)
+        if extra_normalize is not None:
+            normalized.update(extra_normalize(config))
+        return normalized
+
+    return InstanceManagerConfig(
+        type_id=type_id,
+        single_instance=single_instance,
+        instance_id=instance_id,
+        validate_config=validate_config,
+        generate_instance_id=generate_instance_id,
+        normalize_config=normalize_config,
+        prepare_instance_config=prepare_instance_config,
+        on_instance_created=on_instance_created,
+        on_instance_updated=on_instance_updated,
+        default_instance_name=default_instance_name,
+    )

--- a/backend/tests/unit/test_calendar_sdk.py
+++ b/backend/tests/unit/test_calendar_sdk.py
@@ -1,0 +1,131 @@
+from app.plugins.sdk.calendar import (
+    CalendarConfigField,
+    build_calendar_manager_config,
+    build_calendar_plugin_metadata,
+    create_calendar_plugin_instance,
+    extract_calendar_config,
+)
+
+
+class DummyCalendarPlugin:
+    def __init__(self, plugin_id: str, name: str, enabled: bool = True, **kwargs):
+        self.plugin_id = plugin_id
+        self.name = name
+        self.enabled = enabled
+        self.kwargs = kwargs
+
+
+def test_build_calendar_plugin_metadata():
+    metadata = build_calendar_plugin_metadata(
+        type_id="dummy_calendar",
+        name="Dummy Calendar",
+        description="Dummy",
+        plugin_class=DummyCalendarPlugin,
+        supports_multiple_instances=False,
+        instance_label="Source",
+    )
+
+    assert metadata["type_id"] == "dummy_calendar"
+    assert metadata["plugin_type"].value == "calendar"
+    assert metadata["supports_multiple_instances"] is False
+    assert metadata["instance_label"] == "Source"
+    assert metadata["plugin_class"] is DummyCalendarPlugin
+
+
+def test_extract_calendar_config_uses_defaults_and_transforms():
+    fields = (
+        CalendarConfigField("url", default="", converter=str, transform=str.strip),
+        CalendarConfigField("name_override", default="", arg_name="calendar_name"),
+    )
+
+    values = extract_calendar_config(
+        {"url": "  https://example.com/calendar.ics  ", "name_override": "Personal"},
+        fields,
+    )
+
+    assert values == {
+        "url": "https://example.com/calendar.ics",
+        "calendar_name": "Personal",
+    }
+
+
+def test_create_calendar_plugin_instance_builds_kwargs():
+    fields = (
+        CalendarConfigField("url", default="", converter=str),
+        CalendarConfigField("refresh_minutes", default=5, converter=int),
+    )
+
+    plugin = create_calendar_plugin_instance(
+        DummyCalendarPlugin,
+        expected_type_ids="dummy_calendar",
+        plugin_id="dummy-instance",
+        type_id="dummy_calendar",
+        name="Dummy",
+        config={"enabled": True, "url": "https://example.com", "refresh_minutes": "10"},
+        fields=fields,
+        extra_kwargs=lambda config: {"source": config.get("source", "default")},
+    )
+
+    assert plugin is not None
+    assert plugin.plugin_id == "dummy-instance"
+    assert plugin.enabled is True
+    assert plugin.kwargs == {
+        "url": "https://example.com",
+        "refresh_minutes": 10,
+        "source": "default",
+    }
+
+
+def test_create_calendar_plugin_instance_accepts_multiple_type_ids():
+    plugin = create_calendar_plugin_instance(
+        DummyCalendarPlugin,
+        expected_type_ids=("ical", "proton"),
+        plugin_id="calendar-instance",
+        type_id="proton",
+        name="Calendar",
+        config={},
+    )
+
+    assert plugin is not None
+
+
+def test_create_calendar_plugin_instance_returns_none_for_other_type():
+    plugin = create_calendar_plugin_instance(
+        DummyCalendarPlugin,
+        expected_type_ids=("ical", "proton"),
+        plugin_id="calendar-instance",
+        type_id="google",
+        name="Calendar",
+        config={},
+    )
+
+    assert plugin is None
+
+
+def test_build_calendar_manager_config_normalizes_fields_and_extras():
+    fields = (
+        CalendarConfigField("url", default="", converter=str, transform=str.strip),
+        CalendarConfigField("refresh_minutes", default=5, converter=int),
+    )
+
+    manager_config = build_calendar_manager_config(
+        type_id="dummy_calendar",
+        fields=fields,
+        single_instance=True,
+        instance_id="dummy-instance",
+        extra_normalize=lambda config: {"enabled_flag": config.get("enabled", False)},
+        default_instance_name="Dummy Calendar",
+    )
+
+    normalized = manager_config.normalize_config(
+        {"url": "  https://example.com  ", "refresh_minutes": "15", "enabled": True}
+    )
+
+    assert manager_config.single_instance is True
+    assert manager_config.instance_id == "dummy-instance"
+    assert manager_config.default_instance_name == "Dummy Calendar"
+    assert normalized == {
+        "url": "https://example.com",
+        "refresh_minutes": 15,
+        "enabled_flag": True,
+    }


### PR DESCRIPTION
## Summary
- add shared calendar plugin SDK helpers for metadata, config extraction, instance creation, and manager config
- port the built-in Google and iCal calendar plugins onto those helpers
- keep proton as an alias of the iCal plugin while using the same helper surface

## Validation
- uv run pytest tests\\unit\\test_calendar_sdk.py
- uv run pytest tests\\unit\\test_google_calendar_plugin.py tests\\unit\\test_ical_calendar_plugin.py
