### PR TITLE
Build develop docker images nightly, not per-push

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,13 +4,15 @@ on:
   push:
     branches:
       - main
-      - develop
     tags:
       - 'v*'
   pull_request:
     branches:
       - main
       - develop
+  schedule:
+    # Nightly multi-arch image from develop at 03:00 UTC
+    - cron: '0 3 * * *'
   workflow_dispatch:
     inputs:
       push_images:
@@ -27,6 +29,8 @@ jobs:
   changes:
     name: Detect Changes
     runs-on: ubuntu-latest
+    # Schedule always builds (nightly develop); skip path filtering.
+    if: github.event_name != 'schedule'
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
@@ -70,8 +74,8 @@ jobs:
     name: Build Backend Image
     runs-on: ubuntu-latest
     needs: changes
-    # Always run on tags, manual dispatch, or if backend files changed
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || needs.changes.outputs.backend == 'true'
+    # Always run on schedule (nightly develop), tags, manual dispatch, or if backend files changed
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/') || needs.changes.outputs.backend == 'true') }}
     permissions:
       contents: read
       packages: write
@@ -79,12 +83,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # On schedule events, github.ref is the default branch (main); we want develop.
+          ref: ${{ github.event_name == 'schedule' && 'develop' || github.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Container Registry
-        if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/') || github.event.inputs.push_images == 'true')
+        if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/') || github.event.inputs.push_images == 'true')
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -101,7 +108,9 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            type=raw,value=develop,enable=${{ github.event_name == 'schedule' }}
+            type=raw,value=nightly,enable=${{ github.event_name == 'schedule' }}
 
       - name: Build and push backend image
         id: build-backend
@@ -109,8 +118,9 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile.backend-prod
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/') || github.event.inputs.push_images == 'true') }}
+          # Multi-arch only when pushing; PR validation builds amd64 only to stay fast.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/arm/v7' }}
+          push: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/') || github.event.inputs.push_images == 'true') }}
           tags: ${{ steps.meta-backend.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -122,8 +132,8 @@ jobs:
     name: Build Frontend Image
     runs-on: ubuntu-latest
     needs: changes
-    # Always run on tags, manual dispatch, or if frontend files changed
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/') || needs.changes.outputs.frontend == 'true'
+    # Always run on schedule (nightly develop), tags, manual dispatch, or if frontend files changed
+    if: ${{ always() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/') || needs.changes.outputs.frontend == 'true') }}
     permissions:
       contents: read
       packages: write
@@ -131,12 +141,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # On schedule events, github.ref is the default branch (main); we want develop.
+          ref: ${{ github.event_name == 'schedule' && 'develop' || github.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Container Registry
-        if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/') || github.event.inputs.push_images == 'true')
+        if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/') || github.event.inputs.push_images == 'true')
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -153,7 +166,9 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            type=raw,value=develop,enable=${{ github.event_name == 'schedule' }}
+            type=raw,value=nightly,enable=${{ github.event_name == 'schedule' }}
 
       - name: Build and push frontend image
         id: build-frontend
@@ -163,8 +178,9 @@ jobs:
           file: docker/Dockerfile.frontend-prod
           build-args: |
             VITE_API_URL=/api
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/') || github.event.inputs.push_images == 'true') }}
+          # Multi-arch only when pushing; PR validation builds amd64 only to stay fast.
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/arm/v7' }}
+          push: ${{ github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/') || github.event.inputs.push_images == 'true') }}
           tags: ${{ steps.meta-frontend.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Drop `develop` from `push:` triggers in [docker-build.yml](.github/workflows/docker-build.yml). Multi-arch image builds (~3 platforms) no longer run on every develop push.
- Add `schedule:` cron at 03:00 UTC: nightly build that checks out `develop` and pushes `:develop` / `:nightly` tags.
- PR validation builds `linux/amd64` only — multi-arch reserved for pushes/schedule/tags. Faster PR checks.
- `:latest` tag now only fires on `push` to `main` (was `is_default_branch`, which would have incorrectly tagged the schedule-built develop image as `latest`).

## Notes
- Builds run unconditionally on schedule (the `changes` job is skipped, build jobs use `always()`).
- `build-frontend-release.yml` (tarball releases) is unchanged — it's cheap; nightly tarballs from develop continue.

## Test plan
- [ ] Open this PR → CI's docker build runs `linux/amd64` only and does not push (verify in logs).
- [ ] After merging to `develop`, push to develop should NOT trigger docker-build.yml.
- [ ] Wait for the next 03:00 UTC schedule (or `gh workflow run "Build and Push Docker Images"`) — confirm a build runs against `develop` HEAD and pushes `:develop` + `:nightly` tags.
- [ ] Confirm a subsequent merge to `main` still pushes `:main` + `:latest` and full multi-arch.