### PR TITLE
Remove FrontendBuildManager — no host rebuild on plugin install

### DIFF
--- a/backend/app/api/routes/plugins/github.py
+++ b/backend/app/api/routes/plugins/github.py
@@ -14,7 +14,7 @@ from fastapi import APIRouter, Body, HTTPException
 from app.api.routes.plugins.themes import _register_theme_in_db
 from app.config import settings
 from app.plugins.loader import plugin_loader
-from app.services.plugin_installer import frontend_build_manager, plugin_installer
+from app.services.plugin_installer import plugin_installer
 from app.services.theme_installer import theme_installer
 
 logger = logging.getLogger(__name__)
@@ -296,10 +296,6 @@ async def install_plugin_from_github(request: dict[str, Any] = Body(...)):
                     # It just needs a restart to be loaded
 
                 actual_branch = "master" if branch_switched else branch
-                if manifest.get("_has_frontend"):
-                    frontend_build_manager.start_background_build(
-                        plugin_installer.get_frontend_dir()
-                    )
                 return {
                     "success": True,
                     "message": f"Plugin {manifest['id']} installed successfully from {repo_url}",
@@ -307,7 +303,7 @@ async def install_plugin_from_github(request: dict[str, Any] = Body(...)):
                     "branch": actual_branch,
                     "branch_switched": branch_switched,
                     "requires_restart": True,
-                    "frontend_rebuild_in_progress": manifest.get("_has_frontend", False),
+                    "frontend_rebuild_in_progress": False,
                 }
             else:
                 raise HTTPException(
@@ -477,14 +473,12 @@ async def install_plugin_from_local(request: dict[str, Any] = Body(...)):
                     "It will be available after server restart."
                 )
 
