### PR TITLE
Phase 3b followups: env perms, update timeout, cleanup

### DIFF
--- a/rpi-image/systemd/calvin-update.service
+++ b/rpi-image/systemd/calvin-update.service
@@ -14,8 +14,6 @@ ExecStart=/usr/local/bin/update-calvin.sh
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=calvin-update
-# Don't fail the service if script exits with non-zero
-SuccessExitStatus=0 1 2
 # Timeout after 10 minutes to prevent hanging
 TimeoutSec=600
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -119,6 +119,16 @@ parse_args() {
     fi
 }
 
+compose() {
+    if docker compose version >/dev/null 2>&1; then
+        docker compose "$@"
+    elif command -v docker-compose >/dev/null 2>&1; then
+        docker-compose "$@"
+    else
+        return 127
+    fi
+}
+
 install_docker_runtime() {
     log "Installing Docker runtime..."
     install_system_packages docker.io
@@ -131,26 +141,12 @@ install_docker_runtime() {
         install_system_packages docker-compose-v2
     fi
 
-    if ! docker compose version >/dev/null 2>&1 && ! command -v docker-compose >/dev/null 2>&1; then
-        install_system_packages docker-compose
-    fi
-
     systemctl enable docker || log_warn "Failed to enable docker.service"
     systemctl start docker || log_warn "Failed to start docker.service"
     usermod -aG docker "${CALVIN_USER}" || log_warn "Failed to add ${CALVIN_USER} to docker group"
 
     if ! compose version >/dev/null 2>&1; then
         error_exit "Docker Compose is not available after installation" 1
-    fi
-}
-
-compose() {
-    if docker compose version >/dev/null 2>&1; then
-        docker compose "$@"
-    elif command -v docker-compose >/dev/null 2>&1; then
-        docker-compose "$@"
-    else
-        return 127
     fi
 }
 
@@ -182,7 +178,7 @@ install_compose_config() {
     install -m 0644 "${source_compose}" /etc/calvin/docker-compose.yml
 
     if [ ! -f /etc/calvin/.env ]; then
-        install -m 0640 "${CALVIN_DIR}/deploy/calvin.env.example" /etc/calvin/.env
+        install -g "${CALVIN_USER}" -m 0640 "${CALVIN_DIR}/deploy/calvin.env.example" /etc/calvin/.env
     fi
 
     upsert_env_value /etc/calvin/.env CALVIN_DATA_DIR "${CALVIN_DATA_DIR}"

--- a/scripts/update-calvin.sh
+++ b/scripts/update-calvin.sh
@@ -18,13 +18,12 @@ fi
 CALVIN_MODE="${CALVIN_MODE:-prod}"
 REPO_DIR="${REPO_DIR:-/home/calvin/calvin}"
 GIT_BRANCH="${GIT_BRANCH:-main}"
+WAIT_TIMEOUT="${WAIT_TIMEOUT:-180}"
 
 echo "Starting Calvin update..."
 
 compose_is_dev() {
-  [[ "$CALVIN_MODE" == "dev" ]] || {
-    [[ -f "$COMPOSE_FILE" ]] && grep -q "calvin-backend-dev\|calvin-frontend-dev" "$COMPOSE_FILE"
-  }
+  [[ "$CALVIN_MODE" == "dev" ]]
 }
 
 compose() {
@@ -39,16 +38,18 @@ compose() {
 }
 
 wait_for_health() {
-  echo "==> Waiting for /api/health to come back"
-  for _ in $(seq 1 30); do
+  echo "==> Waiting up to ${WAIT_TIMEOUT}s for /api/health to come back"
+  local elapsed=0
+  while [[ $elapsed -lt $WAIT_TIMEOUT ]]; do
     if curl -fsS http://localhost:8000/api/health >/dev/null 2>&1; then
       echo "Calvin is healthy."
       return 0
     fi
     sleep 2
+    elapsed=$((elapsed + 2))
   done
 
-  echo "Calvin did not become healthy within 60s. Check logs:" >&2
+  echo "Calvin did not become healthy within ${WAIT_TIMEOUT}s. Check logs:" >&2
   echo "  docker compose -f $COMPOSE_FILE logs --tail=200" >&2
   return 1
 }


### PR DESCRIPTION
## Summary

Small follow-up cleanups from the PR #23 review. Three independent commits, easy to revert individually.

- **`/etc/calvin/.env` group-readable by calvin** — `install -g calvin -m 0640`. Lets the calvin user run `docker compose -f /etc/calvin/docker-compose.yml ps` for debugging without sudo. Compose still reads it as root via the systemd units.
- **`update-calvin.sh` health timeout configurable** — `WAIT_TIMEOUT` (default 180s, was hardcoded 60s). Closer to the 240s kiosk wait; avoids spurious failures when `compose pull` triggers a slow recreate on a Pi 3B+.
- **Simplify `compose_is_dev`** — drop the grep over the compose file; `CALVIN_MODE` from `/etc/default/calvin-update` is the source of truth.
- **Drop docker-compose v1 fallback** — EOL Jun 2023; `docker-compose-plugin` / `docker-compose-v2` cover modern Debian and RPi-OS.
- **Reorder `compose()` definition** — moved above its first call site for readability.
- **`calvin-update.service`: drop `SuccessExitStatus=0 1 2`** — `update-calvin.sh` only exits non-zero on genuine failure, so masking it made `systemctl status` lie.

## Test plan

- [x] `bash -n scripts/setup.sh scripts/update-calvin.sh`
- [ ] CI: `Setup Validation Prod` — docker-in-docker e2e still passes after the env install + compose-fallback changes
- [ ] Manual on Pi (next update cycle): confirm `update-calvin.sh` survives a slow recreate, and `systemctl status calvin-update` reflects real state