### PR TITLE
Refactor frontend config mapping through registry

### DIFF
--- a/backend/app/api/routes/config.py
+++ b/backend/app/api/routes/config.py
@@ -165,6 +165,10 @@ async def get_config():
         config["orientationFlipped"] = False  # Default to not flipped
     elif "orientation_flipped" in config and "orientationFlipped" not in config:
         config["orientationFlipped"] = config["orientation_flipped"]
+    if "applyDisplayRotation" not in config and "apply_display_rotation" not in config:
+        config["applyDisplayRotation"] = True  # Apply physical rotation by default
+    elif "apply_display_rotation" in config and "applyDisplayRotation" not in config:
+        config["applyDisplayRotation"] = config["apply_display_rotation"]
     if "lastSideViewMode" not in config and "last_side_view_mode" not in config:
         config["lastSideViewMode"] = "photos"  # Default to photos
     elif "last_side_view_mode" in config and "lastSideViewMode" not in config:
@@ -221,6 +225,18 @@ async def get_config():
         config["showWeekNumbers"] = False  # Hide week numbers by default
     elif "show_week_numbers" in config and "showWeekNumbers" not in config:
         config["showWeekNumbers"] = config["show_week_numbers"]
+    if "weekendDays" not in config and "weekend_days" not in config:
+        config["weekendDays"] = [0, 6]  # Sunday + Saturday by default
+    elif "weekend_days" in config and "weekendDays" not in config:
+        config["weekendDays"] = config["weekend_days"]
+    if "showRedDays" not in config and "show_red_days" not in config:
+        config["showRedDays"] = False  # Don't highlight red days by default
+    elif "show_red_days" in config and "showRedDays" not in config:
+        config["showRedDays"] = config["show_red_days"]
+    if "maxVisibleEvents" not in config and "max_visible_events" not in config:
+        config["maxVisibleEvents"] = 4  # Max 4 events per day cell by default
+    elif "max_visible_events" in config and "maxVisibleEvents" not in config:
+        config["maxVisibleEvents"] = config["max_visible_events"]
     if "sideViewPosition" not in config and "side_view_position" not in config:
         config["sideViewPosition"] = "right"  # Right/bottom default
     elif "side_view_position" in config and "sideViewPosition" not in config:
@@ -378,6 +394,58 @@ async def get_config():
         config["clockSize"] = "medium"  # Default size
     elif "clock_size" in config and "clockSize" not in config:
         config["clockSize"] = config["clock_size"]
+    if "clockWidgetEnabled" not in config and "clock_widget_enabled" not in config:
+        config["clockWidgetEnabled"] = False  # Widget disabled by default
+    elif "clock_widget_enabled" in config and "clockWidgetEnabled" not in config:
+        config["clockWidgetEnabled"] = config["clock_widget_enabled"]
+    if "clockWidgetShowInKiosk" not in config and "clock_widget_show_in_kiosk" not in config:
+        config["clockWidgetShowInKiosk"] = False  # Don't show in kiosk by default
+    elif "clock_widget_show_in_kiosk" in config and "clockWidgetShowInKiosk" not in config:
+        config["clockWidgetShowInKiosk"] = config["clock_widget_show_in_kiosk"]
+    if "clockWidgetPosition" not in config and "clock_widget_position" not in config:
+        config["clockWidgetPosition"] = "top-right"  # Default widget position
+    elif "clock_widget_position" in config and "clockWidgetPosition" not in config:
+        config["clockWidgetPosition"] = config["clock_widget_position"]
+    if "clockBarEnabled" not in config and "clock_bar_enabled" not in config:
+        config["clockBarEnabled"] = False  # Bar disabled by default
+    elif "clock_bar_enabled" in config and "clockBarEnabled" not in config:
+        config["clockBarEnabled"] = config["clock_bar_enabled"]
+    if "clockBarMode" not in config and "clock_bar_mode" not in config:
+        config["clockBarMode"] = "horizontal"  # Horizontal layout by default
+    elif "clock_bar_mode" in config and "clockBarMode" not in config:
+        config["clockBarMode"] = config["clock_bar_mode"]
+    if "clockBarShowInNonKiosk" not in config and "clock_bar_show_in_non_kiosk" not in config:
+        config["clockBarShowInNonKiosk"] = False  # Don't show in non-kiosk by default
+    elif "clock_bar_show_in_non_kiosk" in config and "clockBarShowInNonKiosk" not in config:
+        config["clockBarShowInNonKiosk"] = config["clock_bar_show_in_non_kiosk"]
+    if "clockBarShowInKiosk" not in config and "clock_bar_show_in_kiosk" not in config:
+        config["clockBarShowInKiosk"] = False  # Don't show in kiosk by default
+    elif "clock_bar_show_in_kiosk" in config and "clockBarShowInKiosk" not in config:
+        config["clockBarShowInKiosk"] = config["clock_bar_show_in_kiosk"]
+    if "clockBarPosition" not in config and "clock_bar_position" not in config:
+        config["clockBarPosition"] = "top"  # Top position by default
+    elif "clock_bar_position" in config and "clockBarPosition" not in config:
+        config["clockBarPosition"] = config["clock_bar_position"]
+    if "clockBarFontSize" not in config and "clock_bar_font_size" not in config:
+        config["clockBarFontSize"] = 16  # 16px default
+    elif "clock_bar_font_size" in config and "clockBarFontSize" not in config:
+        config["clockBarFontSize"] = config["clock_bar_font_size"]
+    if "clockBarDateFontSize" not in config and "clock_bar_date_font_size" not in config:
+        config["clockBarDateFontSize"] = 14  # 14px default
+    elif "clock_bar_date_font_size" in config and "clockBarDateFontSize" not in config:
+        config["clockBarDateFontSize"] = config["clock_bar_date_font_size"]
+    if "clockBarLayout" not in config and "clock_bar_layout" not in config:
+        config["clockBarLayout"] = "single-line"  # Single-line layout by default
+    elif "clock_bar_layout" in config and "clockBarLayout" not in config:
+        config["clockBarLayout"] = config["clock_bar_layout"]
+    if "clockBarPadding" not in config and "clock_bar_padding" not in config:
+        config["clockBarPadding"] = 8  # 8px default padding
+    elif "clock_bar_padding" in config and "clockBarPadding" not in config:
+        config["clockBarPadding"] = config["clock_bar_padding"]
+    if "clockBarShowWeather" not in config and "clock_bar_show_weather" not in config:
+        config["clockBarShowWeather"] = False  # Don't show weather by default
+    elif "clock_bar_show_weather" in config and "clockBarShowWeather" not in config:
+        config["clockBarShowWeather"] = config["clock_bar_show_weather"]
     if "mealPlanCardSize" not in config and "meal_plan_card_size" not in config:
         config["mealPlanCardSize"] = "medium"  # Default size
     elif "meal_plan_card_size" in config and "mealPlanCardSize" not in config:

--- a/backend/tests/integration/test_api_config.py
+++ b/backend/tests/integration/test_api_config.py
@@ -18,6 +18,82 @@ def test_get_config(test_client: TestClient):
 
 
 @pytest.mark.integration
+def test_get_config_returns_all_frontend_tracked_fields(test_client: TestClient):
+    """Every field the frontend config registry tracks must be present in the response.
+
+    The frontend Pinia store's `applyConfigPayload` resets missing fields to defaults on
+    every fetch. If the backend ever omits one of these keys, polling will quietly clobber
+    locally-mutated values back to defaults. Keep this list in sync with
+    frontend/src/stores/configRegistry.js (CONFIG_FIELD_DEFINITIONS).
+    """
+    expected_keys = {
+        "orientation",
+        "orientationFlipped",
+        "applyDisplayRotation",
+        "calendarSplit",
+        "sideViewPosition",
+        "lastSideViewMode",
+        "photoFrameEnabled",
+        "photoFrameTimeout",
+        "showUI",
+        "modeIndicatorTimeout",
+        "photoRotationInterval",
+        "calendarViewMode",
+        "calendarRefreshInterval",
+        "timeFormat",
+        "weekStartDay",
+        "showWeekNumbers",
+        "weekendDays",
+        "showRedDays",
+        "maxVisibleEvents",
+        "themeMode",
+        "selectedTheme",
+        "darkModeStart",
+        "darkModeEnd",
+        "displayScheduleEnabled",
+        "displaySchedule",
+        "displayTimeoutEnabled",
+        "displayTimeout",
+        "rebootComboKey1",
+        "rebootComboKey2",
+        "rebootComboDuration",
+        "keyboardFeedbackEnabled",
+        "keyboardFeedbackMode",
+        "imageDisplayMode",
+        "timezone",
+        "clockEnabled",
+        "clockDisplayMode",
+        "clockShowDate",
+        "clockShowSeconds",
+        "clockPosition",
+        "clockSize",
+        "clockWidgetEnabled",
+        "clockWidgetShowInKiosk",
+        "clockWidgetPosition",
+        "clockBarEnabled",
+        "clockBarMode",
+        "clockBarShowInNonKiosk",
+        "clockBarShowInKiosk",
+        "clockBarPosition",
+        "clockBarFontSize",
+        "clockBarDateFontSize",
+        "clockBarLayout",
+        "clockBarPadding",
+        "clockBarShowWeather",
+        "mealPlanCardSize",
+        "consoleLogEnabled",
+        "consoleLogLevel",
+        "configPollInterval",
+        "devMode",
+    }
+    response = test_client.get("/api/config")
+    assert response.status_code == 200
+    data = response.json()
+    missing = expected_keys - data.keys()
+    assert not missing, f"backend response missing registry-tracked keys: {sorted(missing)}"
+
+
+@pytest.mark.integration
 def test_update_config(test_client: TestClient):
     """Test updating configuration via API."""
     # Get current config

--- a/frontend/src/stores/config.js
+++ b/frontend/src/stores/config.js
@@ -2,6 +2,7 @@ import { defineStore } from "pinia";
 import { ref, computed } from "vue";
 import axios from "axios";
 import { logError } from "../utils/logger";