-            if manifest.get("_has_frontend"):
-                frontend_build_manager.start_background_build(plugin_installer.get_frontend_dir())
             return {
                 "success": True,
                 "message": f"Plugin {manifest['id']} installed successfully",
                 "manifest": manifest,
                 "requires_restart": True,
-                "frontend_rebuild_in_progress": manifest.get("_has_frontend", False),
+                "frontend_rebuild_in_progress": False,
             }
         else:
             raise HTTPException(

--- a/backend/app/api/routes/plugins/management.py
+++ b/backend/app/api/routes/plugins/management.py
@@ -21,7 +21,7 @@ from app.plugins.loader import plugin_loader
 from app.plugins.manager import plugin_manager
 from app.services.config_service import config_service
 from app.services.event_system import event_system
-from app.services.plugin_installer import frontend_build_manager, plugin_installer
+from app.services.plugin_installer import plugin_installer
 from app.services.theme_installer import theme_installer
 
 from .config import normalize_plugin_config
@@ -32,11 +32,6 @@ router = APIRouter()
 # Cross-cutting type-level keys that all plugins support, regardless of
 # whether they declare them in their own common_config_schema.
 UNIVERSAL_TYPE_CONFIG_KEYS = frozenset({"display_order"})
-
-
-class RebuildStatusResponse(BaseModel):
-    state: str
-    message: str
 
 
 class PluginManifestEnvelope(BaseModel):
@@ -241,15 +236,6 @@ async def get_plugins(
 
 
 # Specific routes must come before parameterized routes to avoid path conflicts
-@router.get("/plugins/rebuild-status", response_model=RebuildStatusResponse)
-async def get_rebuild_status():
-    """Return the current state of a background frontend rebuild."""
-    return {
-        "state": frontend_build_manager.state,
-        "message": frontend_build_manager.message,
-    }
-
-
 @router.get("/plugins/installed", response_model=PluginListResponse)
 async def get_installed_plugins():
     """
@@ -359,15 +345,12 @@ async def install_plugin(
                     f"Failed to emit plugin_installed event for plugin {manifest['id']}: {e}"
                 )
 
-            if manifest.get("_has_frontend"):
-                frontend_build_manager.start_background_build(plugin_installer.get_frontend_dir())
-
             return {
                 "success": True,
                 "message": f"Plugin {manifest['id']} installed successfully",
                 "manifest": manifest,
                 "requires_restart": True,
-                "frontend_rebuild_in_progress": manifest.get("_has_frontend", False),
+                "frontend_rebuild_in_progress": False,
             }
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
@@ -449,7 +432,6 @@ async def uninstall_plugin(plugin_id: str):
             }
         else:
             # Uninstall regular plugin
-            had_frontend = plugin_installer.get_frontend_plugin_path(plugin_id).exists()
             plugin_installer.uninstall_plugin(plugin_id)
 
             # Stop and delete all instances of this plugin type
@@ -499,9 +481,6 @@ async def uninstall_plugin(plugin_id: str):
                 if not m.startswith(f"installed_plugin_{plugin_id}")
             }
 
-            if had_frontend:
-                frontend_build_manager.start_background_build(plugin_installer.get_frontend_dir())
-
             # Emit plugin_uninstalled event
             try:
                 await event_system.emit_event(
@@ -523,7 +502,7 @@ async def uninstall_plugin(plugin_id: str):
             return {
                 "success": True,
                 "message": f"Plugin {plugin_id} uninstalled successfully",
-                "frontend_rebuild_in_progress": had_frontend,
+                "frontend_rebuild_in_progress": False,
             }
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))

--- a/backend/app/services/plugin_installer.py
+++ b/backend/app/services/plugin_installer.py
@@ -5,7 +5,6 @@ import logging
 import shutil
 import subprocess
 import sys
-import threading
 import zipfile
 from pathlib import Path
 from typing import Any
@@ -25,88 +24,6 @@ from app.services.validation import (
 logger = logging.getLogger(__name__)
 
 
-class FrontendBuildManager:
-    """Manages `npm run build` for plugin frontend components.
-
-    Runs builds in a background thread so install endpoints can return immediately.
-    Poll `state` / `message` for progress.
-    """
-
-    def __init__(self):
-        self._lock = threading.Lock()
-        self._state = "idle"  # idle | building | done | failed
-        self._message = ""
-
-    @property
-    def state(self) -> str:
-        with self._lock:
-            return self._state
-
-    @property
-    def message(self) -> str:
-        with self._lock:
-            return self._message
-
-    def start_background_build(self, frontend_dir: Path) -> None:
-        """Kick off a build in a daemon thread. Returns immediately."""
-        with self._lock:
-            if self._state == "building":
-                return  # already in progress
-            self._state = "building"
-            self._message = "Building frontend, this may take a minute…"
-        thread = threading.Thread(target=self._run_build, args=(frontend_dir,), daemon=True)
-        thread.start()
-
-    def _run_build(self, frontend_dir: Path) -> None:
-        success, message = self._build(frontend_dir)
-        with self._lock:
-            self._state = "done" if success else "failed"
-            self._message = message
-
-    def _build(self, frontend_dir: Path) -> tuple[bool, str]:
-        npm = shutil.which("npm")
-        if not npm:
-            return False, "npm not found — rebuild the frontend manually with: npm run build"
-
-        # On Windows, .cmd files can't be executed by CreateProcess directly —
-        # they need cmd.exe as the interpreter.
-        if sys.platform == "win32":
-            cmd = ["cmd", "/c", npm, "run", "build"]
-        else:
-            cmd = [npm, "run", "build"]
-
-        try:
-            result = subprocess.run(
-                cmd,
-                cwd=str(frontend_dir),
-                capture_output=True,
-                text=True,
-                timeout=300,
-            )
-            if result.returncode == 0:
-                return True, "Frontend rebuilt successfully."
-            tail = (result.stderr or result.stdout or "unknown error")[-500:]
-            return False, f"Frontend rebuild failed: {tail}"
-        except subprocess.TimeoutExpired:
-            return False, "Frontend rebuild timed out (5 min limit)"
-        except Exception as exc:
-            return False, f"Frontend rebuild failed: {exc}"
-
-    # Keep synchronous variant for callers that need to wait (e.g. startup resume)
-    def build(self, frontend_dir: Path) -> tuple[bool, str]:
-        with self._lock:
-            self._state = "building"
-            self._message = "Building frontend…"
-        success, message = self._build(frontend_dir)
-        with self._lock:
-            self._state = "done" if success else "failed"
-            self._message = message
-        return success, message
-
-
-frontend_build_manager = FrontendBuildManager()
-
-
 class PluginInstaller:
     """Service for installing, updating, and uninstalling plugins."""
 
@@ -115,13 +32,6 @@ class PluginInstaller:
         # Plugin installation directory (from config)
         self.plugins_dir = settings.plugins_dir.resolve()
         self.plugins_dir.mkdir(parents=True, exist_ok=True)
-
-        # Frontend plugins directory (relative to backend directory)
-        # Backend is typically in backend/, frontend is in frontend/
-        backend_dir = Path(__file__).parent.parent.parent
-        frontend_dir = backend_dir.parent / "frontend"
-        self.frontend_plugins_dir = frontend_dir / "src" / "components" / "plugins"
-        self.frontend_plugins_dir.mkdir(parents=True, exist_ok=True)
 
     def get_plugin_path(self, plugin_id: str) -> Path:
         """
@@ -134,22 +44,6 @@ class PluginInstaller:
             Path to plugin directory
         """
         return self.plugins_dir / plugin_id
-
-    def get_frontend_plugin_path(self, plugin_id: str) -> Path:
-        """
-        Get the frontend path for a plugin's components.
-
-        Args:
-            plugin_id: Plugin identifier
-
-        Returns:
-            Path to frontend plugin directory
-        """
-        return self.frontend_plugins_dir / plugin_id
-
-    def get_frontend_dir(self) -> Path:
-        """Return the root of the frontend source tree (frontend/)."""
-        return self.frontend_plugins_dir.parents[2]
 
     def validate_plugin_package(self, plugin_path: Path) -> dict[str, Any]:
         """
@@ -356,14 +250,11 @@ class PluginInstaller:
                 else:
                     raise ValueError(f"Invalid source path: {source_path}")
 
-            # Install frontend components if they exist
-            frontend_source = plugin_path / "frontend"
-            if frontend_source.exists():
-                frontend_dest = self.get_frontend_plugin_path(install_id)
-                if frontend_dest.exists():
-                    shutil.rmtree(frontend_dest)
-                shutil.copytree(frontend_source, frontend_dest)
-                manifest["_has_frontend"] = True
+            # Frontend assets stay inside the plugin's data directory; the
+            # host serves them through /api/plugins/{id}/static/* and either
+            # picks them up via display_schema (kind=...) or imports a
+            # built ESM module (kind=web-component). No copy into the host
+            # source tree, no rebuild required.
 
             # Install plugin-specific Python packages
             installed_packages = self._install_pip_requirements(manifest)
@@ -382,9 +273,6 @@ class PluginInstaller:
             # doesn't mask the real install error.
             if plugin_path.exists():
                 shutil.rmtree(plugin_path, ignore_errors=True)
-            frontend_path = self.get_frontend_plugin_path(install_id)
-            if frontend_path.exists():
-                shutil.rmtree(frontend_path, ignore_errors=True)
             raise ValueError(f"Failed to install plugin: {e}") from e
 
     def _install_pip_requirements(self, manifest: dict[str, Any]) -> list[str]:
@@ -476,13 +364,8 @@ class PluginInstaller:
         if not plugin_path.exists():
             raise ValueError(f"Plugin {plugin_id} is not installed")
 
-        # Remove plugin directory
+        # Remove plugin directory (frontend assets live inside it, so they go too)
         shutil.rmtree(plugin_path)
-
-        # Remove frontend components
-        frontend_path = self.get_frontend_plugin_path(plugin_id)
-        if frontend_path.exists():
-            shutil.rmtree(frontend_path)
 
     def get_installed_plugins(self) -> list[dict[str, Any]]:
         """
@@ -705,10 +588,6 @@ class PluginInstaller:
                     "removing and allowing reinstallation"
                 )
                 shutil.rmtree(plugin_path)
-                # Also clean up frontend directory if it exists
-                frontend_path = self.get_frontend_plugin_path(install_id)
-                if frontend_path.exists():
-                    shutil.rmtree(frontend_path)
 
         # Install from directory
         return self.install_plugin(plugin_dir, install_id, check_version=True, force=False)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -398,14 +398,6 @@ def temp_plugins_dir(tmp_path):
 
 
 @pytest.fixture
-def temp_frontend_dir(tmp_path):
-    """Create a temporary frontend directory."""
-    frontend_dir = tmp_path / "frontend" / "src" / "components" / "plugins"
-    frontend_dir.mkdir(parents=True)
-    return frontend_dir
-
-
-@pytest.fixture
 def temp_themes_dir(tmp_path):
     """Create a temporary themes directory."""
     themes_dir = tmp_path / "themes"
@@ -414,23 +406,18 @@ def temp_themes_dir(tmp_path):
 
 
 @pytest.fixture(autouse=True)
-def patch_data_directories(
-    monkeypatch, tmp_path, temp_plugins_dir, temp_frontend_dir, temp_themes_dir
-):
+def patch_data_directories(monkeypatch, tmp_path, temp_plugins_dir, temp_themes_dir):
     """Patch plugin/theme installers to write under tmp_path so tests don't touch real data."""
     from app.services.plugin_installer import plugin_installer
     from app.services.theme_installer import theme_installer
 
     original_plugins_dir = plugin_installer.plugins_dir
-    original_frontend_dir = plugin_installer.frontend_plugins_dir
     original_themes_dir = theme_installer.themes_dir
 
     plugin_installer.plugins_dir = temp_plugins_dir
-    plugin_installer.frontend_plugins_dir = temp_frontend_dir
     theme_installer.themes_dir = temp_themes_dir
 
     yield
 
     plugin_installer.plugins_dir = original_plugins_dir
-    plugin_installer.frontend_plugins_dir = original_frontend_dir
     theme_installer.themes_dir = original_themes_dir

--- a/backend/tests/contract/openapi.json
+++ b/backend/tests/contract/openapi.json
@@ -1065,24 +1065,6 @@
         "title": "PluginTypeConfigUpdateResponse",
         "type": "object"
       },
-      "RebuildStatusResponse": {
-        "properties": {
-          "message": {
-            "title": "Message",
-            "type": "string"
-          },
-          "state": {
-            "title": "State",
-            "type": "string"
-          }
-        },
-        "required": [
-          "state",
-          "message"
-        ],
-        "title": "RebuildStatusResponse",
-        "type": "object"
-      },
       "ValidationError": {
         "properties": {
           "loc": {
@@ -2701,28 +2683,6 @@
           }
         },
         "summary": "Suggest Local Plugin Paths",
-        "tags": [
-          "plugins"
-        ]
-      }
-    },
-    "/api/plugins/rebuild-status": {
-      "get": {
-        "description": "Return the current state of a background frontend rebuild.",
-        "operationId": "get_rebuild_status_api_plugins_rebuild_status_get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RebuildStatusResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "Get Rebuild Status",
         "tags": [
           "plugins"
         ]

--- a/backend/tests/e2e/test_github_plugin_e2e.py
+++ b/backend/tests/e2e/test_github_plugin_e2e.py
@@ -227,10 +227,8 @@ class TestGitHubPluginE2E:
         install_data = install_response.json()
         assert install_data["success"] is True
 
-        # Check if frontend components were installed (if the plugin has them)
-        # Frontend might or might not exist - just verify the path structure is correct
-        # In a real test, you'd know which plugins have frontend components
-        plugin_installer.get_frontend_plugin_path(plugin_id)  # Verify path exists
+        # Frontend assets (if any) live inside the plugin's data dir under
+        # frontend/. The host serves them via /api/plugins/{id}/static/*.
 
         # Cleanup
         try:

--- a/backend/tests/integration/test_api_plugins.py
+++ b/backend/tests/integration/test_api_plugins.py
@@ -290,10 +290,10 @@ def register_plugin_types() -> list[dict[str, Any]]:
         # Install plugin
         plugin_installer.install_plugin(plugin_dir)
 
-        # Verify frontend component was installed
-        frontend_path = plugin_installer.get_frontend_plugin_path("test_frontend_plugin")
-        assert frontend_path.exists()
-        assert (frontend_path / "TestComponent.vue").exists()
+        # Verify frontend asset is stored inside the plugin's data dir
+        # (the host serves these via /api/plugins/{id}/static/*).
+        plugin_path = plugin_installer.get_plugin_path("test_frontend_plugin")
+        assert (plugin_path / "frontend" / "TestComponent.vue").exists()
 
 
 @pytest.mark.integration

--- a/backend/tests/integration/test_api_plugins_github.py
+++ b/backend/tests/integration/test_api_plugins_github.py
@@ -740,19 +740,16 @@ class TestPluginUninstallAPI:
 
         plugin_installer.install_plugin(plugin_dir)
 
-        # Verify frontend exists
-        frontend_path = plugin_installer.get_frontend_plugin_path("test_uninstall_frontend")
-        assert frontend_path.exists()
+        plugin_path = plugin_installer.get_plugin_path("test_uninstall_frontend")
+        assert (plugin_path / "frontend").exists()
 
         # Uninstall via API
         response = test_client.delete("/api/plugins/installed/test_uninstall_frontend")
 
         assert response.status_code == 200
 
-        # Verify both plugin and frontend are removed
-        plugin_path = plugin_installer.get_plugin_path("test_uninstall_frontend")
+        # Plugin dir (and its frontend assets) gone
         assert not plugin_path.exists()
-        assert not frontend_path.exists()
 
     def test_uninstall_plugin_not_found(self, test_client):
         """Test uninstalling a non-existent plugin."""

--- a/backend/tests/unit/test_plugin_installer.py
+++ b/backend/tests/unit/test_plugin_installer.py
@@ -17,20 +17,10 @@ def temp_plugins_dir(tmp_path):
 
 
 @pytest.fixture
-def temp_frontend_dir(tmp_path):
-    """Create a temporary frontend directory."""
-    frontend_dir = tmp_path / "frontend" / "src" / "components" / "plugins"
-    frontend_dir.mkdir(parents=True)
-    return frontend_dir
-
-
-@pytest.fixture
-def plugin_installer(temp_plugins_dir, temp_frontend_dir, monkeypatch):
+def plugin_installer(temp_plugins_dir, monkeypatch):
     """Create a PluginInstaller instance with temporary directories."""
     installer = PluginInstaller()
-    # Override directories with temp paths
     installer.plugins_dir = temp_plugins_dir
-    installer.frontend_plugins_dir = temp_frontend_dir
     return installer
 
 
@@ -109,11 +99,6 @@ class TestPluginInstaller:
         """Test getting plugin path."""
         path = plugin_installer.get_plugin_path("test_plugin")
         assert path == plugin_installer.plugins_dir / "test_plugin"
-
-    def test_get_frontend_plugin_path(self, plugin_installer):
-        """Test getting frontend plugin path."""
-        path = plugin_installer.get_frontend_plugin_path("test_plugin")
-        assert path == plugin_installer.frontend_plugins_dir / "test_plugin"
 
     def test_validate_plugin_directory_valid(self, plugin_installer, valid_plugin_package):
         """Test validating a valid plugin directory."""
@@ -257,13 +242,13 @@ class TestPluginInstaller:
     def test_install_plugin_with_frontend_components(
         self, plugin_installer, plugin_package_with_frontend
     ):
-        """Test installing a plugin with frontend components."""
+        """Frontend assets stay inside the plugin's data dir; the host serves
+        them through /api/plugins/{id}/static/*. Nothing gets copied into the
+        host source tree."""
         plugin_installer.install_plugin(plugin_package_with_frontend)
 
-        # Check frontend components were installed
-        frontend_path = plugin_installer.get_frontend_plugin_path("test_plugin")
-        assert frontend_path.exists()
-        assert (frontend_path / "TestComponent.vue").exists()
+        plugin_path = plugin_installer.get_plugin_path("test_plugin")
+        assert (plugin_path / "frontend" / "TestComponent.vue").exists()
 
     def test_install_plugin_cleanup_on_error(self, plugin_installer, tmp_path):
         """Test that plugin installation is cleaned up on error."""
@@ -293,15 +278,15 @@ class TestPluginInstaller:
         assert not plugin_path.exists()
 
     def test_uninstall_plugin_with_frontend(self, plugin_installer, plugin_package_with_frontend):
-        """Test uninstalling a plugin with frontend components."""
+        """Uninstalling removes the plugin dir, which contains its frontend assets."""
         plugin_installer.install_plugin(plugin_package_with_frontend)
 
-        frontend_path = plugin_installer.get_frontend_plugin_path("test_plugin")
-        assert frontend_path.exists()
+        plugin_path = plugin_installer.get_plugin_path("test_plugin")
+        assert (plugin_path / "frontend").exists()
 
         plugin_installer.uninstall_plugin("test_plugin")
 
-        assert not frontend_path.exists()
+        assert not plugin_path.exists()
 
     def test_uninstall_plugin_not_installed(self, plugin_installer):
         """Test uninstalling a plugin that's not installed."""

--- a/backend/tests/unit/test_plugin_installer_github.py
+++ b/backend/tests/unit/test_plugin_installer_github.py
@@ -8,11 +8,10 @@ from app.services.plugin_installer import PluginInstaller
 
 
 @pytest.fixture
-def plugin_installer(temp_plugins_dir, temp_frontend_dir, monkeypatch):
+def plugin_installer(temp_plugins_dir, monkeypatch):
     """Create a PluginInstaller instance with temporary directories."""
     installer = PluginInstaller()
     installer.plugins_dir = temp_plugins_dir
-    installer.frontend_plugins_dir = temp_frontend_dir
     return installer
 
 
@@ -351,10 +350,10 @@ class TestPluginInstallFromRepo:
 
         assert manifest["id"] == "plugin2"
 
-        # Check frontend components were installed
-        frontend_path = plugin_installer.get_frontend_plugin_path("plugin2")
-        assert frontend_path.exists()
-        assert (frontend_path / "Component.vue").exists()
+        # Frontend assets stay inside the plugin's data dir (host serves them
+        # via /api/plugins/{id}/static/*).
+        plugin_path = plugin_installer.get_plugin_path("plugin2")
+        assert (plugin_path / "frontend" / "Component.vue").exists()
 
     def test_install_plugin_from_repo_path_traversal_protection(
         self, plugin_installer, mock_repo_structure

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -906,26 +906,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/plugins/rebuild-status": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get Rebuild Status
-         * @description Return the current state of a background frontend rebuild.
-         */
-        get: operations["get_rebuild_status_api_plugins_rebuild_status_get"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/api/plugins/{plugin_id}": {
         parameters: {
             query?: never;
@@ -1858,13 +1838,6 @@ export interface components {
             plugin_id: string;
             /** Success */
             success: boolean;
-        };
-        /** RebuildStatusResponse */
-        RebuildStatusResponse: {
-            /** Message */
-            message: string;
-            /** State */
-            state: string;
         };
         /** ValidationError */
         ValidationError: {
@@ -3073,26 +3046,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
-                };
-            };
-        };
-    };
-    get_rebuild_status_api_plugins_rebuild_status_get: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["RebuildStatusResponse"];
                 };
             };
         };

