### PR TITLE
Tighten CI and auto-open develop->main promotion PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,9 @@ jobs:
         working-directory: ./backend
         run: uv sync --extra dev
       
-      - name: Run Ruff linter (with auto-fix check)
+      - name: Run Ruff linter
         working-directory: ./backend
-        run: |
-          # First, try to auto-fix issues
-          uv run ruff check --fix . || true
-          # Then check if there are any remaining issues
-          uv run ruff check .
+        run: uv run ruff check .
       
       - name: Run Ruff formatter check
         working-directory: ./backend
@@ -50,7 +46,7 @@ jobs:
       
       - name: Run Bandit security linter
         working-directory: ./backend
-        run: uv run bandit -r app -f json -o bandit-report.json || true
+        run: uv run bandit -r app -ll
       
       - name: Run backend tests
         working-directory: ./backend

--- a/.github/workflows/promote-develop-to-main.yml
+++ b/.github/workflows/promote-develop-to-main.yml
@@ -1,0 +1,51 @@
+name: Promote develop to main
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [develop]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  open-promotion-pr:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Open or update develop -> main PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Skip if develop is not ahead of main.
+          ahead=$(git rev-list --count origin/main..origin/develop)
+          if [ "$ahead" -eq 0 ]; then
+            echo "develop is not ahead of main; nothing to promote."
+            exit 0
+          fi
+
+          existing=$(gh pr list --base main --head develop --state open --json number --jq '.[0].number // empty')
+
+          commits=$(git log --pretty=format:'- %h %s' origin/main..origin/develop)
+          body=$(printf '%s\n\n%s\n\n%s\n' \
+            "Auto-opened by \`promote-develop-to-main.yml\` after CI succeeded on \`develop\`." \
+            "**Commits ($ahead ahead of main):**" \
+            "$commits")
+
+          if [ -z "$existing" ]; then
+            gh pr create --base main --head develop \
+              --title "Promote develop to main" \
+              --body "$body"
+          else
+            echo "PR #$existing already open; updating body."
+            gh pr edit "$existing" --body "$body"
+          fi

--- a/backend/app/api/routes/system.py
+++ b/backend/app/api/routes/system.py
@@ -90,7 +90,7 @@ def _attempt_restart_calvin_service(service: str) -> bool:
 _UPDATE_LOG_LOCATIONS = [
     lambda: settings.repo_dir / "backend" / "logs" / "calvin-update.log",
     lambda: settings.repo_dir.parent / "calvin-update.log",
-    lambda: Path("/tmp/calvin-update.log"),
+    lambda: Path("/tmp/calvin-update.log"),  # nosec B108 - read-only fallback for log discovery
     lambda: Path("/var/log/calvin-update.log"),
 ]
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -16,7 +16,7 @@ class Settings(BaseSettings):
     debug: bool = True
 
     # API
-    api_host: str = "0.0.0.0"
+    api_host: str = "0.0.0.0"  # nosec B104 - intentional: Pi serves the LAN
     api_port: int = 8000
 
     # Database

--- a/backend/app/plugins/calendar/google.py
+++ b/backend/app/plugins/calendar/google.py
@@ -296,7 +296,7 @@ async def handle_plugin_config_update(
         ical_url = extract_config_value(c, "ical_url", converter=to_str)
         if ical_url:
             # Generate hash from URL (same instance for same URL)
-            url_hash = hashlib.md5(ical_url.encode()).hexdigest()[:8]
+            url_hash = hashlib.md5(ical_url.encode(), usedforsecurity=False).hexdigest()[:8]
             return f"{t}-{url_hash}"
         # Fallback ID if URL not available
         return f"{t}-instance"

--- a/backend/app/plugins/calendar/ical.py
+++ b/backend/app/plugins/calendar/ical.py
@@ -239,7 +239,7 @@ async def handle_plugin_config_update(
         ical_url = extract_config_value(c, "ical_url", converter=to_str)
         if ical_url:
             # Generate hash from URL (same instance for same URL)
-            url_hash = hashlib.md5(ical_url.encode()).hexdigest()[:8]
+            url_hash = hashlib.md5(ical_url.encode(), usedforsecurity=False).hexdigest()[:8]
             return f"{t}-{url_hash}"
         # Fallback ID if URL not available
         return f"{t}-instance"

--- a/backend/app/plugins/image/local.py
+++ b/backend/app/plugins/image/local.py
@@ -221,7 +221,9 @@ class LocalImagePlugin(ImagePlugin):
                         file_size = file_path.stat().st_size
 
                         # Generate image ID from file path hash
-                        image_id = hashlib.md5(str(file_path).encode()).hexdigest()
+                        image_id = hashlib.md5(
+                            str(file_path).encode(), usedforsecurity=False
+                        ).hexdigest()
 
                         # Generate thumbnail if it doesn't exist
                         thumbnail_path = self._get_thumbnail_path(image_id)
@@ -306,7 +308,7 @@ class LocalImagePlugin(ImagePlugin):
             await self.scan_images()
 
             # Return the new image
-            image_id = hashlib.md5(str(file_path).encode()).hexdigest()
+            image_id = hashlib.md5(str(file_path).encode(), usedforsecurity=False).hexdigest()
             return await self.get_image(image_id)
         except Exception:
             logger.exception("Error uploading image {}", filename)

--- a/backend/app/plugins/service/iframe.py
+++ b/backend/app/plugins/service/iframe.py
@@ -219,7 +219,7 @@ async def handle_plugin_config_update(
         url = extract_config_value(c, "url", converter=to_str)
         if url:
             # Generate hash from URL (same instance for same URL)
-            url_hash = hashlib.md5(url.encode()).hexdigest()[:8]
+            url_hash = hashlib.md5(url.encode(), usedforsecurity=False).hexdigest()[:8]
             return f"{t}-{url_hash}"
         # Fallback ID if URL not available
         return f"{t}-instance"

--- a/backend/app/plugins/utils/instance_manager.py
+++ b/backend/app/plugins/utils/instance_manager.py
@@ -209,7 +209,9 @@ async def handle_plugin_config_update_generic(
                 import hashlib
 
                 config_str = str(sorted(config.items()))
-                config_hash = hashlib.md5(config_str.encode()).hexdigest()[:8]
+                config_hash = hashlib.md5(config_str.encode(), usedforsecurity=False).hexdigest()[
+                    :8
+                ]
                 plugin_instance_id = f"{type_id}-{config_hash}"
 
         # Ensure uniqueness


### PR DESCRIPTION
## Summary
- Drop `|| true` bypasses (ruff auto-fix, bandit) so a green CI run actually means all checks passed.
- Resolve bandit findings: `usedforsecurity=False` on 6 MD5 calls used as non-security IDs (B324); `# nosec` on the read-only `/tmp` log fallback (B108) and intentional `0.0.0.0` bind (B104). Bandit now runs at `-ll` to gate on medium+ findings.
- Add `.github/workflows/promote-develop-to-main.yml`: when CI succeeds on `develop`, auto-open (or refresh) a PR `develop -> main`. No auto-merge — you still click merge.

## Test plan
- [ ] CI passes on this PR (proves tightened checks are actually green).
- [ ] After merge to `develop`, confirm the new workflow fires on the next push and opens a PR titled "Promote develop to main" with base=`main`, head=`develop`.
- [ ] Push another commit to `develop`; confirm the existing PR auto-includes it (no duplicate).
- [ ] Merge that PR; confirm `build-frontend-release.yml` cuts a `stable-*` release as expected.