+import { applyConfigPayload, createDefaultDisplaySchedule } from "./configRegistry";
 
 export const useConfigStore = defineStore("config", () => {
   const orientation = ref("landscape"); // 'landscape' | 'portrait'
@@ -31,15 +32,7 @@ export const useConfigStore = defineStore("config", () => {
   const darkModeStart = ref(18); // Dark mode start hour (0-23, default 18 = 6 PM)
   const darkModeEnd = ref(6); // Dark mode end hour (0-23, default 6 = 6 AM)
   const displayScheduleEnabled = ref(false); // Enable display power schedule
-  const displaySchedule = ref([
-    { day: 0, enabled: true, onTime: "06:00", offTime: "22:00" }, // Monday
-    { day: 1, enabled: true, onTime: "06:00", offTime: "22:00" }, // Tuesday
-    { day: 2, enabled: true, onTime: "06:00", offTime: "22:00" }, // Wednesday
-    { day: 3, enabled: true, onTime: "06:00", offTime: "22:00" }, // Thursday
-    { day: 4, enabled: true, onTime: "06:00", offTime: "22:00" }, // Friday
-    { day: 5, enabled: true, onTime: "06:00", offTime: "22:00" }, // Saturday
-    { day: 6, enabled: true, onTime: "06:00", offTime: "22:00" }, // Sunday
-  ]); // Display schedule per day of week
+  const displaySchedule = ref(createDefaultDisplaySchedule()); // Display schedule per day of week
   const displayTimeoutEnabled = ref(false); // Enable display timeout (screensaver)
   const displayTimeout = ref(0); // Display timeout in seconds (0 = never)
   const rebootComboKey1 = ref("KEY_1"); // First key for reboot combo
@@ -79,6 +72,67 @@ export const useConfigStore = defineStore("config", () => {
   const loading = ref(false);
   const error = ref(null);
 
+  const configRefs = {
+    orientation,
+    orientationFlipped,
+    applyDisplayRotation,
+    calendarSplit,
+    sideViewPosition,
+    lastSideViewMode,
+    photoFrameEnabled,
+    photoFrameTimeout,
+    showUI,
+    modeIndicatorTimeout,
+    photoRotationInterval,
+    calendarViewMode,
+    calendarRefreshInterval,
+    timeFormat,
+    weekStartDay,
+    showWeekNumbers,
+    weekendDays,
+    showRedDays,
+    maxVisibleEvents,
+    themeMode,
+    selectedTheme,
+    darkModeStart,
+    darkModeEnd,
+    displayScheduleEnabled,
+    displaySchedule,
+    displayTimeoutEnabled,
+    displayTimeout,
+    rebootComboKey1,
+    rebootComboKey2,
+    rebootComboDuration,
+    keyboardFeedbackEnabled,
+    keyboardFeedbackMode,
+    imageDisplayMode,
+    timezone,
+    clockEnabled,
+    clockDisplayMode,
+    clockShowDate,
+    clockShowSeconds,
+    clockPosition,
+    clockSize,
+    clockWidgetEnabled,
+    clockWidgetShowInKiosk,
+    clockWidgetPosition,
+    clockBarEnabled,
+    clockBarMode,
+    clockBarShowInNonKiosk,
+    clockBarShowInKiosk,
+    clockBarPosition,
+    clockBarFontSize,
+    clockBarDateFontSize,
+    clockBarLayout,
+    clockBarPadding,
+    clockBarShowWeather,
+    mealPlanCardSize,
+    consoleLogEnabled,
+    consoleLogLevel,
+    configPollInterval,
+    devMode,
+  };
+
   const setOrientation = newOrientation => {
     orientation.value = newOrientation;
   };
@@ -112,358 +166,7 @@ export const useConfigStore = defineStore("config", () => {
     error.value = null;
     try {
       const response = await axios.get("/api/config");
-      // Update all config values to ensure reactivity
-      if (response.data.orientation !== undefined) {
-        orientation.value = response.data.orientation;
-      }
-      if (response.data.orientationFlipped !== undefined) {
-        orientationFlipped.value = response.data.orientationFlipped;
-      } else if (response.data.orientation_flipped !== undefined) {
-        orientationFlipped.value = response.data.orientation_flipped;
-      }
-      if (response.data.lastSideViewMode !== undefined) {
-        lastSideViewMode.value = response.data.lastSideViewMode;
-      } else if (response.data.last_side_view_mode !== undefined) {
-        lastSideViewMode.value = response.data.last_side_view_mode;
-      } else {
-        lastSideViewMode.value = "photos"; // Default
-      }
-      if (response.data.calendarSplit !== undefined) {
-        calendarSplit.value = response.data.calendarSplit;
-      }
-      if (response.data.calendar_split !== undefined) {
-        calendarSplit.value = response.data.calendar_split;
-      }
-      if (response.data.photoFrameEnabled !== undefined) {
-        photoFrameEnabled.value = response.data.photoFrameEnabled;
-      }
-      if (response.data.photo_frame_enabled !== undefined) {
-        photoFrameEnabled.value = response.data.photo_frame_enabled;
-      }
-      if (response.data.photoFrameTimeout !== undefined) {
-        photoFrameTimeout.value = response.data.photoFrameTimeout;
-      }
-      if (response.data.photo_frame_timeout !== undefined) {
-        photoFrameTimeout.value = response.data.photo_frame_timeout;
-      }
-      if (response.data.showUI !== undefined) {
-        showUI.value = response.data.showUI;
-      }
-      if (response.data.show_ui !== undefined) {
-        showUI.value = response.data.show_ui;
-      }
-      if (response.data.photoRotationInterval !== undefined) {
-        photoRotationInterval.value = response.data.photoRotationInterval;
-      }
-      if (response.data.photo_rotation_interval !== undefined) {
-        photoRotationInterval.value = response.data.photo_rotation_interval;
-      }
-      if (response.data.calendarViewMode !== undefined) {
-        calendarViewMode.value = response.data.calendarViewMode;
-      }
-      if (response.data.calendar_view_mode !== undefined) {
-        calendarViewMode.value = response.data.calendar_view_mode;
-      }
-      if (response.data.calendarRefreshInterval !== undefined) {
-        calendarRefreshInterval.value = response.data.calendarRefreshInterval;
-      } else if (response.data.calendar_refresh_interval !== undefined) {
-        calendarRefreshInterval.value = response.data.calendar_refresh_interval;
-      }
-      if (response.data.timeFormat !== undefined) {
-        timeFormat.value = response.data.timeFormat;
-      }
-      if (response.data.time_format !== undefined) {
-        timeFormat.value = response.data.time_format;
-      }
-      if (response.data.modeIndicatorTimeout !== undefined) {
-        modeIndicatorTimeout.value = response.data.modeIndicatorTimeout;
-      }
-      if (response.data.mode_indicator_timeout !== undefined) {
-        modeIndicatorTimeout.value = response.data.mode_indicator_timeout;
-      }
-      if (response.data.keyboardFeedbackEnabled !== undefined) {
-        keyboardFeedbackEnabled.value = response.data.keyboardFeedbackEnabled;
-      }
-      if (response.data.keyboard_feedback_enabled !== undefined) {
-        keyboardFeedbackEnabled.value = response.data.keyboard_feedback_enabled;
-      }
-      if (response.data.keyboardFeedbackMode !== undefined) {
-        keyboardFeedbackMode.value = response.data.keyboardFeedbackMode;
-      }
-      if (response.data.keyboard_feedback_mode !== undefined) {
-        keyboardFeedbackMode.value = response.data.keyboard_feedback_mode;
-      }
-      if (response.data.weekStartDay !== undefined) {
-        weekStartDay.value = response.data.weekStartDay;
-      }
-      if (response.data.week_start_day !== undefined) {
-        weekStartDay.value = response.data.week_start_day;
-      }
-      if (response.data.showWeekNumbers !== undefined) {
-        showWeekNumbers.value = response.data.showWeekNumbers;
-      }
-      if (response.data.show_week_numbers !== undefined) {
-        showWeekNumbers.value = response.data.show_week_numbers;
-      }
-      if (response.data.weekendDays !== undefined) {
-        weekendDays.value = response.data.weekendDays;
-      }
-      if (response.data.weekend_days !== undefined) {
-        weekendDays.value = response.data.weekend_days;
-      }
-      if (response.data.showRedDays !== undefined) {
-        showRedDays.value = response.data.showRedDays;
-      }
-      if (response.data.show_red_days !== undefined) {
-        showRedDays.value = response.data.show_red_days;
-      }
-      if (response.data.maxVisibleEvents !== undefined) {
-        maxVisibleEvents.value = response.data.maxVisibleEvents;
-      }
-      if (response.data.max_visible_events !== undefined) {
-        maxVisibleEvents.value = response.data.max_visible_events;
-      }
-      if (response.data.sideViewPosition !== undefined) {
-        sideViewPosition.value = response.data.sideViewPosition;
-      }
-      if (response.data.side_view_position !== undefined) {
-        sideViewPosition.value = response.data.side_view_position;
-      }
-      if (response.data.themeMode !== undefined) {
-        themeMode.value = response.data.themeMode;
-      }
-      if (response.data.theme_mode !== undefined) {
-        themeMode.value = response.data.theme_mode;
-      }
-      if (response.data.selectedTheme !== undefined) {
-        selectedTheme.value = response.data.selectedTheme;
-      }
-      if (response.data.selected_theme !== undefined) {
-        selectedTheme.value = response.data.selected_theme;
-      }
-      if (response.data.darkModeStart !== undefined) {
-        darkModeStart.value = response.data.darkModeStart;
-      }
-      if (response.data.dark_mode_start !== undefined) {
-        darkModeStart.value = response.data.dark_mode_start;
-      }
-      if (response.data.darkModeEnd !== undefined) {
-        darkModeEnd.value = response.data.darkModeEnd;
-      }
-      if (response.data.dark_mode_end !== undefined) {
-        darkModeEnd.value = response.data.dark_mode_end;
-      }
-      if (response.data.displayScheduleEnabled !== undefined) {
-        displayScheduleEnabled.value = response.data.displayScheduleEnabled;
-      }
-      if (response.data.display_schedule_enabled !== undefined) {
-        displayScheduleEnabled.value = response.data.display_schedule_enabled;
-      }
-      if (response.data.displaySchedule !== undefined) {
-        if (typeof response.data.displaySchedule === "string") {
-          displaySchedule.value = JSON.parse(response.data.displaySchedule);
-        } else {
-          displaySchedule.value = response.data.displaySchedule;
-        }
-      }
-      if (response.data.display_schedule !== undefined) {
-        if (typeof response.data.display_schedule === "string") {
-          displaySchedule.value = JSON.parse(response.data.display_schedule);
-        } else {
-          displaySchedule.value = response.data.display_schedule;
-        }
-      }
-      if (response.data.displayTimeoutEnabled !== undefined) {
-        displayTimeoutEnabled.value = response.data.displayTimeoutEnabled;
-      }
-      if (response.data.display_timeout_enabled !== undefined) {
-        displayTimeoutEnabled.value = response.data.display_timeout_enabled;
-      }
-      if (response.data.displayTimeout !== undefined) {
-        displayTimeout.value = response.data.displayTimeout;
-      }
-      if (response.data.display_timeout !== undefined) {
-        displayTimeout.value = response.data.display_timeout;
-      }
-      if (response.data.rebootComboKey1 !== undefined) {
-        rebootComboKey1.value = response.data.rebootComboKey1;
-      }
-      if (response.data.reboot_combo_key1 !== undefined) {
-        rebootComboKey1.value = response.data.reboot_combo_key1;
-      }
-      if (response.data.rebootComboKey2 !== undefined) {
-        rebootComboKey2.value = response.data.rebootComboKey2;
-      }
-      if (response.data.reboot_combo_key2 !== undefined) {
-        rebootComboKey2.value = response.data.reboot_combo_key2;
-      }
-      if (response.data.rebootComboDuration !== undefined) {
-        rebootComboDuration.value = response.data.rebootComboDuration;
-      }
-      if (response.data.reboot_combo_duration !== undefined) {
-        rebootComboDuration.value = response.data.reboot_combo_duration;
-      }
-      if (response.data.imageDisplayMode !== undefined) {
-        imageDisplayMode.value = response.data.imageDisplayMode;
-      }
-      if (response.data.image_display_mode !== undefined) {
-        imageDisplayMode.value = response.data.image_display_mode;
-      }
-      // Handle timezone - can be null, undefined, or a string
-      if (response.data.timezone !== undefined) {
-        timezone.value = response.data.timezone ?? null;
-      } else {
-        // Ensure timezone is always set (default to null if not provided)
-        timezone.value = null;
-      }
-      // Handle clock settings
-      if (response.data.clockEnabled !== undefined) {
-        clockEnabled.value = response.data.clockEnabled;
-      } else if (response.data.clock_enabled !== undefined) {
-        clockEnabled.value = response.data.clock_enabled;
-      }
-      if (response.data.clockDisplayMode !== undefined) {
-        clockDisplayMode.value = response.data.clockDisplayMode;
-      } else if (response.data.clock_display_mode !== undefined) {
-        clockDisplayMode.value = response.data.clock_display_mode;
-      } else {
-        clockDisplayMode.value = "header"; // Default
-      }
-      if (response.data.clockShowDate !== undefined) {
-        clockShowDate.value = response.data.clockShowDate;
-      } else if (response.data.clock_show_date !== undefined) {
-        clockShowDate.value = response.data.clock_show_date;
-      }
-      if (response.data.clockShowSeconds !== undefined) {
-        clockShowSeconds.value = response.data.clockShowSeconds;
-      } else if (response.data.clock_show_seconds !== undefined) {
-        clockShowSeconds.value = response.data.clock_show_seconds;
-      }
-      if (response.data.clockPosition !== undefined) {
-        clockPosition.value = response.data.clockPosition;
-      } else if (response.data.clock_position !== undefined) {
-        clockPosition.value = response.data.clock_position;
-      } else {
-        clockPosition.value = "top-right"; // Default
-      }
-      if (response.data.clockSize !== undefined) {
-        clockSize.value = response.data.clockSize;
-      } else if (response.data.clock_size !== undefined) {
-        clockSize.value = response.data.clock_size;
-      } else {
-        clockSize.value = "medium"; // Default
-      }
-      // New clock settings
-      if (response.data.clockWidgetEnabled !== undefined) {
-        clockWidgetEnabled.value = response.data.clockWidgetEnabled;
-      } else if (response.data.clock_widget_enabled !== undefined) {
-        clockWidgetEnabled.value = response.data.clock_widget_enabled;
-      }
-      if (response.data.clockWidgetShowInKiosk !== undefined) {
-        clockWidgetShowInKiosk.value = response.data.clockWidgetShowInKiosk;
-      } else if (response.data.clock_widget_show_in_kiosk !== undefined) {
-        clockWidgetShowInKiosk.value = response.data.clock_widget_show_in_kiosk;
-      }
-      if (response.data.clockWidgetPosition !== undefined) {
-        clockWidgetPosition.value = response.data.clockWidgetPosition;
-      } else if (response.data.clock_widget_position !== undefined) {
-        clockWidgetPosition.value = response.data.clock_widget_position;
-      } else {
-        clockWidgetPosition.value = "top-right"; // Default
-      }
-      if (response.data.clockBarEnabled !== undefined) {
-        clockBarEnabled.value = response.data.clockBarEnabled;
-      } else if (response.data.clock_bar_enabled !== undefined) {
-        clockBarEnabled.value = response.data.clock_bar_enabled;
-      }
-      if (response.data.clockBarMode !== undefined) {
-        clockBarMode.value = response.data.clockBarMode;
-      } else if (response.data.clock_bar_mode !== undefined) {
-        clockBarMode.value = response.data.clock_bar_mode;
-      } else {
-        clockBarMode.value = "horizontal"; // Default
-      }
-      if (response.data.clockBarShowInNonKiosk !== undefined) {
-        clockBarShowInNonKiosk.value = response.data.clockBarShowInNonKiosk;
-      } else if (response.data.clock_bar_show_in_non_kiosk !== undefined) {
-        clockBarShowInNonKiosk.value = response.data.clock_bar_show_in_non_kiosk;
-      }
-      if (response.data.clockBarShowInKiosk !== undefined) {
-        clockBarShowInKiosk.value = response.data.clockBarShowInKiosk;
-      } else if (response.data.clock_bar_show_in_kiosk !== undefined) {
-        clockBarShowInKiosk.value = response.data.clock_bar_show_in_kiosk;
-      }
-      if (response.data.clockBarPosition !== undefined) {
-        clockBarPosition.value = response.data.clockBarPosition;
-      } else if (response.data.clock_bar_position !== undefined) {
-        clockBarPosition.value = response.data.clock_bar_position;
-      } else {
-        clockBarPosition.value = "top"; // Default
-      }
-      if (response.data.clockBarFontSize !== undefined) {
-        clockBarFontSize.value = response.data.clockBarFontSize;
-      } else if (response.data.clock_bar_font_size !== undefined) {
-        clockBarFontSize.value = response.data.clock_bar_font_size;
-      } else {
-        clockBarFontSize.value = 16; // Default
-      }
-      if (response.data.clockBarDateFontSize !== undefined) {
-        clockBarDateFontSize.value = response.data.clockBarDateFontSize;
-      } else if (response.data.clock_bar_date_font_size !== undefined) {
-        clockBarDateFontSize.value = response.data.clock_bar_date_font_size;
-      } else {
-        clockBarDateFontSize.value = 14; // Default
-      }
-      if (response.data.clockBarLayout !== undefined) {
-        clockBarLayout.value = response.data.clockBarLayout;
-      } else if (response.data.clock_bar_layout !== undefined) {
-        clockBarLayout.value = response.data.clock_bar_layout;
-      } else {
-        clockBarLayout.value = "single-line"; // Default
-      }
-      if (response.data.clockBarPadding !== undefined) {
-        clockBarPadding.value = response.data.clockBarPadding;
-      } else if (response.data.clock_bar_padding !== undefined) {
-        clockBarPadding.value = response.data.clock_bar_padding;
-      } else {
-        clockBarPadding.value = 8; // Default
-      }
-      if (response.data.clockBarShowWeather !== undefined) {
-        clockBarShowWeather.value = response.data.clockBarShowWeather;
-      } else if (response.data.clock_bar_show_weather !== undefined) {
-        clockBarShowWeather.value = response.data.clock_bar_show_weather;
-      }
-      if (response.data.mealPlanCardSize !== undefined) {
-        mealPlanCardSize.value = response.data.mealPlanCardSize;
-      } else if (response.data.meal_plan_card_size !== undefined) {
-        mealPlanCardSize.value = response.data.meal_plan_card_size;
-      } else {
-        mealPlanCardSize.value = "medium"; // Default
-      }
-      if (response.data.consoleLogEnabled !== undefined) {
-        consoleLogEnabled.value = response.data.consoleLogEnabled;
-      } else if (response.data.console_log_enabled !== undefined) {
-        consoleLogEnabled.value = response.data.console_log_enabled;
-      } else {
-        consoleLogEnabled.value = true; // Default to enabled for backwards compatibility
-      }
-      if (response.data.consoleLogLevel !== undefined) {
-        consoleLogLevel.value = response.data.consoleLogLevel;
-      } else if (response.data.console_log_level !== undefined) {
-        consoleLogLevel.value = response.data.console_log_level;
-      } else {
-        consoleLogLevel.value = "info"; // Default to 'info' level
-      }
-      if (response.data.configPollInterval !== undefined) {
-        configPollInterval.value = response.data.configPollInterval;
-      } else if (response.data.config_poll_interval !== undefined) {
-        configPollInterval.value = response.data.config_poll_interval;
-      } else {
-        configPollInterval.value = 30; // Default to 30 seconds
-      }
-      if (response.data.devMode !== undefined) {
-        devMode.value = response.data.devMode;
-      }
+      applyConfigPayload(response.data, configRefs, { useDefaults: true });
       return response.data;
     } catch (err) {
       error.value = err.message;
@@ -478,161 +181,8 @@ export const useConfigStore = defineStore("config", () => {
     error.value = null;
     try {
       const response = await axios.post("/api/config", config);
-      // Update local config from response or from the config object passed in
-      if (config.orientation !== undefined) {
-        orientation.value = config.orientation;
-      }
-      if (config.orientationFlipped !== undefined) {
-        orientationFlipped.value = config.orientationFlipped;
-      }
-      if (config.applyDisplayRotation !== undefined) {
-        applyDisplayRotation.value = config.applyDisplayRotation;
-      } else if (config.apply_display_rotation !== undefined) {
-        applyDisplayRotation.value = config.apply_display_rotation;
-      }
-      if (config.lastSideViewMode !== undefined) {
-        lastSideViewMode.value = config.lastSideViewMode;
-      }
-      if (config.calendarSplit !== undefined) {
-        calendarSplit.value = config.calendarSplit;
-      }
-      if (config.showWeekNumbers !== undefined) {
-        showWeekNumbers.value = config.showWeekNumbers;
-      } else if (config.show_week_numbers !== undefined) {
-        showWeekNumbers.value = config.show_week_numbers;
-      }
-      if (config.timeFormat !== undefined) {
-        timeFormat.value = config.timeFormat;
-      } else if (config.time_format !== undefined) {
-        timeFormat.value = config.time_format;
-      }
-      if (config.maxVisibleEvents !== undefined) {
-        maxVisibleEvents.value = config.maxVisibleEvents;
-      } else if (config.max_visible_events !== undefined) {
-        maxVisibleEvents.value = config.max_visible_events;
-      }
-      if (config.weekendDays !== undefined) {
-        weekendDays.value = config.weekendDays;
-      } else if (config.weekend_days !== undefined) {
-        weekendDays.value = config.weekend_days;
-      }
-      if (config.showRedDays !== undefined) {
-        showRedDays.value = config.showRedDays;
-      } else if (config.show_red_days !== undefined) {
-        showRedDays.value = config.show_red_days;
-      }
-      if (config.mealPlanCardSize !== undefined) {
-        mealPlanCardSize.value = config.mealPlanCardSize;
-      } else if (config.meal_plan_card_size !== undefined) {
-        mealPlanCardSize.value = config.meal_plan_card_size;
-      }
-      if (config.showUI !== undefined) {
-        showUI.value = config.showUI;
-      } else if (config.show_ui !== undefined) {
-        showUI.value = config.show_ui;
-      }
-      // Also check response data in case backend returns it
-      if (response.data?.showUI !== undefined) {
-        showUI.value = response.data.showUI;
-      } else if (response.data?.show_ui !== undefined) {
-        showUI.value = response.data.show_ui;
-      }
-      if (config.clockPosition !== undefined) {
-        clockPosition.value = config.clockPosition;
-      } else if (config.clock_position !== undefined) {
-        clockPosition.value = config.clock_position;
-      }
-      if (config.clockEnabled !== undefined) {
-        clockEnabled.value = config.clockEnabled;
-      } else if (config.clock_enabled !== undefined) {
-        clockEnabled.value = config.clock_enabled;
-      }
-      if (config.clockDisplayMode !== undefined) {
-        clockDisplayMode.value = config.clockDisplayMode;
-      } else if (config.clock_display_mode !== undefined) {
-        clockDisplayMode.value = config.clock_display_mode;
-      }
-      if (config.clockShowDate !== undefined) {
-        clockShowDate.value = config.clockShowDate;
-      } else if (config.clock_show_date !== undefined) {
-        clockShowDate.value = config.clock_show_date;
-      }
-      if (config.clockShowSeconds !== undefined) {
-        clockShowSeconds.value = config.clockShowSeconds;
-      } else if (config.clock_show_seconds !== undefined) {
-        clockShowSeconds.value = config.clock_show_seconds;
-      }
-      if (config.clockSize !== undefined) {
-        clockSize.value = config.clockSize;
-      } else if (config.clock_size !== undefined) {
-        clockSize.value = config.clock_size;
-      }
-      // New clock settings
-      if (config.clockWidgetEnabled !== undefined) {
-        clockWidgetEnabled.value = config.clockWidgetEnabled;
-      } else if (config.clock_widget_enabled !== undefined) {
-        clockWidgetEnabled.value = config.clock_widget_enabled;
-      }
-      if (config.clockWidgetShowInKiosk !== undefined) {
-        clockWidgetShowInKiosk.value = config.clockWidgetShowInKiosk;
-      } else if (config.clock_widget_show_in_kiosk !== undefined) {
-        clockWidgetShowInKiosk.value = config.clock_widget_show_in_kiosk;
-      }
-      if (config.clockWidgetPosition !== undefined) {
-        clockWidgetPosition.value = config.clockWidgetPosition;
-      } else if (config.clock_widget_position !== undefined) {
-        clockWidgetPosition.value = config.clock_widget_position;
-      }
-      if (config.clockBarEnabled !== undefined) {
-        clockBarEnabled.value = config.clockBarEnabled;
-      } else if (config.clock_bar_enabled !== undefined) {
-        clockBarEnabled.value = config.clock_bar_enabled;
-      }
-      if (config.clockBarMode !== undefined) {
-        clockBarMode.value = config.clockBarMode;
-      } else if (config.clock_bar_mode !== undefined) {
-        clockBarMode.value = config.clock_bar_mode;
-      }
-      if (config.clockBarShowInNonKiosk !== undefined) {
-        clockBarShowInNonKiosk.value = config.clockBarShowInNonKiosk;
-      } else if (config.clock_bar_show_in_non_kiosk !== undefined) {
-        clockBarShowInNonKiosk.value = config.clock_bar_show_in_non_kiosk;
-      }
-      if (config.clockBarShowInKiosk !== undefined) {
-        clockBarShowInKiosk.value = config.clockBarShowInKiosk;
-      } else if (config.clock_bar_show_in_kiosk !== undefined) {
-        clockBarShowInKiosk.value = config.clock_bar_show_in_kiosk;
-      }
-      if (config.clockBarPosition !== undefined) {
-        clockBarPosition.value = config.clockBarPosition;
-      } else if (config.clock_bar_position !== undefined) {
-        clockBarPosition.value = config.clock_bar_position;
-      }
-      if (config.clockBarFontSize !== undefined) {
-        clockBarFontSize.value = config.clockBarFontSize;
-      } else if (config.clock_bar_font_size !== undefined) {
-        clockBarFontSize.value = config.clock_bar_font_size;
-      }
-      if (config.clockBarDateFontSize !== undefined) {
-        clockBarDateFontSize.value = config.clockBarDateFontSize;
-      } else if (config.clock_bar_date_font_size !== undefined) {
-        clockBarDateFontSize.value = config.clock_bar_date_font_size;
-      }
-      if (config.clockBarLayout !== undefined) {
-        clockBarLayout.value = config.clockBarLayout;
-      } else if (config.clock_bar_layout !== undefined) {
-        clockBarLayout.value = config.clock_bar_layout;
-      }
-      if (config.clockBarPadding !== undefined) {
-        clockBarPadding.value = config.clockBarPadding;
-      } else if (config.clock_bar_padding !== undefined) {
-        clockBarPadding.value = config.clock_bar_padding;
-      }
-      if (config.clockBarShowWeather !== undefined) {
-        clockBarShowWeather.value = config.clockBarShowWeather;
-      } else if (config.clock_bar_show_weather !== undefined) {
-        clockBarShowWeather.value = config.clock_bar_show_weather;
-      }
+      applyConfigPayload(config, configRefs);
+      applyConfigPayload(response.data || {}, configRefs);
       return response.data;
     } catch (err) {
       error.value = err.message;

--- a/frontend/src/stores/configRegistry.js
+++ b/frontend/src/stores/configRegistry.js
@@ -1,0 +1,258 @@
+export const createDefaultDisplaySchedule = () => [
+  { day: 0, enabled: true, onTime: "06:00", offTime: "22:00" },
+  { day: 1, enabled: true, onTime: "06:00", offTime: "22:00" },
+  { day: 2, enabled: true, onTime: "06:00", offTime: "22:00" },
+  { day: 3, enabled: true, onTime: "06:00", offTime: "22:00" },
+  { day: 4, enabled: true, onTime: "06:00", offTime: "22:00" },
+  { day: 5, enabled: true, onTime: "06:00", offTime: "22:00" },
+  { day: 6, enabled: true, onTime: "06:00", offTime: "22:00" },
+];
+
+const cloneDefault = value => {
+  if (typeof value === "function") return value();
+  if (Array.isArray(value) || (value && typeof value === "object")) {
+    return JSON.parse(JSON.stringify(value));
+  }
+  return value;
+};
+
+const parseJsonString = (value, fallback) => {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return fallback;
+  }
+};
+
+export const CONFIG_FIELD_DEFINITIONS = [
+  { name: "orientation", keys: ["orientation"], defaultValue: "landscape" },
+  {
+    name: "orientationFlipped",
+    keys: ["orientationFlipped", "orientation_flipped"],
+    defaultValue: false,
+  },
+  {
+    name: "applyDisplayRotation",
+    keys: ["applyDisplayRotation", "apply_display_rotation"],
+    defaultValue: true,
+  },
+  { name: "calendarSplit", keys: ["calendarSplit", "calendar_split"], defaultValue: 70 },
+  {
+    name: "sideViewPosition",
+    keys: ["sideViewPosition", "side_view_position"],
+    defaultValue: "right",
+  },
+  {
+    name: "lastSideViewMode",
+    keys: ["lastSideViewMode", "last_side_view_mode"],
+    defaultValue: "photos",
+  },
+  {
+    name: "photoFrameEnabled",
+    keys: ["photoFrameEnabled", "photo_frame_enabled"],
+    defaultValue: false,
+  },
+  {
+    name: "photoFrameTimeout",
+    keys: ["photoFrameTimeout", "photo_frame_timeout"],
+    defaultValue: 300,
+  },
+  { name: "showUI", keys: ["showUI", "show_ui"], defaultValue: true },
+  {
+    name: "modeIndicatorTimeout",
+    keys: ["modeIndicatorTimeout", "mode_indicator_timeout"],
+    defaultValue: 5,
+  },
+  {
+    name: "photoRotationInterval",
+    keys: ["photoRotationInterval", "photo_rotation_interval"],
+    defaultValue: 30,
+  },
+  {
+    name: "calendarViewMode",
+    keys: ["calendarViewMode", "calendar_view_mode"],
+    defaultValue: "month",
+  },
+  {
+    name: "calendarRefreshInterval",
+    keys: ["calendarRefreshInterval", "calendar_refresh_interval"],
+    defaultValue: 15,
+  },
+  { name: "timeFormat", keys: ["timeFormat", "time_format"], defaultValue: "24h" },
+  { name: "weekStartDay", keys: ["weekStartDay", "week_start_day"], defaultValue: 1 },
+  {
+    name: "showWeekNumbers",
+    keys: ["showWeekNumbers", "show_week_numbers"],
+    defaultValue: false,
+  },
+  { name: "weekendDays", keys: ["weekendDays", "weekend_days"], defaultValue: [0, 6] },
+  { name: "showRedDays", keys: ["showRedDays", "show_red_days"], defaultValue: false },
+  {
+    name: "maxVisibleEvents",
+    keys: ["maxVisibleEvents", "max_visible_events"],
+    defaultValue: 4,
+  },
+  { name: "themeMode", keys: ["themeMode", "theme_mode"], defaultValue: "auto" },
+  { name: "selectedTheme", keys: ["selectedTheme", "selected_theme"], defaultValue: null },
+  { name: "darkModeStart", keys: ["darkModeStart", "dark_mode_start"], defaultValue: 18 },
+  { name: "darkModeEnd", keys: ["darkModeEnd", "dark_mode_end"], defaultValue: 6 },
+  {
+    name: "displayScheduleEnabled",
+    keys: ["displayScheduleEnabled", "display_schedule_enabled"],
+    defaultValue: false,
+  },
+  {
+    name: "displaySchedule",
+    keys: ["displaySchedule", "display_schedule"],
+    defaultValue: createDefaultDisplaySchedule,
+    parse: value => parseJsonString(value, createDefaultDisplaySchedule()),
+  },
+  {
+    name: "displayTimeoutEnabled",
+    keys: ["displayTimeoutEnabled", "display_timeout_enabled"],
+    defaultValue: false,
+  },
+  { name: "displayTimeout", keys: ["displayTimeout", "display_timeout"], defaultValue: 0 },
+  {
+    name: "rebootComboKey1",
+    keys: ["rebootComboKey1", "reboot_combo_key1"],
+    defaultValue: "KEY_1",
+  },
+  {
+    name: "rebootComboKey2",
+    keys: ["rebootComboKey2", "reboot_combo_key2"],
+    defaultValue: "KEY_7",
+  },
+  {
+    name: "rebootComboDuration",
+    keys: ["rebootComboDuration", "reboot_combo_duration"],
+    defaultValue: 10000,
+  },
+  {
+    name: "keyboardFeedbackEnabled",
+    keys: ["keyboardFeedbackEnabled", "keyboard_feedback_enabled"],
+    defaultValue: true,
+  },
+  {
+    name: "keyboardFeedbackMode",
+    keys: ["keyboardFeedbackMode", "keyboard_feedback_mode"],
+    defaultValue: "normal",
+  },
+  {
+    name: "imageDisplayMode",
+    keys: ["imageDisplayMode", "image_display_mode"],
+    defaultValue: "smart",
+  },
+  { name: "timezone", keys: ["timezone"], defaultValue: null, parse: value => value ?? null },
+  { name: "clockEnabled", keys: ["clockEnabled", "clock_enabled"], defaultValue: true },
+  {
+    name: "clockDisplayMode",
+    keys: ["clockDisplayMode", "clock_display_mode"],
+    defaultValue: "header",
+  },
+  { name: "clockShowDate", keys: ["clockShowDate", "clock_show_date"], defaultValue: false },
+  {
+    name: "clockShowSeconds",
+    keys: ["clockShowSeconds", "clock_show_seconds"],
+    defaultValue: false,
+  },
+  { name: "clockPosition", keys: ["clockPosition", "clock_position"], defaultValue: "top-right" },
+  { name: "clockSize", keys: ["clockSize", "clock_size"], defaultValue: "medium" },
+  {
+    name: "clockWidgetEnabled",
+    keys: ["clockWidgetEnabled", "clock_widget_enabled"],
+    defaultValue: false,
+  },
+  {
+    name: "clockWidgetShowInKiosk",
+    keys: ["clockWidgetShowInKiosk", "clock_widget_show_in_kiosk"],
+    defaultValue: false,
+  },
+  {
+    name: "clockWidgetPosition",
+    keys: ["clockWidgetPosition", "clock_widget_position"],
+    defaultValue: "top-right",
+  },
+  { name: "clockBarEnabled", keys: ["clockBarEnabled", "clock_bar_enabled"], defaultValue: false },
+  { name: "clockBarMode", keys: ["clockBarMode", "clock_bar_mode"], defaultValue: "horizontal" },
+  {
+    name: "clockBarShowInNonKiosk",
+    keys: ["clockBarShowInNonKiosk", "clock_bar_show_in_non_kiosk"],
+    defaultValue: false,
+  },
+  {
+    name: "clockBarShowInKiosk",
+    keys: ["clockBarShowInKiosk", "clock_bar_show_in_kiosk"],
+    defaultValue: false,
+  },
+  {
+    name: "clockBarPosition",
+    keys: ["clockBarPosition", "clock_bar_position"],
+    defaultValue: "top",
+  },
+  {
+    name: "clockBarFontSize",
+    keys: ["clockBarFontSize", "clock_bar_font_size"],
+    defaultValue: 16,
+  },
+  {
+    name: "clockBarDateFontSize",
+    keys: ["clockBarDateFontSize", "clock_bar_date_font_size"],
+    defaultValue: 14,
+  },
+  {
+    name: "clockBarLayout",
+    keys: ["clockBarLayout", "clock_bar_layout"],
+    defaultValue: "single-line",
+  },
+  { name: "clockBarPadding", keys: ["clockBarPadding", "clock_bar_padding"], defaultValue: 8 },
+  {
+    name: "clockBarShowWeather",
+    keys: ["clockBarShowWeather", "clock_bar_show_weather"],
+    defaultValue: false,
+  },
+  {
+    name: "mealPlanCardSize",
+    keys: ["mealPlanCardSize", "meal_plan_card_size"],
+    defaultValue: "medium",
+  },
+  {
+    name: "consoleLogEnabled",
+    keys: ["consoleLogEnabled", "console_log_enabled"],
+    defaultValue: true,
+  },
+  {
+    name: "consoleLogLevel",
+    keys: ["consoleLogLevel", "console_log_level"],
+    defaultValue: "info",
+  },
+  {
+    name: "configPollInterval",
+    keys: ["configPollInterval", "config_poll_interval"],
+    defaultValue: 30,
+  },
+  { name: "devMode", keys: ["devMode", "dev_mode"], defaultValue: false },
+];
+
+export const getConfigPayloadValue = (payload, field) => {
+  for (const key of field.keys) {
+    if (payload?.[key] !== undefined) {
+      return { found: true, value: payload[key] };
+    }
+  }
+  return { found: false, value: undefined };
+};
+
+export const applyConfigPayload = (payload, refsByName, { useDefaults = false } = {}) => {
+  for (const field of CONFIG_FIELD_DEFINITIONS) {
+    const targetRef = refsByName[field.name];
+    if (!targetRef) continue;
+
+    const { found, value } = getConfigPayloadValue(payload, field);
+    if (!found && !useDefaults) continue;
+
+    const rawValue = found ? value : cloneDefault(field.defaultValue);
+    targetRef.value = field.parse ? field.parse(rawValue) : rawValue;
+  }
+};

--- a/frontend/tests/unit/stores/config.spec.js
+++ b/frontend/tests/unit/stores/config.spec.js
@@ -73,6 +73,41 @@ describe("Config Store", () => {
     expect(store.showUI).toBe(false);
   });
 
+  it("should hydrate snake_case aliases and parse JSON schedule values", async () => {
+    const schedule = [{ day: 0, enabled: false, onTime: "07:30", offTime: "21:00" }];
+    axios.get.mockResolvedValue({
+      data: {
+        apply_display_rotation: false,
+        calendar_refresh_interval: 5,
+        display_schedule: JSON.stringify(schedule),
+        clock_bar_show_in_kiosk: true,
+        console_log_level: "debug",
+      },
+    });
+
+    const store = useConfigStore();
+    await store.fetchConfig();
+
+    expect(store.applyDisplayRotation).toBe(false);
+    expect(store.calendarRefreshInterval).toBe(5);
+    expect(store.displaySchedule).toEqual(schedule);
+    expect(store.clockBarShowInKiosk).toBe(true);
+    expect(store.consoleLogLevel).toBe("debug");
+  });
+
+  it("should apply defaults for missing values after fetch", async () => {
+    axios.get.mockResolvedValue({ data: { orientation: "portrait" } });
+
+    const store = useConfigStore();
+    store.setLastSideViewMode("web_services");
+    await store.fetchConfig();
+
+    expect(store.orientation).toBe("portrait");
+    expect(store.lastSideViewMode).toBe("photos");
+    expect(store.timezone).toBeNull();
+    expect(store.clockDisplayMode).toBe("header");
+  });
+
   it("should update config via API", async () => {
     const updateData = {
       orientation: "landscape",
@@ -93,6 +128,23 @@ describe("Config Store", () => {
     expect(axios.post).toHaveBeenCalledWith("/api/config", updateData);
     expect(store.orientation).toBe("landscape");
     expect(store.calendarSplit).toBe(72);
+  });
+
+  it("should update all registered config fields from camelCase or snake_case payloads", async () => {
+    axios.post.mockResolvedValue({ data: { show_ui: true, clock_bar_padding: 12 } });
+
+    const store = useConfigStore();
+    await store.updateConfig({
+      apply_display_rotation: false,
+      displaySchedule: [{ day: 1, enabled: true, onTime: "08:00", offTime: "20:00" }],
+      clockBarShowWeather: true,
+    });
+
+    expect(store.applyDisplayRotation).toBe(false);
+    expect(store.displaySchedule[0].day).toBe(1);
+    expect(store.clockBarShowWeather).toBe(true);
+    expect(store.showUI).toBe(true);
+    expect(store.clockBarPadding).toBe(12);
   });
 
   it("should handle API errors gracefully", async () => {


### PR DESCRIPTION
## Summary
- add a config registry for frontend config keys, aliases, defaults, and parsers
- replace hand-written fetch/update mapping blocks in the Pinia config store
- add tests for snake_case aliases, default fallback, JSON schedule parsing, and update application

## Tests
- cd frontend && npm run test -- tests/unit/stores/config.spec.js --run
- cd frontend && npm run test -- tests/unit/stores tests/unit/composables --run
- cd frontend && npm run lint