### PR TITLE
Add plugin protocol version support

### DIFF
--- a/backend/app/plugins/definitions.py
+++ b/backend/app/plugins/definitions.py
@@ -11,6 +11,9 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from app.plugins.base import PluginType
 
+CURRENT_PLUGIN_PROTOCOL_VERSION = 1
+SUPPORTED_PLUGIN_PROTOCOL_VERSIONS = {CURRENT_PLUGIN_PROTOCOL_VERSION}
+
 
 class ConfigFieldDefinition(BaseModel):
     """Typed config field metadata with permissive extra support."""
@@ -71,7 +74,7 @@ class CapabilitySet(BaseModel):
 class PluginDefinition(BaseModel):
     """Normalized plugin definition consumed by the app."""
 
-    protocol_version: int = 1
+    protocol_version: int = CURRENT_PLUGIN_PROTOCOL_VERSION
     type_id: str
     plugin_type: PluginType
     name: str
@@ -94,10 +97,22 @@ class PluginDefinition(BaseModel):
     def from_raw(cls, raw: "PluginDefinition | dict[str, Any]") -> "PluginDefinition":
         """Normalize a raw plugin definition into the typed model."""
         if isinstance(raw, cls):
-            return raw
+            return raw.ensure_supported()
         if isinstance(raw, dict):
-            return cls.model_validate(raw)
+            return cls.model_validate(raw).ensure_supported()
         raise TypeError(f"Unsupported plugin definition type: {type(raw)!r}")
+
+    def ensure_supported(self) -> "PluginDefinition":
+        """Validate that this plugin definition targets a supported protocol version."""
+        if self.protocol_version not in SUPPORTED_PLUGIN_PROTOCOL_VERSIONS:
+            supported = ", ".join(
+                str(version) for version in sorted(SUPPORTED_PLUGIN_PROTOCOL_VERSIONS)
+            )
+            raise ValueError(
+                f"Unsupported plugin protocol version: {self.protocol_version}. "
+                f"Supported versions: {supported}"
+            )
+        return self
 
     def get(self, key: str, default: Any = None) -> Any:
         """Mapping-style compatibility for legacy callers."""

--- a/backend/app/plugins/sdk/backend.py
+++ b/backend/app/plugins/sdk/backend.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from app.plugins.base import PluginType
+from app.plugins.definitions import CURRENT_PLUGIN_PROTOCOL_VERSION
 from app.plugins.utils.config import extract_config_value
 from app.plugins.utils.instance_manager import InstanceManagerConfig
 
