### PR TITLE
Align plugin display contract docs and tests

### DIFF
--- a/backend/tests/e2e/test_github_plugin_e2e.py
+++ b/backend/tests/e2e/test_github_plugin_e2e.py
@@ -183,8 +183,10 @@ class TestGitHubPluginE2E:
         branch_switched = data.get("branch_switched", False)
         print(f"\nUsed branch: {actual_branch} (switched: {branch_switched})")
 
-    def test_install_plugin_with_frontend_from_real_repo(self, test_client, network_available):
-        """Test installing a plugin with frontend components from a real repository."""
+    def test_install_plugin_with_frontend_static_assets_from_real_repo(
+        self, test_client, network_available
+    ):
+        """Test installing a plugin with frontend static assets from a real repository."""
         # First, enumerate to find plugins with frontend
         enum_response = test_client.post(
             "/api/plugins/github/enumerate",

--- a/backend/tests/integration/test_api_plugins.py
+++ b/backend/tests/integration/test_api_plugins.py
@@ -262,8 +262,8 @@ def register_plugin_types() -> list[dict[str, Any]]:
         response = test_client.delete("/api/plugins/installed/nonexistent")
         assert response.status_code == 404
 
-    def test_install_plugin_with_frontend_components(self, test_client, tmp_path):
-        """Test installing a plugin with frontend components."""
+    def test_install_plugin_with_frontend_static_assets(self, test_client, tmp_path):
+        """Test installing a plugin with frontend static assets."""
         # Clean up first in case it exists
         try:
             plugin_installer.uninstall_plugin("test_frontend_plugin")
@@ -285,15 +285,58 @@ def register_plugin_types() -> list[dict[str, Any]]:
 
         frontend_dir = plugin_dir / "frontend"
         frontend_dir.mkdir()
-        (frontend_dir / "TestComponent.vue").write_text("<template><div>Test</div></template>")
+        (frontend_dir / "dist.js").write_text(
+            "customElements.define('calvin-test-frontend-plugin', class extends HTMLElement {})"
+        )
+        (frontend_dir / "dist.css").write_text(":host { display: block; }")
 
         # Install plugin
         plugin_installer.install_plugin(plugin_dir)
 
-        # Verify frontend asset is stored inside the plugin's data dir
-        # (the host serves these via /api/plugins/{id}/static/*).
+        # Verify frontend assets are stored inside the plugin's data dir.
         plugin_path = plugin_installer.get_plugin_path("test_frontend_plugin")
-        assert (plugin_path / "frontend" / "TestComponent.vue").exists()
+        assert (plugin_path / "frontend" / "dist.js").exists()
+        assert (plugin_path / "frontend" / "dist.css").exists()
+
+    def test_plugin_static_asset_endpoint_serves_installed_frontend_asset(
+        self, test_client, temp_plugins_dir, monkeypatch
+    ):
+        """Test serving installed plugin frontend assets without a frontend rebuild."""
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "plugins_dir", temp_plugins_dir)
+
+        frontend_dir = temp_plugins_dir / "test_static_plugin" / "frontend"
+        frontend_dir.mkdir(parents=True)
+        (frontend_dir / "dist.js").write_text(
+            "customElements.define('calvin-static-test', class extends HTMLElement {})"
+        )
+
+        response = test_client.get("/api/plugins/test_static_plugin/static/dist.js")
+
+        assert response.status_code == 200
+        assert "calvin-static-test" in response.text
+
+    @pytest.mark.asyncio
+    async def test_plugin_static_asset_endpoint_rejects_path_traversal(
+        self, temp_plugins_dir, monkeypatch
+    ):
+        """Test plugin static asset paths cannot escape the plugin frontend directory."""
+        from fastapi import HTTPException
+
+        from app.api.routes.plugins.static_assets import get_plugin_static_asset
+        from app.config import settings
+
+        monkeypatch.setattr(settings, "plugins_dir", temp_plugins_dir)
+
+        frontend_dir = temp_plugins_dir / "test_static_plugin" / "frontend"
+        frontend_dir.mkdir(parents=True)
+        (temp_plugins_dir / "test_static_plugin" / "secret.txt").write_text("secret")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_plugin_static_asset("test_static_plugin", "../secret.txt")
+
+        assert exc_info.value.status_code == 400
 
 
 @pytest.mark.integration

