### PR TITLE
Add structured update state tracking

### DIFF
--- a/backend/app/api/routes/system.py
+++ b/backend/app/api/routes/system.py
@@ -10,6 +10,7 @@ import subprocess
 import threading
 import time
 from pathlib import Path
+from typing import Any
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import StreamingResponse
@@ -93,6 +94,22 @@ _UPDATE_LOG_LOCATIONS = [
     lambda: Path("/tmp/calvin-update.log"),  # nosec B108 - read-only fallback for log discovery
     lambda: Path("/var/log/calvin-update.log"),
 ]
+_UPDATE_STATE_STALE_AFTER_SEC = 15 * 60
+_COMMIT_KEYS = {
+    "current_commit",
+    "current_commit_short",
+    "current_commit_msg",
+    "new_commit",
+    "new_commit_short",
+    "new_commit_msg",
+}
+
+_UPDATE_STATE_LOCATIONS = [
+    lambda: settings.repo_dir / "backend" / "logs" / "calvin-update-state.json",
+    lambda: settings.repo_dir.parent / "calvin-update-state.json",
+    lambda: Path("/tmp/calvin-update-state.json"),  # nosec B108 - read-only fallback
+    lambda: Path("/var/log/calvin-update-state.json"),
+]
 
 
 def _find_update_log() -> Path | None:
@@ -101,6 +118,86 @@ def _find_update_log() -> Path | None:
         if p.exists():
             return p
     return None
+
+
+def _find_update_state() -> Path | None:
+    for loc_fn in _UPDATE_STATE_LOCATIONS:
+        p = loc_fn()
+        if p.exists():
+            return p
+    return None
+
+
+def _empty_update_status(status: str, message: str) -> dict[str, Any]:
+    return {
+        "status": status,
+        "message": message,
+        "current_commit": None,
+        "current_commit_short": None,
+        "current_commit_msg": None,
+        "new_commit": None,
+        "new_commit_short": None,
+        "new_commit_msg": None,
+        "backend_restarted": False,
+    }
+
+
+def _read_update_state(state_file: Path) -> dict[str, Any] | None:
+    try:
+        with open(state_file, encoding="utf-8") as f:
+            state = json.load(f)
+        return state if isinstance(state, dict) else None
+    except (OSError, json.JSONDecodeError):
+        logger.warning("Failed to read update state file: %s", state_file, exc_info=True)
+        return None
+
+
+def _state_to_update_status(state: dict[str, Any], state_file: Path) -> dict[str, Any]:
+    raw_status = str(state.get("status") or "unknown").lower()
+    status = {
+        "success": "idle",
+        "complete": "idle",
+        "completed": "idle",
+        "running": "running",
+        "error": "error",
+        "failed": "error",
+    }.get(raw_status, "unknown")
+    message = str(state.get("message") or "Update status unknown. Check logs for details.")
+
+    if status == "running":
+        state_mtime = state_file.stat().st_mtime
+        stale_after = state.get("stale_after_seconds", _UPDATE_STATE_STALE_AFTER_SEC)
+        try:
+            stale_after = int(stale_after)
+        except (TypeError, ValueError):
+            stale_after = _UPDATE_STATE_STALE_AFTER_SEC
+
+        if (time.time() - state_mtime) > stale_after:
+            status = "error"
+            message = "Update appears to have stalled or failed"
+
+    data = _empty_update_status(status, message)
+    data.update(
+        {
+            "state_status": raw_status,
+            "phase": state.get("phase"),
+            "started_at": state.get("started_at"),
+            "updated_at": state.get("updated_at"),
+            "finished_at": state.get("finished_at"),
+            "error": state.get("error"),
+            "mode": state.get("mode"),
+            "branch": state.get("branch"),
+            "log_file": state.get("log_file"),
+            "state_file": str(state_file),
+            "backend_restarted": bool(state.get("backend_restarted", False)),
+        }
+    )
+
+    for key in _COMMIT_KEYS:
+        if key in state:
+            data[key] = state.get(key)
+
+    return data
 
 
 @router.post("/update")