@@ -66,6 +67,7 @@ def build_backend_plugin_metadata(
     description: str,
     plugin_class: type[Any],
     version: str = "1.0.0",
+    protocol_version: int = CURRENT_PLUGIN_PROTOCOL_VERSION,
     supports_multiple_instances: bool = True,
     instance_label: str | None = None,
     common_config_schema: dict[str, Any] | None = None,
@@ -74,6 +76,7 @@ def build_backend_plugin_metadata(
 ) -> dict[str, Any]:
     """Build standard metadata for a backend plugin."""
     metadata = {
+        "protocol_version": protocol_version,
         "type_id": type_id,
         "plugin_type": PluginType.BACKEND,
         "name": name,

--- a/backend/app/plugins/sdk/calendar.py
+++ b/backend/app/plugins/sdk/calendar.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from app.plugins.base import PluginType
+from app.plugins.definitions import CURRENT_PLUGIN_PROTOCOL_VERSION
 from app.plugins.utils.config import extract_config_value
 from app.plugins.utils.instance_manager import InstanceManagerConfig
 
@@ -44,6 +45,7 @@ def build_calendar_plugin_metadata(
     description: str,
     plugin_class: type[Any],
     version: str = "1.0.0",
+    protocol_version: int = CURRENT_PLUGIN_PROTOCOL_VERSION,
     supports_multiple_instances: bool = True,
     instance_label: str | None = None,
     common_config_schema: dict[str, Any] | None = None,
@@ -51,6 +53,7 @@ def build_calendar_plugin_metadata(
 ) -> dict[str, Any]:
     """Build standard metadata for a calendar plugin."""
     metadata = {
+        "protocol_version": protocol_version,
         "type_id": type_id,
         "plugin_type": PluginType.CALENDAR,
         "name": name,

--- a/backend/app/plugins/sdk/image.py
+++ b/backend/app/plugins/sdk/image.py
@@ -8,6 +8,7 @@ import httpx
 from loguru import logger
 
 from app.plugins.base import PluginType
+from app.plugins.definitions import CURRENT_PLUGIN_PROTOCOL_VERSION
 from app.plugins.protocols import ImagePlugin
 from app.plugins.utils.config import extract_config_value
 from app.plugins.utils.instance_manager import InstanceManagerConfig
@@ -70,6 +71,7 @@ def build_image_plugin_metadata(
     description: str,
     plugin_class: type[Any],
     version: str = "1.0.0",
+    protocol_version: int = CURRENT_PLUGIN_PROTOCOL_VERSION,
     supports_multiple_instances: bool = True,
     instance_label: str | None = None,
     common_config_schema: dict[str, Any] | None = None,
@@ -77,6 +79,7 @@ def build_image_plugin_metadata(
 ) -> dict[str, Any]:
     """Build standard metadata for an image plugin."""
     metadata = {
+        "protocol_version": protocol_version,
         "type_id": type_id,
         "plugin_type": PluginType.IMAGE,
         "name": name,

--- a/backend/app/plugins/sdk/service.py
+++ b/backend/app/plugins/sdk/service.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from app.plugins.base import PluginType
+from app.plugins.definitions import CURRENT_PLUGIN_PROTOCOL_VERSION
 from app.plugins.utils.config import extract_config_value
 from app.plugins.utils.instance_manager import InstanceManagerConfig
 
@@ -44,6 +45,7 @@ def build_service_plugin_metadata(
     description: str,
     plugin_class: type[Any],
     version: str = "1.0.0",
+    protocol_version: int = CURRENT_PLUGIN_PROTOCOL_VERSION,
     supports_multiple_instances: bool = True,
     instance_label: str | None = None,
     common_config_schema: dict[str, Any] | None = None,
@@ -54,6 +56,7 @@ def build_service_plugin_metadata(
 ) -> dict[str, Any]:
     """Build standard metadata for a service plugin."""
     metadata = {
+        "protocol_version": protocol_version,
         "type_id": type_id,
         "plugin_type": PluginType.SERVICE,
         "name": name,

--- a/backend/app/services/plugin_installer.py
+++ b/backend/app/services/plugin_installer.py
@@ -11,9 +11,11 @@ from pathlib import Path
 from typing import Any
 
 from app.config import settings
+from app.plugins.definitions import CURRENT_PLUGIN_PROTOCOL_VERSION
 from app.services.validation import (
     validate_directory_structure,
     validate_manifest_format_version,
+    validate_manifest_protocol_version,
     validate_manifest_required_fields,
     validate_plugin_optional_fields,
     validate_plugin_type,
@@ -183,6 +185,12 @@ class PluginInstaller:
         validate_manifest_format_version(
             manifest, ["1.0.0"], default_version="1.0.0", manifest_type="plugin.json"
         )
+        validate_manifest_protocol_version(
+            manifest,
+            [CURRENT_PLUGIN_PROTOCOL_VERSION],
+            default_version=CURRENT_PLUGIN_PROTOCOL_VERSION,
+            manifest_type="plugin.json",
+        )
         validate_plugin_optional_fields(manifest)
 
         return manifest
@@ -213,6 +221,12 @@ class PluginInstaller:
         validate_plugin_type(manifest["type"])
         validate_manifest_format_version(
             manifest, ["1.0.0"], default_version="1.0.0", manifest_type="plugin.json"
+        )
+        validate_manifest_protocol_version(
+            manifest,
+            [CURRENT_PLUGIN_PROTOCOL_VERSION],
+            default_version=CURRENT_PLUGIN_PROTOCOL_VERSION,
+            manifest_type="plugin.json",
         )
         validate_plugin_optional_fields(manifest)
 

--- a/backend/app/services/validation/__init__.py
+++ b/backend/app/services/validation/__init__.py
@@ -2,6 +2,7 @@
 
 from .manifest_validator import (
     validate_manifest_format_version,
+    validate_manifest_protocol_version,
     validate_manifest_required_fields,
     validate_path_traversal,
     validate_plugin_optional_fields,
@@ -16,6 +17,7 @@ from .package_validator import (
 __all__ = [
     "validate_manifest_required_fields",
     "validate_manifest_format_version",
+    "validate_manifest_protocol_version",
     "validate_path_traversal",
     "validate_plugin_type",
     "validate_plugin_optional_fields",

--- a/backend/app/services/validation/manifest_validator.py
+++ b/backend/app/services/validation/manifest_validator.py
@@ -49,6 +49,34 @@ def validate_manifest_format_version(
         )
 
 
+def validate_manifest_protocol_version(
+    manifest: dict[str, Any],
+    supported_versions: list[int],
+    default_version: int = 1,
+    manifest_type: str = "manifest",
+) -> None:
+    """
+    Validate manifest protocol version.
+
+    Args:
+        manifest: Manifest dictionary to validate
+        supported_versions: List of supported protocol versions
+        default_version: Default protocol version if not specified
+        manifest_type: Type of manifest (for error messages)
+
+    Raises:
+        ValueError: If protocol version is invalid or unsupported
+    """
+    protocol_version = manifest.get("protocol_version", default_version)
+    if not isinstance(protocol_version, int):
+        raise ValueError(f"{manifest_type} protocol_version must be an integer")
+    if protocol_version not in supported_versions:
+        raise ValueError(
+            f"Unsupported {manifest_type} protocol version: {protocol_version}. "
+            f"Supported versions: {', '.join(str(version) for version in supported_versions)}"
+        )
+
+
 def validate_path_traversal(path: str | Path, base_path: str | Path | None = None) -> None:
     """
     Validate that a path does not contain path traversal attempts.

--- a/backend/tests/unit/test_plugin_definitions.py
+++ b/backend/tests/unit/test_plugin_definitions.py
@@ -36,3 +36,14 @@ class TestPluginDefinition:
         assert definition["type_id"] == "test_plugin"
         assert definition.get("name") == "Test Plugin"
         assert definition.get("missing", "fallback") == "fallback"
+
+    def test_from_raw_rejects_unsupported_protocol_version(self):
+        with pytest.raises(ValueError, match="Unsupported plugin protocol version"):
+            PluginDefinition.from_raw(
+                {
+                    "protocol_version": 2,
+                    "type_id": "future_plugin",
+                    "plugin_type": PluginType.SERVICE,
+                    "name": "Future Plugin",
+                }
+            )

--- a/backend/tests/unit/test_plugin_installer.py
+++ b/backend/tests/unit/test_plugin_installer.py
@@ -121,6 +121,26 @@ class TestPluginInstaller:
         assert manifest["id"] == "test_plugin"
         assert manifest["name"] == "Test Plugin"
 
+    def test_validate_plugin_directory_defaults_protocol_version(
+        self, plugin_installer, valid_plugin_package
+    ):
+        """Test plugin manifests default to protocol version 1 when omitted."""
+        manifest = plugin_installer.validate_plugin_package(valid_plugin_package)
+        assert manifest.get("protocol_version", 1) == 1
+
+    def test_validate_plugin_directory_unsupported_protocol_version(
+        self, plugin_installer, tmp_path, valid_plugin_manifest
+    ):
+        """Test validating plugin directory with unsupported protocol version."""
+        plugin_dir = tmp_path / "invalid_plugin"
+        plugin_dir.mkdir()
+        manifest = {**valid_plugin_manifest, "protocol_version": 2}
+        (plugin_dir / "plugin.json").write_text(json.dumps(manifest))
+        (plugin_dir / "plugin.py").write_text("# Plugin code")
+
+        with pytest.raises(ValueError, match="Unsupported plugin.json protocol version"):
+            plugin_installer.validate_plugin_package(plugin_dir)
+
     def test_validate_plugin_directory_missing_manifest(self, plugin_installer, tmp_path):
         """Test validating plugin directory without plugin.json."""
         plugin_dir = tmp_path / "invalid_plugin"

--- a/backend/tests/unit/test_plugin_loader.py
+++ b/backend/tests/unit/test_plugin_loader.py
@@ -173,6 +173,26 @@ class TestPluginLoader:
             assert len(types) == 1
             assert types[0].type_id == "valid"
 
+    def test_get_plugin_types_skips_unsupported_protocol_versions(self, plugin_loader_instance):
+        """Test future protocol versions are skipped without breaking valid plugins."""
+        with patch("app.plugins.loader.plugin_manager") as mock_manager:
+            mock_manager.hook.register_plugin_types.return_value = [
+                [
+                    {"type_id": "valid", "plugin_type": PluginType.SERVICE, "name": "Valid"},
+                    {
+                        "protocol_version": 2,
+                        "type_id": "future",
+                        "plugin_type": PluginType.SERVICE,
+                        "name": "Future Plugin",
+                    },
+                ]
+            ]
+
+            types = plugin_loader_instance.get_plugin_types()
+
+            assert len(types) == 1
+            assert types[0].type_id == "valid"
+
     def test_create_plugin_instance(self, plugin_loader_instance):
         """Test creating a plugin instance."""
         mock_plugin = MagicMock()

--- a/backend/tests/unit/test_theme_installer.py
+++ b/backend/tests/unit/test_theme_installer.py
@@ -345,7 +345,9 @@ class TestThemeInstaller:
 
         # This should now fail (previously would have passed)
         with pytest.raises(ValueError, match="variables must be an object"):
-            theme_installer.validate_theme_package(zip_path)    def test_validate_theme_directory_unsupported_format_version(self, theme_installer, tmp_path):
+            theme_installer.validate_theme_package(zip_path)
+
+    def test_validate_theme_directory_unsupported_format_version(self, theme_installer, tmp_path):
         """Test validating theme directory with unsupported format version."""
         theme_dir = tmp_path / "invalid_theme"
         theme_dir.mkdir()

--- a/docs/plugins/PLUGIN_PACKAGE_FORMAT.md
+++ b/docs/plugins/PLUGIN_PACKAGE_FORMAT.md
@@ -12,14 +12,19 @@ The plugin package format is versioned to allow for future changes while maintai
 
 - **Repository Manifest (`plugins.json`)**: The `version` field specifies the manifest format version
 - **Plugin Manifest (`plugin.json`)**: The `format_version` field (optional) specifies the plugin manifest format version
+- **Plugin Protocol (`plugin.json` and runtime metadata)**: The `protocol_version` field specifies the Calvin plugin protocol the plugin targets
 
 If `format_version` is not specified in `plugin.json`, it defaults to `1.0.0` (the current format).
+If `protocol_version` is not specified, it defaults to `1` for backward compatibility.
 
 ### Version Compatibility
 
 - **Format 1.0.0**: Initial format specification
   - Supports all current features (dependencies, files, requirements, etc.)
   - All plugins without `format_version` are treated as 1.0.0
+- **Protocol 1**: Current Calvin plugin protocol
+  - Plugins without `protocol_version` are treated as protocol 1
+  - Calvin rejects plugins that declare a newer unsupported protocol version
 
 Future format versions will be documented here with migration guides.
 
@@ -331,7 +336,8 @@ Each plugin **must** have a `plugin.json` file in its root directory. This manif
   "id": "my_plugin",
   "name": "My Plugin",
   "version": "1.0.0",
-  "type": "service"
+  "type": "service",
+  "protocol_version": 1
 }
 ```
 
@@ -352,6 +358,11 @@ Each plugin **must** have a `plugin.json` file in its root directory. This manif
 
 - **`type`** (string, required): Plugin type
   - Must be one of: `"calendar"`, `"image"`, or `"service"`
+
+- **`protocol_version`** (integer, optional): Calvin plugin protocol version
+  - Defaults to `1` if not specified
+  - Should match the runtime plugin protocol the plugin was authored against
+  - Calvin currently supports protocol version `1`
 
 ### Format Version Field
 


### PR DESCRIPTION
Summary: make plugin protocol version explicit in Calvin core. Adds supported protocol version constants, rejects unsupported future protocol versions during plugin definition normalization, emits protocol_version from SDK metadata builders, validates optional protocol_version in plugin.json during install, updates plugin package format docs, and adds unit coverage for definitions, loader, and installer paths. Validation: uv run pytest tests/unit/test_plugin_definitions.py tests/unit/test_plugin_loader.py tests/unit/test_plugin_installer.py -> 46 passed.