--- a/backend/tests/integration/test_api_plugins_github.py
+++ b/backend/tests/integration/test_api_plugins_github.py
@@ -34,7 +34,7 @@ class TestGitHubPluginEnumeration:
             )
             zipf.writestr("repo-main/plugin1/plugin.py", "# Plugin 1")
 
-            # Plugin 2 with frontend
+            # Plugin 2 with frontend static assets
             zipf.writestr(
                 "repo-main/plugin2/plugin.json",
                 json.dumps(
@@ -47,7 +47,10 @@ class TestGitHubPluginEnumeration:
                 ),
             )
             zipf.writestr("repo-main/plugin2/plugin.py", "# Plugin 2")
-            zipf.writestr("repo-main/plugin2/frontend/Component.vue", "<template></template>")
+            zipf.writestr(
+                "repo-main/plugin2/frontend/dist.js",
+                "customElements.define('calvin-github-plugin2', class extends HTMLElement {})",
+            )
 
             # plugins.json manifest
             zipf.writestr(
@@ -713,8 +716,8 @@ class TestPluginUninstallAPI:
         plugin_path = plugin_installer.get_plugin_path("test_uninstall_api")
         assert not plugin_path.exists()
 
-    def test_uninstall_plugin_with_frontend(self, test_client, tmp_path):
-        """Test uninstalling a plugin with frontend components."""
+    def test_uninstall_plugin_with_frontend_static_assets(self, test_client, tmp_path):
+        """Test uninstalling a plugin with frontend static assets."""
         # Clean up first
         try:
             plugin_installer.uninstall_plugin("test_uninstall_frontend")
@@ -736,7 +739,9 @@ class TestPluginUninstallAPI:
 
         frontend_dir = plugin_dir / "frontend"
         frontend_dir.mkdir()
-        (frontend_dir / "Component.vue").write_text("<template></template>")
+        (frontend_dir / "dist.js").write_text(
+            "customElements.define('calvin-uninstall-test', class extends HTMLElement {})"
+        )
 
         plugin_installer.install_plugin(plugin_dir)
 

--- a/backend/tests/unit/test_plugin_installer.py
+++ b/backend/tests/unit/test_plugin_installer.py
@@ -69,12 +69,14 @@ def register_plugin_types() -> list[dict[str, Any]]:
 
 @pytest.fixture
 def plugin_package_with_frontend(tmp_path, valid_plugin_package):
-    """Create a plugin package with frontend components."""
+    """Create a plugin package with frontend static assets."""
     frontend_dir = valid_plugin_package / "frontend"
     frontend_dir.mkdir()
 
-    component_file = frontend_dir / "TestComponent.vue"
-    component_file.write_text("<template><div>Test Component</div></template>")
+    component_file = frontend_dir / "dist.js"
+    component_file.write_text(
+        "customElements.define('calvin-test-plugin', class extends HTMLElement {})"
+    )
 
     return valid_plugin_package
 
@@ -239,7 +241,7 @@ class TestPluginInstaller:
         with pytest.raises(ValueError, match="already installed"):
             plugin_installer.install_plugin(valid_plugin_package)
 
-    def test_install_plugin_with_frontend_components(
+    def test_install_plugin_with_frontend_static_assets(
         self, plugin_installer, plugin_package_with_frontend
     ):
         """Frontend assets stay inside the plugin's data dir; the host serves
@@ -248,7 +250,7 @@ class TestPluginInstaller:
         plugin_installer.install_plugin(plugin_package_with_frontend)
 
         plugin_path = plugin_installer.get_plugin_path("test_plugin")
-        assert (plugin_path / "frontend" / "TestComponent.vue").exists()
+        assert (plugin_path / "frontend" / "dist.js").exists()
 
     def test_install_plugin_cleanup_on_error(self, plugin_installer, tmp_path):
         """Test that plugin installation is cleaned up on error."""

--- a/backend/tests/unit/test_plugin_installer_github.py
+++ b/backend/tests/unit/test_plugin_installer_github.py
@@ -33,7 +33,7 @@ def mock_repo_structure(tmp_path):
     (plugin1_dir / "plugin.json").write_text(json.dumps(manifest1))
     (plugin1_dir / "plugin.py").write_text("# Plugin 1 code")
 
-    # Plugin 2: Plugin with frontend
+    # Plugin 2: Plugin with frontend static assets
     plugin2_dir = repo_root / "plugin2"
     plugin2_dir.mkdir()
     manifest2 = {
@@ -46,7 +46,9 @@ def mock_repo_structure(tmp_path):
     (plugin2_dir / "plugin.py").write_text("# Plugin 2 code")
     frontend_dir = plugin2_dir / "frontend"
     frontend_dir.mkdir()
-    (frontend_dir / "Component.vue").write_text("<template><div>Component</div></template>")
+    (frontend_dir / "dist.js").write_text(
+        "customElements.define('calvin-plugin2', class extends HTMLElement {})"
+    )
 
     # Plugin 3: In subdirectory
     plugin3_dir = repo_root / "plugins" / "plugin3"
@@ -342,8 +344,10 @@ class TestPluginInstallFromRepo:
         assert (plugin_path / "plugin.json").exists()
         assert (plugin_path / "plugin.py").exists()
 
-    def test_install_plugin_from_repo_with_frontend(self, plugin_installer, mock_repo_structure):
-        """Test installing a plugin with frontend components from repo."""
+    def test_install_plugin_from_repo_with_frontend_static_assets(
+        self, plugin_installer, mock_repo_structure
+    ):
+        """Test installing a plugin with frontend static assets from repo."""
         manifest = plugin_installer.install_plugin_from_repo(
             mock_repo_structure, "plugin2", plugin_id=None
         )
@@ -353,7 +357,7 @@ class TestPluginInstallFromRepo:
         # Frontend assets stay inside the plugin's data dir (host serves them
         # via /api/plugins/{id}/static/*).
         plugin_path = plugin_installer.get_plugin_path("plugin2")
-        assert (plugin_path / "frontend" / "Component.vue").exists()
+        assert (plugin_path / "frontend" / "dist.js").exists()
 
     def test_install_plugin_from_repo_path_traversal_protection(
         self, plugin_installer, mock_repo_structure

--- a/docs/plugins/PLUGIN_FRONTEND_COMPONENTS.md
+++ b/docs/plugins/PLUGIN_FRONTEND_COMPONENTS.md
@@ -1,117 +1,103 @@
-# Plugin Frontend Components
+# Plugin Display UI
 
-## Overview
+Calvin no longer installs plugin-provided Vue single-file components into the main frontend
+bundle. Service plugins should render dashboard content through one of two supported contracts:
 
-Yes, the plugin installation process **does handle frontend components** provided by plugins. When a plugin includes a `frontend/` directory, it is automatically copied to the frontend during installation.
+1. **Schema renderers**: recommended for most plugins. The plugin returns a `display_schema`
+   with a built-in `kind`, and Calvin renders it with the matching built-in Vue renderer.
+2. **Web components**: an escape hatch for custom UI. The plugin ships pre-built browser-native
+   JavaScript and optional CSS under its `frontend/` directory, and Calvin loads those files at
+   runtime through the plugin static asset endpoint.
 
-## How It Works
+This means installing a schema or web-component plugin does not require a frontend rebuild.
 
-### Installation Process
+## Schema Renderers
 
-When installing a plugin (from zip or GitHub), the installer:
+Use schema renderers when the plugin can describe its UI declaratively. The frontend dispatches
+`display_schema.kind` through `frontend/src/components/plugins/SchemaRenderer.vue`.
 
-1. **Checks for `frontend/` directory** in the plugin package
-2. **Copies the entire `frontend/` directory** to `frontend/src/components/plugins/{plugin_id}/`
-3. **Makes components available** via the path `{plugin_id}/ComponentName.vue`
+Supported renderer kinds include:
 
-### Code Location
+- `status-tile`
+- `status-list`
+- `status-row`
+- `card-grid`
+- `item-list`
+- `iframe`
+- `image-with-caption`
+- `metric-dashboard`
+- `weather-forecast`
+- `web-component`
 
-The frontend component installation logic is in `backend/app/services/plugin_installer.py`:
+Example plugin metadata:
 
 ```python
-# Install frontend components if they exist
-frontend_source = plugin_path / "frontend"
-if frontend_source.exists():
-    frontend_dest = self.get_frontend_plugin_path(install_id)
-    if frontend_dest.exists():
-        shutil.rmtree(frontend_dest)
-    shutil.copytree(frontend_source, frontend_dest)
-```
-
-This works for:
-- ✅ **Zip file installations** - extracts plugin, then copies frontend/
-- ✅ **GitHub installations** - downloads repo, extracts plugin, then copies frontend/
-- ✅ **Directory installations** - copies plugin directory, then copies frontend/
-
-### Example: Mealie Plugin
-
-The Mealie plugin (available in the calvin-plugins repository) demonstrates this:
-
-**Backend** (in the plugin's `plugin.py`):
-```python
-"display_schema": {
-    "type": "api",
-    "api_endpoint": "/api/plugins/{service_id}/data",
-    "method": "GET",
-    "component": "mealie/MealPlanViewer.vue",  # Plugin-provided frontend component
+display_schema={
+    "kind": "status-tile",
+    "label": "Temperature",
+    "value_path": "$.temperature",
+    "unit": "C",
+    "status_path": "$.status",
 }
 ```
 
-**Frontend Component** (in the plugin's `frontend/MealPlanViewer.vue`):
-- This component is loaded dynamically by the `ServiceViewer` component
-- Uses the `usePluginComponent` composable to load plugin-provided components
+The plugin's service data endpoint returns the data object that schema paths bind to.
 
-## Plugin Package Structure
+## Web Components
 
-For a plugin to include frontend components, it should have this structure:
+Use `kind: "web-component"` only when the built-in schema renderers are not expressive enough.
+The plugin must ship already-built browser JavaScript in `frontend/`.
 
-```
+Example package structure:
+
+```text
 my-plugin/
 ├── plugin.json
 ├── plugin.py
 └── frontend/
-    └── MyComponent.vue
-    └── (or subdirectories)
-        └── components/
-            └── MyComponent.vue
+    ├── dist.js
+    └── dist.css
 ```
 
-## Installation Result
-
-After installation, the frontend component will be at:
-```
-frontend/src/components/plugins/{plugin_id}/MyComponent.vue
-```
-
-And referenced in `display_schema.component` as:
-```python
-"component": "{plugin_id}/MyComponent.vue"
-```
-
-## Component Loading
-
-Frontend components are automatically loaded by:
-- `frontend/src/composables/usePluginComponent.js` - Dynamically imports plugin components
-- `frontend/src/components/service/ServiceViewer.vue` - Uses the composable to render plugin components
-
-The system uses Vite's `import.meta.glob()` to discover all plugin components at build time.
-
-## Uninstallation
-
-When uninstalling a plugin, frontend components are also removed:
+Example display schema:
 
 ```python
-# Remove frontend components
-frontend_path = self.get_frontend_plugin_path(plugin_id)
-if frontend_path.exists():
-    shutil.rmtree(frontend_path)
+display_schema={
+    "kind": "web-component",
+    "element": "calvin-my-plugin",
+    "module": "dist.js",
+    "stylesheet": "dist.css",
+}
 ```
 
-## Important Notes
+At runtime, Calvin loads:
 
-1. **Frontend rebuild required**: After installing a plugin with frontend components, the frontend needs to be rebuilt for the components to be available (Vite's glob needs to pick them up)
+```text
+/api/plugins/{plugin_id}/static/dist.js
+/api/plugins/{plugin_id}/static/dist.css
+```
 
-2. **Component path**: The component path in `display_schema.component` should be relative to `frontend/src/components/plugins/`, e.g., `mealie/MealPlanViewer.vue`
+The JavaScript module must register the custom element named by `display_schema.element`.
+Calvin assigns the latest service data to the element's `data` property.
 
-3. **Subdirectories**: You can organize components in subdirectories within the `frontend/` directory, and the full path will be preserved
+## Installation Behavior
 
-4. **No manual registration**: Plugin components don't need to be manually registered - they're discovered automatically via the glob pattern
+When a plugin includes a `frontend/` directory, Calvin stores it with the installed plugin under:
 
-## Testing
+```text
+backend/data/plugins/{plugin_id}/frontend/
+```
 
-To verify frontend components are installed correctly:
+Those files are served by:
 
-1. Check that `frontend/src/components/plugins/{plugin_id}/` exists after installation
-2. Verify the component files are present
-3. Check that the plugin's `display_schema.component` path matches the installed location
-4. Rebuild the frontend and test the plugin
+```text
+GET /api/plugins/{plugin_id}/static/{asset_path}
+```
+
+The static endpoint prevents path traversal outside the plugin's `frontend/` directory.
+
+## Choosing a Contract
+
+Prefer schema renderers for stable dashboard UI because they inherit Calvin's layout, theme,
+accessibility, and test coverage. Use web components for custom visualizations or interactions
+that cannot reasonably be represented with the built-in renderer set.

--- a/docs/plugins/PLUGIN_INSTALLATION.md
+++ b/docs/plugins/PLUGIN_INSTALLATION.md
@@ -10,8 +10,9 @@ A plugin package is a directory or zip file containing:
 my-plugin/
 ├── plugin.json          # Plugin manifest (required)
 ├── plugin.py            # Plugin implementation (required)
-├── frontend/            # Frontend components (optional)
-│   └── MyComponent.vue
+├── frontend/            # Pre-built web component/static assets (optional)
+│   ├── dist.js
+│   └── dist.css
 └── assets/              # Static assets (optional)
     └── icon.png
 ```
@@ -135,10 +136,10 @@ class MyServicePlugin(ServicePlugin):
                 },
             },
             "display_schema": {
-                "type": "api",
-                "api_endpoint": "/api/plugins/{service_id}/data",
-                "method": "GET",
-                "component": "my_plugin/MyComponent.vue",  # Optional: custom frontend component
+                "kind": "status-tile",
+                "label": "Latest Value",
+                "value_path": "$.value",
+                "status_path": "$.status",
             },
             "plugin_class": cls,
         }
@@ -193,56 +194,80 @@ def create_plugin_instance(
     )
 ```
 
-## Frontend Components
+## Plugin Display UI
 
-If your plugin provides frontend components, place them in the `frontend/` directory:
+Service plugins render through `display_schema`. Prefer built-in schema renderers for normal
+dashboard content, and use a web component only when the built-in renderers are not expressive
+enough.
+
+### Built-In Schema Renderers
+
+The frontend dispatches `display_schema.kind` to a built-in renderer. Supported kinds include:
+
+- `status-tile`
+- `status-list`
+- `status-row`
+- `card-grid`
+- `item-list`
+- `iframe`
+- `image-with-caption`
+- `metric-dashboard`
+- `weather-forecast`
+- `web-component`
+
+Example:
+
+```python
+"display_schema": {
+    "kind": "status-tile",
+    "label": "Latest Value",
+    "value_path": "$.value",
+    "status_path": "$.status",
+}
+```
+
+### Web Components
+
+If your plugin needs custom UI, ship a pre-built browser-native web component in the
+`frontend/` directory:
 
 ```
 my-plugin/
 ├── plugin.json
 ├── plugin.py
 └── frontend/
-    └── MyComponent.vue
+    ├── dist.js
+    └── dist.css
 ```
 
-**Important**: The `frontend/` directory contents will be copied to `frontend/src/components/plugins/{plugin_id}/` during installation.
-
-### Component Path in display_schema
-
-The component path in `display_schema.component` should be relative to `frontend/src/components/plugins/`:
+The JavaScript module must register the custom element named by `display_schema.element`:
 
 ```python
 "display_schema": {
-    "type": "api",
-    "api_endpoint": "/api/plugins/{service_id}/data",
-    "method": "GET",
-    "component": "my_plugin/MyComponent.vue",  # {plugin_id}/ComponentName.vue
+    "kind": "web-component",
+    "element": "calvin-my-plugin",
+    "module": "dist.js",
+    "stylesheet": "dist.css",
 }
 ```
 
-**Example**: If your plugin ID is `my_plugin` and you have `frontend/MyComponent.vue`, the component path should be `my_plugin/MyComponent.vue`.
+At runtime, Calvin loads these assets through:
 
-### Subdirectories
-
-You can organize components in subdirectories:
-
-```
-my-plugin/
-└── frontend/
-    └── components/
-        └── MyComponent.vue
+```text
+/api/plugins/{plugin_id}/static/dist.js
+/api/plugins/{plugin_id}/static/dist.css
 ```
 
-Then use: `"component": "my_plugin/components/MyComponent.vue"`
+Calvin assigns the latest service data to the custom element's `data` property.
 
-### Frontend Component Installation
+### Frontend Asset Installation
 
 During installation:
 1. The installer checks for a `frontend/` directory in your plugin package
-2. If found, it copies the entire `frontend/` directory to `frontend/src/components/plugins/{plugin_id}/`
-3. The component is then available via the path `{plugin_id}/...` in `display_schema.component`
+2. If found, it stores the directory under `backend/data/plugins/{plugin_id}/frontend/`
+3. The static asset endpoint serves files from that directory
 
-**Note**: The frontend components are automatically loaded by the `ServiceViewer` component using the `usePluginComponent` composable. No additional frontend code changes are needed.
+Schema and web-component plugins do not require a frontend rebuild after installation.
 
 ## Installing Plugins
 
@@ -296,7 +321,7 @@ curl -X POST "http://localhost:8000/api/plugins/install-from-github" \
 
 1. Plugin package is validated (checks for `plugin.json` and `plugin.py`)
 2. Plugin is extracted to `backend/data/plugins/{plugin_id}/`
-3. Frontend components are copied to `frontend/src/components/plugins/{plugin_id}/`
+3. Frontend static assets are stored with the installed plugin, if present
 4. Plugin is loaded and registered with pluggy
 5. Plugin type is added to the database (disabled by default)
 

--- a/docs/plugins/PLUGIN_PACKAGE_FORMAT.md
+++ b/docs/plugins/PLUGIN_PACKAGE_FORMAT.md
@@ -40,8 +40,8 @@ my-plugin.zip
 └── my-plugin/              # Root directory (optional, can be flat)
     ├── plugin.json         # REQUIRED: Plugin manifest
     ├── plugin.py           # REQUIRED: Plugin implementation
-    ├── frontend/           # OPTIONAL: Frontend components
-    │   └── MyComponent.vue
+    ├── frontend/           # OPTIONAL: pre-built web component/static assets
+    │   └── dist.js
     └── assets/             # OPTIONAL: Static assets
         └── icon.png
 ```
@@ -171,8 +171,9 @@ Each plugin directory must follow this structure:
 plugin-name/
 ├── plugin.json         # REQUIRED: Plugin manifest
 ├── plugin.py          # REQUIRED: Plugin implementation
-├── frontend/           # OPTIONAL: Frontend components
-│   └── *.vue
+├── frontend/           # OPTIONAL: pre-built web component/static assets
+│   ├── dist.js
+│   └── dist.css
 └── assets/             # OPTIONAL: Static assets
     └── *
 ```
@@ -182,8 +183,10 @@ plugin-name/
 - `plugin.py`: Plugin implementation
 
 **Optional Directories:**
-- `frontend/`: Vue components for the plugin
-- `assets/`: Static assets (images, icons, etc.)
+- `frontend/`: Pre-built browser-native assets for `display_schema.kind = "web-component"`.
+  These files are served at `/api/plugins/{plugin_id}/static/{asset_path}` and do not require a
+  frontend rebuild.
+- `assets/`: Static assets used by the plugin backend.
 
 ## Validation Rules
 
@@ -215,7 +218,7 @@ plugin-name/
 1. Extract zip to temporary directory
 2. Validate package structure (exactly one plugin)
 3. Extract plugin to `backend/data/plugins/{plugin_id}/`
-4. Copy frontend components if present
+4. Store frontend static assets if present
 5. Reload plugin loader
 
 ### Repository Installation (Single Plugin)
@@ -253,7 +256,7 @@ my-service-plugin.zip
       ├── plugin.json
       ├── plugin.py
       └── frontend/
-          └── ServiceViewer.vue
+          └── dist.js
 
 # Installation
 curl -X POST /api/plugins/install -F "file=@my-service-plugin.zip"

--- a/docs/plugins/PLUGIN_PERSISTENCE_AND_RESTART.md
+++ b/docs/plugins/PLUGIN_PERSISTENCE_AND_RESTART.md
@@ -29,7 +29,9 @@ Stores individual plugin instances:
 When you install a plugin:
 
 1. ✅ **Files are installed** to `backend/data/plugins/{plugin_id}/`
-2. ✅ **Frontend components** are copied to `frontend/src/components/plugins/{plugin_id}/`
+2. ✅ **Frontend static assets**, if present, stay under
+   `backend/data/plugins/{plugin_id}/frontend/` and are served at
+   `/api/plugins/{plugin_id}/static/{asset_path}`
 3. ✅ **Plugin module is loaded** into memory via `plugin_loader.load_installed_plugins()`
 4. ✅ **Plugin is registered** with pluggy (the plugin system)
 5. ❌ **Plugin type is NOT automatically added to database**
@@ -57,4 +59,3 @@ To make newly installed plugins appear immediately:
 ## Future Improvement
 
 A future version may add automatic database registration after installation, eliminating the need for a restart.
-

--- a/docs/plugins/PLUGIN_REPOSITORY_SETUP.md
+++ b/docs/plugins/PLUGIN_REPOSITORY_SETUP.md
@@ -40,7 +40,7 @@ calvin-plugins/
 │   ├── plugin.json
 │   ├── plugin.py
 │   └── frontend/
-│       └── Component.vue
+│       └── dist.js
 ├── plugin2/               # Another plugin
 │   ├── plugin.json
 │   └── plugin.py
@@ -360,4 +360,3 @@ Extensions work across all workspace folders. Configure once, applies to both.
 - ✅ **Version control separately** but coordinate releases
 
 This setup gives you the flexibility to develop plugins independently while maintaining a clean separation between core and plugins.
-

--- a/docs/testing/E2E_TEST_REPO_SETUP.md
+++ b/docs/testing/E2E_TEST_REPO_SETUP.md
@@ -32,7 +32,7 @@ export TEST_GITHUB_BRANCH="main"  # Optional, defaults to "main"
    │   ├── plugin.json
    │   ├── plugin.py
    │   └── frontend/
-   │       └── Component.vue
+   │       └── dist.js
    └── README.md
    ```
 
@@ -177,4 +177,3 @@ jobs:
   - Scheduled nightly builds
   - Local development validation
   - Debugging integration issues
-

--- a/docs/testing/TEST_COVERAGE_NEW_FEATURES.md
+++ b/docs/testing/TEST_COVERAGE_NEW_FEATURES.md
@@ -36,7 +36,7 @@ We use a **hybrid approach** for testing GitHub plugin installation:
 
 - `TestPluginInstallFromRepo`: Tests installing plugins from repositories
   - Basic installation from repo
-  - Installation with frontend components
+  - Installation with frontend static assets for web components
   - Path traversal protection
   - Error handling for non-existent plugins
   - Error handling for already installed plugins
@@ -49,7 +49,7 @@ We use a **hybrid approach** for testing GitHub plugin installation:
 **Coverage**:
 - ✅ Plugin enumeration (auto-discovery and manifest-based)
 - ✅ Repository installation
-- ✅ Frontend component installation from repos
+- ✅ Frontend static asset installation from repos
 - ✅ Version checking
 - ✅ Security (path traversal protection)
 
@@ -71,7 +71,7 @@ We use a **hybrid approach** for testing GitHub plugin installation:
 
 - `TestPluginUninstallAPI`: Tests `/api/plugins/installed/{id}` DELETE endpoint
   - Successful uninstall
-  - Uninstall with frontend components
+  - Uninstall with frontend static assets
   - Error handling for non-existent plugins
 
 **Coverage**:
@@ -79,7 +79,7 @@ We use a **hybrid approach** for testing GitHub plugin installation:
 - ✅ GitHub installation API
 - ✅ Branch fallback logic
 - ✅ Uninstall API
-- ✅ Frontend component cleanup on uninstall
+- ✅ Frontend static asset cleanup on uninstall
 
 ### 3. `backend/tests/integration/test_api_system.py`
 
@@ -176,7 +176,10 @@ uv run pytest  # Also skips E2E (they're marked slow)
 ### ✅ Fully Covered
 - Plugin enumeration from repositories
 - Plugin installation from repositories
-- Frontend component installation
+- Frontend static asset installation
+- Plugin static asset serving
+- Schema renderer dispatch
+- Web component host loading contract
 - Version checking
 - Path traversal protection
 - GitHub API integration (mocked)
@@ -187,18 +190,19 @@ uv run pytest  # Also skips E2E (they're marked slow)
 ### ⚠️ Partially Covered
 - Real GitHub API calls (mocked in integration tests, real in E2E tests)
 - Polkit rules (tested via mocked subprocess calls)
-- Frontend rebuild after component installation (not tested - requires build step)
+- Full browser execution of third-party web component modules
 
 ### ✅ E2E Coverage (Optional)
 - Real GitHub repository integration
 - Actual network calls and error handling
 - Real branch fallback behavior
 - Actual plugin structure validation
+- Schema and web-component plugin contracts, where covered by the test repository
 
 ### ❌ Not Covered (Future Work)
 - End-to-end plugin installation flow
 - Real GitHub repository access
-- Frontend component loading after installation
+- Browser-level verification that an installed web component renders correctly after installation
 - Polkit rule file creation (tested in integration, not unit)
 
 ## Testing Strategy
@@ -230,4 +234,3 @@ uv run pytest  # Also skips E2E (they're marked slow)
 - Integration tests use mocked external services
 - Unit tests focus on business logic
 - Integration tests focus on API contracts
-

--- a/frontend/tests/unit/components/plugins/Renderers.spec.js
+++ b/frontend/tests/unit/components/plugins/Renderers.spec.js
@@ -30,6 +30,31 @@ describe("SchemaRenderer dispatcher", () => {
     });
     expect(wrapper.text()).toContain("Unknown schema kind");
   });
+
+  it("dispatches web-component schemas to the web component host", () => {
+    const wrapper = mount(SchemaRenderer, {
+      props: {
+        schema: { kind: "web-component", element: "calvin-test-card", module: "dist.js" },
+        data: { value: 42 },
+        pluginId: "test-plugin",
+      },
+      global: {
+        stubs: {
+          WebComponentHost: {
+            props: ["schema", "data", "pluginId"],
+            template:
+              '<div class="web-component-host-stub" :data-plugin-id="pluginId">{{ schema.element }} {{ data.value }}</div>',
+          },
+        },
+      },
+    });
+
+    expect(wrapper.find(".web-component-host-stub").exists()).toBe(true);
+    expect(wrapper.find(".web-component-host-stub").attributes("data-plugin-id")).toBe(
+      "test-plugin"
+    );
+    expect(wrapper.text()).toContain("calvin-test-card 42");
+  });
 });
 
 describe("StatusList", () => {


### PR DESCRIPTION
## Summary
- update plugin docs for schema renderers and runtime-loaded web components
- remove stale Vue component/frontend rebuild guidance
- add and rename tests around frontend static assets, static asset serving, and schema web-component dispatch

## Tests
- cd backend && uv run pytest tests/unit/test_plugin_installer.py tests/unit/test_plugin_installer_github.py tests/integration/test_api_plugins.py::TestPluginInstallationAPI tests/integration/test_api_plugins_github.py::TestPluginUninstallAPI -v
- cd frontend && npm run test -- tests/unit/components/plugins/Renderers.spec.js tests/unit/components/plugins/WebComponentHost.spec.js --run
- cd frontend && npm run lint
- cd backend && uv run ruff check app tests