@@ -127,10 +224,28 @@ async def trigger_update():
         log_dir = settings.repo_dir / "backend" / "logs"
         log_dir.mkdir(parents=True, exist_ok=True)
         log_file = log_dir / "calvin-update.log"
+        state_file = log_dir / "calvin-update-state.json"
 
         # Capture current end-of-file position so the stream endpoint knows
         # where this run's output begins (the log is appended, not truncated).
         log_offset = int(log_file.stat().st_size) if log_file.exists() else 0
+
+        state_file.write_text(
+            json.dumps(
+                {
+                    "status": "running",
+                    "phase": "starting",
+                    "message": "Starting Calvin update",
+                    "mode": os.environ.get("CALVIN_MODE"),
+                    "branch": git_branch,
+                    "log_file": str(log_file),
+                    "started_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                    "updated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
 
         # Run update script in background (non-blocking)
         # Redirect both stdout and stderr to log file AND keep them for error checking
@@ -145,12 +260,12 @@ async def trigger_update():
                     **os.environ,
                     "PATH": settings.system_path,
                     "GIT_BRANCH": git_branch,  # Pass git branch to update script
+                    "UPDATE_LOG_FILE": str(log_file),
+                    "UPDATE_STATE_FILE": str(state_file),
                 },
             )
 
         # Wait a moment to see if process starts successfully
-        import time
-
         time.sleep(0.5)
 
         # Check if process is still running (didn't immediately fail)
@@ -169,6 +284,23 @@ async def trigger_update():
                     "Log file not created. Script may not be executable or may have failed."
                 )
 