--- a/frontend/src/components/settings/categories/PluginsCategory.vue
+++ b/frontend/src/components/settings/categories/PluginsCategory.vue
@@ -14,8 +14,6 @@
         :branch-switched="pluginBranchSwitched"
         :actual-branch="pluginActualBranch"
         :dev-mode="configStore.devMode"
-        :rebuild-status="rebuildStatus"
-        :rebuild-message="rebuildMessage"
         @update:repoUrl="githubRepoUrl = $event"
         @update:branch="githubBranch = $event"
         @zip-select="handleZipSelect"
@@ -120,7 +118,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from "vue";
+import { ref, computed, onMounted } from "vue";
 import { usePlugins } from "@/composables";
 import { useSystem } from "@/composables";
 import { useConfigStore } from "@/stores/config";
@@ -148,7 +146,6 @@ const {
   pluginRequiresRestart,
   pluginBranchSwitched,
   pluginActualBranch,
-  pluginFrontendRebuildResult,
   expandedPlugins,
   pluginFormData,
   savingPlugin,
@@ -216,25 +213,6 @@ const cancelPipInstall = () => {
   showPipWarningModal.value = false;
   pendingInstallAction.value = null;
 };
-
-// Frontend rebuild banner
-const rebuildStatus = ref("idle"); // idle | building | done | error
-const rebuildMessage = ref("");
-
-watch(pluginFrontendRebuildResult, result => {
-  if (!result) return;
-  if (result.building) {
-    rebuildStatus.value = "building";
-    rebuildMessage.value = result.message || "Building frontend…";
-  } else {
-    rebuildStatus.value = result.success ? "done" : "error";
-    rebuildMessage.value =
-      result.message ||
-      (result.success
-        ? "Frontend rebuilt — refresh the page to load new plugin components."
-        : "Frontend rebuild failed — rebuild manually with: npm run build");
-  }
-});
 
 // Handlers
 const handleZipSelect = async file => {

--- a/frontend/src/components/settings/specialized/PluginInstaller.vue
+++ b/frontend/src/components/settings/specialized/PluginInstaller.vue
@@ -348,18 +348,6 @@
       </div>
     </div>
 
-    <!-- Frontend Rebuild Progress -->
-    <div
-      v-if="rebuildStatus !== 'idle'"
-      :class="['rebuild-status', `rebuild-status--${rebuildStatus}`]"
-    >
-      <span v-if="rebuildStatus === 'building'" class="rebuild-spinner" aria-hidden="true"></span>
-      <span class="rebuild-status-text">{{ rebuildMessage }}</span>
-      <button v-if="rebuildStatus === 'done'" class="btn-refresh-inline" @click="handleRefresh">
-        Refresh Now
-      </button>
-    </div>
-
     <!-- Restart Required Notice -->
     <div v-if="requiresRestart" class="restart-notice">
       <div class="restart-notice-content">
@@ -436,14 +424,6 @@ const props = defineProps({
   devMode: {
     type: Boolean,
     default: false,
-  },
-  rebuildStatus: {
-    type: String,
-    default: "idle", // idle | building | done | error
-  },
-  rebuildMessage: {
-    type: String,
-    default: "",
   },
 });
 
@@ -662,10 +642,6 @@ const handleForceUpdate = pluginPath => {
 
 const handleRestart = () => {
   emit("restart");
-};
-
-const handleRefresh = () => {
-  window.location.reload();
 };
 
 const handleRepoUrlInput = event => {
@@ -1106,72 +1082,6 @@ watch(searchQuery, () => {
   opacity: 0.6;
   cursor: not-allowed;
   transform: none;
-}
-
-.rebuild-status {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  margin-top: 1rem;
-  padding: 0.75rem 1rem;
-  border-radius: 6px;
-  font-size: 0.875rem;
-}
-
-.rebuild-status--building {
-  background: rgba(59, 130, 246, 0.12);
-  border: 1px solid rgba(59, 130, 246, 0.35);
-  color: #3b82f6;
-}
-
-.rebuild-status--done {
-  background: rgba(34, 197, 94, 0.12);
-  border: 1px solid rgba(34, 197, 94, 0.35);
-  color: #22c55e;
-}
-
-.rebuild-status--error {
-  background: rgba(239, 68, 68, 0.12);
-  border: 1px solid rgba(239, 68, 68, 0.35);
-  color: #ef4444;
-}
-
-.rebuild-spinner {
-  width: 14px;
-  height: 14px;
-  border: 2px solid currentColor;
-  border-top-color: transparent;
-  border-radius: 50%;
-  animation: rebuild-spin 0.8s linear infinite;
-  flex-shrink: 0;
-  opacity: 0.7;
-}
-
-@keyframes rebuild-spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-.rebuild-status-text {
-  flex: 1;
-}
-
-.btn-refresh-inline {
-  padding: 0.25rem 0.625rem;
-  background: rgba(34, 197, 94, 0.15);
-  color: inherit;
-  border: 1px solid currentColor;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 0.8rem;
-  font-weight: 600;
-  white-space: nowrap;
-  transition: background 0.2s;
-}
-
-.btn-refresh-inline:hover {
-  background: rgba(34, 197, 94, 0.3);
 }
 
 .error-message {

--- a/frontend/src/composables/usePlugins.js
+++ b/frontend/src/composables/usePlugins.js
@@ -26,7 +26,6 @@ const pluginInstallSuccess = ref("");
 const pluginRequiresRestart = ref(false);
 const pluginBranchSwitched = ref(false);
 const pluginActualBranch = ref("");
-const pluginFrontendRebuildResult = ref(null); // null | { success: bool, message: str }
 const expandedPlugins = ref({});
 const pluginFormData = ref({});
 const savingPlugin = ref(null);
@@ -59,42 +58,6 @@ const sortedPluginCategories = computed(() => {
 
   return categories.filter(c => c.plugins.length > 0);
 });
-
-// Poll the backend rebuild-status endpoint until building is complete,
-// updating pluginFrontendRebuildResult along the way.
-let _rebuildPollTimer = null;
-function _startRebuildPolling() {
-  if (_rebuildPollTimer !== null) return; // already polling
-  pluginFrontendRebuildResult.value = {
-    building: true,
-    success: null,
-    message: "Building frontend, this may take a minute…",
-  };
-
-  const poll = async () => {
-    try {
-      const status = await pluginsApi.getRebuildStatus();
-      if (status.state === "building") {
-        pluginFrontendRebuildResult.value = {
-          building: true,
-          success: null,
-          message: status.message,
-        };
-        _rebuildPollTimer = setTimeout(poll, 2000);
-      } else {
-        _rebuildPollTimer = null;
-        pluginFrontendRebuildResult.value = {
-          building: false,
-          success: status.state === "done",
-          message: status.message,
-        };
-      }
-    } catch {
-      _rebuildPollTimer = null;
-    }
-  };
-  _rebuildPollTimer = setTimeout(poll, 1000);
-}
 
 export function usePlugins() {
   // Load plugins
@@ -198,10 +161,6 @@ export function usePlugins() {
       const response = await pluginsApi.installPluginFromZip(file);
       pluginInstallSuccess.value = "Plugin installed successfully!";
       pluginRequiresRestart.value = response.requires_restart || false;
-      if (response.frontend_rebuild_in_progress) {
-        _startRebuildPolling();
-      }
-
       if (!pluginRequiresRestart.value) {
         setTimeout(() => {
           pluginInstallSuccess.value = "";
@@ -308,10 +267,6 @@ export function usePlugins() {
       pluginRequiresRestart.value = response.requires_restart || false;
       pluginBranchSwitched.value = response.branch_switched || false;
       pluginActualBranch.value = response.branch || branch;
-      if (response.frontend_rebuild_in_progress) {
-        _startRebuildPolling();
-      }
-
       // Mark the installed plugin in-place so the list stays visible
       const installedId = response.manifest?.id || pluginPath;
       const idx = availablePlugins.value.findIndex(
@@ -382,9 +337,6 @@ export function usePlugins() {
           if (response.branch_switched) {
             pluginBranchSwitched.value = true;
             pluginActualBranch.value = response.branch || branch;
-          }
-          if (response.frontend_rebuild_in_progress) {
-            _startRebuildPolling();
           }
         } catch (error) {
           results.failed.push({
@@ -520,10 +472,6 @@ export function usePlugins() {
       const response = await pluginsApi.installPluginFromLocal(localPath, pluginPath, force);
       pluginInstallSuccess.value = "Plugin installed successfully!";
       pluginRequiresRestart.value = response.requires_restart || false;
-      if (response.frontend_rebuild_in_progress) {
-        _startRebuildPolling();
-      }
-
       // Mark the installed plugin in-place so the list stays visible
       const installedId = response.manifest?.id || pluginPath;
       const idx = availablePlugins.value.findIndex(
@@ -574,9 +522,6 @@ export function usePlugins() {
             response,
           });
           if (response.requires_restart) results.requiresRestart = true;
-          if (response.frontend_rebuild_in_progress) {
-            _startRebuildPolling();
-          }
         } catch (error) {
           results.failed.push({
             id: plugin.id,
@@ -635,10 +580,7 @@ export function usePlugins() {
   // Uninstall plugin
   const uninstallPlugin = async (pluginId, pluginType = null) => {
     try {
-      const response = await pluginsApi.uninstallPlugin(pluginId, pluginType);
-      if (response.frontend_rebuild_in_progress) {
-        _startRebuildPolling();
-      }
+      await pluginsApi.uninstallPlugin(pluginId, pluginType);
       await loadPlugins();
     } catch (error) {
       logError("[usePlugins]", "Failed to uninstall plugin:", error);
@@ -905,7 +847,6 @@ export function usePlugins() {
     pluginRequiresRestart,
     pluginBranchSwitched,
     pluginActualBranch,
-    pluginFrontendRebuildResult,
     expandedPlugins,
     pluginFormData,
     savingPlugin,

--- a/frontend/src/services/pluginsApi.js
+++ b/frontend/src/services/pluginsApi.js
@@ -138,14 +138,6 @@ export async function installPluginFromGitHub(repoUrl, pluginPath, branch = "mai
 }
 
 /**
- * Get the current state of a background frontend rebuild.
- */
-export async function getRebuildStatus() {
-  const response = await api.get("/plugins/rebuild-status");
-  return response.data;
-}
-
-/**
  * Suggest local plugin repo paths by scanning sibling directories (dev mode only).
  */
 export async function suggestLocalPath() {


### PR DESCRIPTION
## Summary

Plugin install used to:
1. Copy the plugin's `frontend/` dir into `frontend/src/components/plugins/{id}/` on the host
2. Trigger `npm run build` in a background thread
3. Frontend polled `/api/plugins/rebuild-status` until done
4. User reloaded so the Vite-glob loader could pick up the new SFC

Now that plugins use schema-driven rendering or ship a pre-built ESM that the host loads dynamically through `/api/plugins/{id}/static/{path}` (added in #19), none of that machinery is needed. This PR rips it out.

**This is the prerequisite for Phase 3 (deployment simplification).** Once Node isn't required at install time, the runtime Docker image can drop the npm toolchain and the Pi can run the same multi-arch image CI builds.

## What's gone

**Backend**
- `FrontendBuildManager` class + the module-level singleton
- `GET /api/plugins/rebuild-status` endpoint + `RebuildStatusResponse` model
- The frontend-copy-on-install path in `PluginInstaller.install_plugin` (and the matching cleanup on uninstall / corrupt-reinstall)
- `frontend_plugins_dir`, `get_frontend_plugin_path`, `get_frontend_dir` helpers — frontend assets stay inside the plugin's own data directory
- All references in routes (`management.py`, `github.py`)
- Test fixtures + assertions referring to the removed paths

**Frontend**
- `getRebuildStatus()` in `pluginsApi.js`
- The rebuild polling loop + `pluginFrontendRebuildResult` ref in `usePlugins.js`
- The `frontend_rebuild_in_progress` triggers at six install/uninstall sites
- The rebuild banner UI in `PluginInstaller.vue` + the corresponding props passthrough in `PluginsCategory.vue`

## What stays

- `frontend_rebuild_in_progress: false` is still returned on install/uninstall responses for one release so any external clients consuming the API don't break. Field will be removed next.
- `usePluginComponent.js` and the `frontend/src/components/plugins/**/*.vue` Vite glob remain — `iframe/IframeViewer.vue` still uses it. Migrating iframe to a schema kind and deleting the glob is a separate PR. The glob is a build-time concern (runs once in CI), so it doesn't block Phase 3.

## Test plan

- [x] `cd backend && uv run pytest` — 661 passing, 15 skipped
- [x] `cd frontend && npm test` — 549 passing
- [x] Lint + format clean (ruff, prettier, eslint, snapshot)
- [ ] Install a schema-driven plugin (e.g., yr_weather from calvin-plugins): no `.rebuild_needed` marker is written, no `npm run build` fires, plugin appears after backend restart
- [ ] Install a plugin with a `frontend/` dir (e.g., chromecast with its `dist.js`): files end up in `data/plugins/chromecast/frontend/`, served by the static-asset route, not copied into the host source tree
- [ ] Uninstall: plugin's data dir is gone (frontend assets along with it)

## Diff stats

15 files changed, 39 insertions(+), 487 deletions(-)