### PR TITLE
Fix calendar month rollover and today highlight

### DIFF
--- a/frontend/src/components/CalendarView.vue
+++ b/frontend/src/components/CalendarView.vue
@@ -181,15 +181,41 @@ const startCalendarAutoRefresh = () => {
   calendarAutoRefreshInterval = setInterval(() => loadEvents(true), ms);
 };
 
+// Refresh "today" and, on date rollover, advance currentDate if the user is
+// viewing the month that just ended. setInterval can fire late after the
+// browser/device has been asleep, so this is also called on visibilitychange.
+const refreshToday = () => {
+  const previousToday = today.value;
+  const newToday = new Date();
+  const dayChanged =
+    previousToday.getFullYear() !== newToday.getFullYear() ||
+    previousToday.getMonth() !== newToday.getMonth() ||
+    previousToday.getDate() !== newToday.getDate();
+  if (!dayChanged) return;
+  today.value = newToday;
+  const cd = currentDate.value;
+  const wasTrackingToday =
+    cd.getFullYear() === previousToday.getFullYear() && cd.getMonth() === previousToday.getMonth();
+  if (wasTrackingToday) {
+    calendarStore.setCurrentDate(newToday);
+  }
+};
+
+const handleVisibilityChange = () => {
+  if (document.visibilityState === "visible") {
+    refreshToday();
+  }
+};
+
 // Load calendar sources on mount
 onMounted(async () => {
   await calendarStore.fetchSources();
 
   // Update today's date every minute to refresh the calendar
   // This ensures the "today" highlight updates automatically
-  todayRefreshInterval = setInterval(() => {
-    today.value = new Date();
-  }, 60000); // Update every minute
+  todayRefreshInterval = setInterval(refreshToday, 60000);
+
+  document.addEventListener("visibilitychange", handleVisibilityChange);
 
   startCalendarAutoRefresh();
 });
@@ -201,6 +227,7 @@ onUnmounted(() => {
   if (calendarAutoRefreshInterval) {
     clearInterval(calendarAutoRefreshInterval);
   }
+  document.removeEventListener("visibilitychange", handleVisibilityChange);
 });
 
 watch(calendarRefreshIntervalMinutes, () => {


### PR DESCRIPTION
## Summary

When midnight crossed into a new month, the calendar stayed on the previous month and the "today" highlight disappeared.

`CalendarView` had a minute interval refreshing the reactive `today` ref, but the grid is rendered from `currentDate` (in the calendar store), which was never advanced. So at 00:00 on the 1st: `today` became the new month, the grid kept rendering the old month, no cell matched, highlight gone.

## Changes

- On date rollover, advance `currentDate` to the new today **only when the user is currently viewing the month that contained the previous today**. This preserves manual navigation to other months (e.g. planning ahead in August won't yank you back).
- Also re-check on `document.visibilitychange` so the rollover is corrected promptly when the device wakes from sleep — browsers throttle `setInterval` in background tabs, so the minute tick can fire late. `visibilitychange` does not fire on Vue route changes / keep-alive activation, so going to/from the calendar in-app doesn't re-trigger this.
- Extracted the rollover logic into a `refreshToday` helper shared by both the interval and the visibility listener.

The existing `watch(currentDate, loadEvents)` picks up the new month and reloads events automatically.

## Test plan

- [ ] Open the calendar near midnight on the last day of a month; verify it switches to the new month at 00:00 and the new day is highlighted
- [ ] Navigate within the current month (week view, jump dates) before midnight — rollover still happens
- [ ] Navigate to a different month before midnight — rollover does **not** yank the view away
- [ ] Sleep the device through midnight, wake it — verify view corrects on visibility regain (no need to wait a full minute)