+            state_file.write_text(
+                json.dumps(
+                    {
+                        "status": "error",
+                        "phase": "starting",
+                        "message": "Update script exited immediately.",
+                        "error": error_msg,
+                        "branch": git_branch,
+                        "log_file": str(log_file),
+                        "started_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                        "updated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                        "finished_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
             raise HTTPException(status_code=500, detail=error_msg)
 
         return {
@@ -176,6 +308,7 @@ async def trigger_update():
             "message": f"Update process started (PID: {process.pid})",
             "pid": process.pid,
             "log_file": str(log_file),
+            "state_file": str(state_file),
             "log_offset": log_offset,
         }
     except HTTPException:
@@ -190,20 +323,18 @@ async def get_update_status():
     Get the status of the last update.
     Reads the last few lines from the update log.
     """
+    state_file = _find_update_state()
+    if state_file:
+        state = _read_update_state(state_file)
+        if state:
+            return _state_to_update_status(state, state_file)
+
     log_file = _find_update_log()
 
     if not log_file or not log_file.exists():
-        return {
-            "status": "unknown",
-            "message": "Update log not found. No updates have been run yet.",
-            "current_commit": None,
-            "current_commit_short": None,
-            "current_commit_msg": None,
-            "new_commit": None,
-            "new_commit_short": None,
-            "new_commit_msg": None,
-            "backend_restarted": False,
-        }
+        return _empty_update_status(
+            "unknown", "Update log not found. No updates have been run yet."
+        )
 
     try:
         # Read last 50 lines of log for better context (increased to capture commit info)
@@ -390,18 +521,9 @@ async def get_update_status():
             "backend_restarted": has_backend_restarted,
         }
     except Exception as e:
-        return {
-            "status": "error",
-            "message": f"Failed to read update log: {str(e)}",
-            "last_log": "",
-            "current_commit": None,
-            "current_commit_short": None,
-            "current_commit_msg": None,
-            "new_commit": None,
-            "new_commit_short": None,
-            "new_commit_msg": None,
-            "backend_restarted": False,
-        }
+        data = _empty_update_status("error", f"Failed to read update log: {str(e)}")
+        data["last_log"] = ""
+        return data
 
 
 @router.get("/update/stream")

--- a/backend/tests/integration/test_api_system.py
+++ b/backend/tests/integration/test_api_system.py
@@ -246,6 +246,11 @@ class TestSystemUpdateEndpoints:
         data = response.json()
         assert data["status"] == "started"
         assert "pid" in data
+        assert data["state_file"].endswith("calvin-update-state.json")
+
+        popen_env = mock_popen.call_args.kwargs["env"]
+        assert popen_env["UPDATE_STATE_FILE"].endswith("calvin-update-state.json")
+        assert popen_env["UPDATE_LOG_FILE"].endswith("calvin-update.log")
 
 
 @pytest.mark.integration

--- a/backend/tests/unit/test_update_status_parsing.py
+++ b/backend/tests/unit/test_update_status_parsing.py
@@ -1,3 +1,4 @@
+import json
 import os
 import time
 
@@ -80,3 +81,116 @@ async def test_update_status_detects_running_when_recently_updated(monkeypatch, 
 
     data = await get_update_status()
     assert data["status"] == "running"
+
+
+async def test_update_status_prefers_structured_success_state(monkeypatch, tmp_path):
+    from app.api.routes.system import get_update_status
+    from app.config import settings
+
+    repo_dir = tmp_path / "repo"
+    monkeypatch.setattr(settings, "repo_dir", repo_dir, raising=False)
+
+    state_file = repo_dir / "backend" / "logs" / "calvin-update-state.json"
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(
+        json.dumps(
+            {
+                "status": "success",
+                "phase": "complete",
+                "message": "Update completed successfully",
+                "current_commit": "abc123",
+                "new_commit": "def456",
+                "backend_restarted": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    data = await get_update_status()
+    assert data["status"] == "idle"
+    assert data["state_status"] == "success"
+    assert data["phase"] == "complete"
+    assert data["current_commit"] == "abc123"
+    assert data["new_commit"] == "def456"
+    assert data["backend_restarted"] is True
+
+
+async def test_update_status_reads_structured_running_state(monkeypatch, tmp_path):
+    from app.api.routes.system import get_update_status
+    from app.config import settings
+
+    repo_dir = tmp_path / "repo"
+    monkeypatch.setattr(settings, "repo_dir", repo_dir, raising=False)
+
+    state_file = repo_dir / "backend" / "logs" / "calvin-update-state.json"
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(
+        json.dumps(
+            {
+                "status": "running",
+                "phase": "pulling_code",
+                "message": "Pulling latest code",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    data = await get_update_status()
+    assert data["status"] == "running"
+    assert data["phase"] == "pulling_code"
+    assert data["message"] == "Pulling latest code"
+
+
+async def test_update_status_reads_structured_error_state(monkeypatch, tmp_path):
+    from app.api.routes.system import get_update_status
+    from app.config import settings
+
+    repo_dir = tmp_path / "repo"
+    monkeypatch.setattr(settings, "repo_dir", repo_dir, raising=False)
+
+    state_file = repo_dir / "backend" / "logs" / "calvin-update-state.json"
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(
+        json.dumps(
+            {
+                "status": "error",
+                "phase": "healthcheck",
+                "message": "Update failed. Check logs for details.",
+                "error": "curl exited with 1",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    data = await get_update_status()
+    assert data["status"] == "error"
+    assert data["phase"] == "healthcheck"
+    assert data["error"] == "curl exited with 1"
+
+
+async def test_update_status_marks_stale_structured_running_state_error(monkeypatch, tmp_path):
+    from app.api.routes.system import get_update_status
+    from app.config import settings
+
+    repo_dir = tmp_path / "repo"
+    monkeypatch.setattr(settings, "repo_dir", repo_dir, raising=False)
+
+    state_file = repo_dir / "backend" / "logs" / "calvin-update-state.json"
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(
+        json.dumps(
+            {
+                "status": "running",
+                "phase": "healthcheck",
+                "message": "Waiting for Calvin to become healthy",
+                "stale_after_seconds": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    stale = time.time() - 10
+    os.utime(state_file, (stale, stale))
+
+    data = await get_update_status()
+    assert data["status"] == "error"
+    assert data["message"] == "Update appears to have stalled or failed"

--- a/scripts/update-calvin.sh
+++ b/scripts/update-calvin.sh
@@ -29,12 +29,23 @@ CURRENT_COMMIT_MSG=""
 NEW_COMMIT=""
 NEW_COMMIT_SHORT=""
 NEW_COMMIT_MSG=""
+BACKEND_RESTARTED="false"
 
 json_escape() {
-  printf '%s' "$1" | sed \
-    -e 's/\\/\\\\/g' \
-    -e 's/"/\\"/g' \
-    -e 's/	/\\t/g'
+  local s="$1"
+  local bs='\\' dq='\"' bb='\b' bf='\f' bn='\n' br='\r' bt='\t'
+  s="${s//\\/$bs}"
+  s="${s//\"/$dq}"
+  s="${s//$'\b'/$bb}"
+  s="${s//$'\f'/$bf}"
+  s="${s//$'\n'/$bn}"
+  s="${s//$'\r'/$br}"
+  s="${s//$'\t'/$bt}"
+  printf '%s' "$s"
+}
+
+_json_field() {
+  printf '  "%s": "%s"' "$1" "$(json_escape "$2")"
 }
 
 write_update_state() {
@@ -42,36 +53,43 @@ write_update_state() {
   local phase="$2"
   local message="$3"
   local error="${4:-}"
-  local now
-  local finished_at=""
+  local now finished_at=""
 
   now="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
   if [[ "$status" == "success" || "$status" == "error" ]]; then
     finished_at="$now"
   fi
 
+  local lines=()
+  lines+=("$(_json_field status "$status")")
+  lines+=("$(_json_field phase "$phase")")
+  lines+=("$(_json_field message "$message")")
+  lines+=("$(_json_field mode "$CALVIN_MODE")")
+  lines+=("$(_json_field branch "$GIT_BRANCH")")
+  lines+=("$(_json_field log_file "$UPDATE_LOG_FILE")")
+  lines+=("$(_json_field started_at "$UPDATE_STARTED_AT")")
+  lines+=("$(_json_field updated_at "$now")")
+  [[ -n "$finished_at" ]] && lines+=("$(_json_field finished_at "$finished_at")")
+  [[ -n "$CURRENT_COMMIT" ]] && lines+=("$(_json_field current_commit "$CURRENT_COMMIT")")
+  [[ -n "$CURRENT_COMMIT_SHORT" ]] && lines+=("$(_json_field current_commit_short "$CURRENT_COMMIT_SHORT")")
+  [[ -n "$CURRENT_COMMIT_MSG" ]] && lines+=("$(_json_field current_commit_msg "$CURRENT_COMMIT_MSG")")
+  [[ -n "$NEW_COMMIT" ]] && lines+=("$(_json_field new_commit "$NEW_COMMIT")")
+  [[ -n "$NEW_COMMIT_SHORT" ]] && lines+=("$(_json_field new_commit_short "$NEW_COMMIT_SHORT")")
+  [[ -n "$NEW_COMMIT_MSG" ]] && lines+=("$(_json_field new_commit_msg "$NEW_COMMIT_MSG")")
+  lines+=("  \"backend_restarted\": $BACKEND_RESTARTED")
+  [[ -n "$error" ]] && lines+=("$(_json_field error "$error")")
+
   mkdir -p "$(dirname "$UPDATE_STATE_FILE")"
   {
     printf '{\n'
-    printf '  "status": "%s",\n' "$(json_escape "$status")"
-    printf '  "phase": "%s",\n' "$(json_escape "$phase")"
-    printf '  "message": "%s",\n' "$(json_escape "$message")"
-    printf '  "mode": "%s",\n' "$(json_escape "$CALVIN_MODE")"
-    printf '  "branch": "%s",\n' "$(json_escape "$GIT_BRANCH")"
-    printf '  "log_file": "%s",\n' "$(json_escape "$UPDATE_LOG_FILE")"
-    printf '  "started_at": "%s",\n' "$(json_escape "$UPDATE_STARTED_AT")"
-    printf '  "updated_at": "%s",\n' "$(json_escape "$now")"
-    if [[ -n "$finished_at" ]]; then
-      printf '  "finished_at": "%s",\n' "$(json_escape "$finished_at")"
-    fi
-    printf '  "current_commit": "%s",\n' "$(json_escape "$CURRENT_COMMIT")"
-    printf '  "current_commit_short": "%s",\n' "$(json_escape "$CURRENT_COMMIT_SHORT")"
-    printf '  "current_commit_msg": "%s",\n' "$(json_escape "$CURRENT_COMMIT_MSG")"
-    printf '  "new_commit": "%s",\n' "$(json_escape "$NEW_COMMIT")"
-    printf '  "new_commit_short": "%s",\n' "$(json_escape "$NEW_COMMIT_SHORT")"
-    printf '  "new_commit_msg": "%s",\n' "$(json_escape "$NEW_COMMIT_MSG")"
-    printf '  "backend_restarted": %s,\n' "false"
-    printf '  "error": "%s"\n' "$(json_escape "$error")"
+    local i last=$((${#lines[@]} - 1))
+    for ((i = 0; i <= last; i++)); do
+      if (( i < last )); then
+        printf '%s,\n' "${lines[i]}"
+      else
+        printf '%s\n' "${lines[i]}"
+      fi
+    done
     printf '}\n'
   } >"${UPDATE_STATE_FILE}.tmp"
   mv "${UPDATE_STATE_FILE}.tmp" "$UPDATE_STATE_FILE"
@@ -95,12 +113,14 @@ capture_new_commit() {
 
 on_error() {
   local exit_code=$?
+  trap - ERR
   write_update_state "error" "$UPDATE_PHASE" "Update failed. Check logs for details." \
     "line ${BASH_LINENO[0]}: ${BASH_COMMAND} exited with ${exit_code}"
   exit "$exit_code"
 }
 
 fail_update() {
+  trap - ERR
   local message="$1"
   echo "$message" >&2
   write_update_state "error" "$UPDATE_PHASE" "$message" "$message"
@@ -165,6 +185,7 @@ if compose_is_dev; then
     write_update_state "running" "$UPDATE_PHASE" "Recreating dev compose stack"
     echo "==> Recreating dev compose stack"
     compose -f "$COMPOSE_FILE" up -d --force-recreate
+    BACKEND_RESTARTED="true"
   else
     echo "==> Dev source updated; hot reload will pick up code changes"
     echo "==> Skipping compose recreate because host compose control is unavailable"
@@ -184,6 +205,7 @@ else
   write_update_state "running" "$UPDATE_PHASE" "Restarting Calvin"
   echo "==> Restarting Calvin"
   compose -f "$COMPOSE_FILE" up -d
+  BACKEND_RESTARTED="true"
 fi
 
 wait_for_health

--- a/scripts/update-calvin.sh
+++ b/scripts/update-calvin.sh
@@ -19,8 +19,99 @@ CALVIN_MODE="${CALVIN_MODE:-prod}"
 REPO_DIR="${REPO_DIR:-/home/calvin/calvin}"
 GIT_BRANCH="${GIT_BRANCH:-main}"
 WAIT_TIMEOUT="${WAIT_TIMEOUT:-180}"
+UPDATE_LOG_FILE="${UPDATE_LOG_FILE:-${REPO_DIR}/backend/logs/calvin-update.log}"
+UPDATE_STATE_FILE="${UPDATE_STATE_FILE:-${REPO_DIR}/backend/logs/calvin-update-state.json}"
+UPDATE_STARTED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+UPDATE_PHASE="starting"
+CURRENT_COMMIT=""
+CURRENT_COMMIT_SHORT=""
+CURRENT_COMMIT_MSG=""
+NEW_COMMIT=""
+NEW_COMMIT_SHORT=""
+NEW_COMMIT_MSG=""
+
+json_escape() {
+  printf '%s' "$1" | sed \
+    -e 's/\\/\\\\/g' \
+    -e 's/"/\\"/g' \
+    -e 's/	/\\t/g'
+}
+
+write_update_state() {
+  local status="$1"
+  local phase="$2"
+  local message="$3"
+  local error="${4:-}"
+  local now
+  local finished_at=""
+
+  now="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  if [[ "$status" == "success" || "$status" == "error" ]]; then
+    finished_at="$now"
+  fi
+
+  mkdir -p "$(dirname "$UPDATE_STATE_FILE")"
+  {
+    printf '{\n'
+    printf '  "status": "%s",\n' "$(json_escape "$status")"
+    printf '  "phase": "%s",\n' "$(json_escape "$phase")"
+    printf '  "message": "%s",\n' "$(json_escape "$message")"
+    printf '  "mode": "%s",\n' "$(json_escape "$CALVIN_MODE")"
+    printf '  "branch": "%s",\n' "$(json_escape "$GIT_BRANCH")"
+    printf '  "log_file": "%s",\n' "$(json_escape "$UPDATE_LOG_FILE")"
+    printf '  "started_at": "%s",\n' "$(json_escape "$UPDATE_STARTED_AT")"
+    printf '  "updated_at": "%s",\n' "$(json_escape "$now")"
+    if [[ -n "$finished_at" ]]; then
+      printf '  "finished_at": "%s",\n' "$(json_escape "$finished_at")"
+    fi
+    printf '  "current_commit": "%s",\n' "$(json_escape "$CURRENT_COMMIT")"
+    printf '  "current_commit_short": "%s",\n' "$(json_escape "$CURRENT_COMMIT_SHORT")"
+    printf '  "current_commit_msg": "%s",\n' "$(json_escape "$CURRENT_COMMIT_MSG")"
+    printf '  "new_commit": "%s",\n' "$(json_escape "$NEW_COMMIT")"
+    printf '  "new_commit_short": "%s",\n' "$(json_escape "$NEW_COMMIT_SHORT")"
+    printf '  "new_commit_msg": "%s",\n' "$(json_escape "$NEW_COMMIT_MSG")"
+    printf '  "backend_restarted": %s,\n' "false"
+    printf '  "error": "%s"\n' "$(json_escape "$error")"
+    printf '}\n'
+  } >"${UPDATE_STATE_FILE}.tmp"
+  mv "${UPDATE_STATE_FILE}.tmp" "$UPDATE_STATE_FILE"
+}
+
+capture_current_commit() {
+  if [[ -d "$REPO_DIR/.git" ]]; then
+    CURRENT_COMMIT="$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null || true)"
+    CURRENT_COMMIT_SHORT="$(git -C "$REPO_DIR" rev-parse --short HEAD 2>/dev/null || true)"
+    CURRENT_COMMIT_MSG="$(git -C "$REPO_DIR" log -1 --pretty=%s 2>/dev/null || true)"
+  fi
+}
+
+capture_new_commit() {
+  if [[ -d "$REPO_DIR/.git" ]]; then
+    NEW_COMMIT="$(git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null || true)"
+    NEW_COMMIT_SHORT="$(git -C "$REPO_DIR" rev-parse --short HEAD 2>/dev/null || true)"
+    NEW_COMMIT_MSG="$(git -C "$REPO_DIR" log -1 --pretty=%s 2>/dev/null || true)"
+  fi
+}
+
+on_error() {
+  local exit_code=$?
+  write_update_state "error" "$UPDATE_PHASE" "Update failed. Check logs for details." \
+    "line ${BASH_LINENO[0]}: ${BASH_COMMAND} exited with ${exit_code}"
+  exit "$exit_code"
+}
+
+fail_update() {
+  local message="$1"
+  echo "$message" >&2
+  write_update_state "error" "$UPDATE_PHASE" "$message" "$message"
+  exit 1
+}
+
+trap on_error ERR
 
 echo "Starting Calvin update..."
+capture_current_commit
+write_update_state "running" "$UPDATE_PHASE" "Starting Calvin update"
 
 compose_is_dev() {
   [[ "$CALVIN_MODE" == "dev" ]]
@@ -38,6 +129,8 @@ compose() {
 }
 
 wait_for_health() {
+  UPDATE_PHASE="healthcheck"
+  write_update_state "running" "$UPDATE_PHASE" "Waiting for Calvin to become healthy"
   echo "==> Waiting up to ${WAIT_TIMEOUT}s for /api/health to come back"
   local elapsed=0
   while [[ $elapsed -lt $WAIT_TIMEOUT ]]; do
@@ -56,16 +149,20 @@ wait_for_health() {
 
 if compose_is_dev; then
   if [[ ! -d "$REPO_DIR/.git" ]]; then
-    echo "Dev update requires a git checkout at $REPO_DIR" >&2
-    exit 1
+    fail_update "Dev update requires a git checkout at $REPO_DIR"
   fi
 
+  UPDATE_PHASE="pulling_code"
+  write_update_state "running" "$UPDATE_PHASE" "Pulling latest code"
   echo "==> Pulling latest code"
   git -C "$REPO_DIR" fetch origin "$GIT_BRANCH"
   git -C "$REPO_DIR" checkout "$GIT_BRANCH"
   git -C "$REPO_DIR" pull --ff-only --autostash origin "$GIT_BRANCH"
+  capture_new_commit
 
   if [[ -f "$COMPOSE_FILE" ]] && compose version >/dev/null 2>&1; then
+    UPDATE_PHASE="restarting"
+    write_update_state "running" "$UPDATE_PHASE" "Recreating dev compose stack"
     echo "==> Recreating dev compose stack"
     compose -f "$COMPOSE_FILE" up -d --force-recreate
   else
@@ -74,17 +171,22 @@ if compose_is_dev; then
   fi
 else
   if [[ ! -f "$COMPOSE_FILE" ]]; then
-    echo "Compose file not found at $COMPOSE_FILE" >&2
     echo "Set COMPOSE_FILE=/path/to/docker-compose.yml or run setup.sh first." >&2
-    exit 1
+    fail_update "Compose file not found at $COMPOSE_FILE"
   fi
 
+  UPDATE_PHASE="pulling_image"
+  write_update_state "running" "$UPDATE_PHASE" "Pulling latest Calvin runtime image"
   echo "==> Pulling latest Calvin runtime image"
   compose -f "$COMPOSE_FILE" pull
 
+  UPDATE_PHASE="restarting"
+  write_update_state "running" "$UPDATE_PHASE" "Restarting Calvin"
   echo "==> Restarting Calvin"
   compose -f "$COMPOSE_FILE" up -d
 fi
 
 wait_for_health
+UPDATE_PHASE="complete"
+write_update_state "success" "$UPDATE_PHASE" "Update completed successfully"
 echo "Update complete!"


### PR DESCRIPTION
## Summary
- write structured JSON update state snapshots from the update script
- have /api/system/update/status prefer structured state with legacy log fallback
- pass log/state paths through trigger_update and cover state parsing in tests

## Tests
- uv run pytest tests/unit/test_update_status_parsing.py tests/integration/test_api_system.py -v
- uv run ruff check app tests
- bash -n scripts/update-calvin.sh
- git diff --check