### PR TITLE
Show update health status in settings

### DIFF
--- a/frontend/src/components/settings/tabs/system/UpdatesTab.vue
+++ b/frontend/src/components/settings/tabs/system/UpdatesTab.vue
@@ -375,22 +375,22 @@ watch(
 }
 
 .status-pill.success {
-  background: rgba(40, 167, 69, 0.14);
-  color: #1f7a39;
+  background: color-mix(in srgb, var(--accent-secondary) 18%, transparent);
+  color: var(--accent-secondary);
 }
 
 .status-pill.info {
-  background: rgba(23, 162, 184, 0.14);
-  color: #0c5460;
+  background: color-mix(in srgb, var(--accent-primary) 18%, transparent);
+  color: var(--accent-primary);
 }
 
 .status-pill.error {
-  background: rgba(220, 53, 69, 0.14);
-  color: #b02a37;
+  background: color-mix(in srgb, var(--accent-error) 18%, transparent);
+  color: var(--accent-error);
 }
 
 .status-pill.neutral {
-  background: rgba(108, 117, 125, 0.14);
+  background: var(--bg-tertiary);
   color: var(--text-secondary);
 }
 

--- a/frontend/src/components/settings/tabs/system/UpdatesTab.vue
+++ b/frontend/src/components/settings/tabs/system/UpdatesTab.vue
@@ -21,6 +21,13 @@
 
       <SettingItem label="Update Actions" help="Trigger system update">
         <div class="button-group">
+          <button
+            class="btn-secondary"
+            :disabled="statusRefreshLoading"
+            @click="refreshSystemStatus"
+          >
+            {{ statusRefreshLoading ? "Checking..." : "Check status" }}
+          </button>
           <button class="btn-primary" :disabled="updating" @click="handleTriggerUpdate">
             {{ updating ? "Updating..." : "🔄 Trigger Update" }}
           </button>
@@ -31,17 +38,56 @@
         {{ updateMessage }}
       </div>
 
+      <div class="health-summary" aria-label="System health summary">
+        <div class="status-tile">
+          <span class="status-label">Backend API</span>
+          <span class="status-pill" :class="backendHealthClass">
+            {{ backendHealthLabel }}
+          </span>
+          <span v-if="backendHealthCheckedAt" class="status-meta">
+            {{ formatDateTime(backendHealthCheckedAt) }}
+          </span>
+        </div>
+        <div class="status-tile">
+          <span class="status-label">Update state</span>
+          <span class="status-pill" :class="updateStatusClass">
+            {{ updateStatusLabel }}
+          </span>
+          <span v-if="updateStatus?.phase" class="status-meta">
+            {{ formatPhase(updateStatus.phase) }}
+          </span>
+        </div>
+        <div v-if="updateStatusCheckedAt" class="status-tile">
+          <span class="status-label">Last checked</span>
+          <span class="status-value">{{ formatDateTime(updateStatusCheckedAt) }}</span>
+        </div>
+      </div>
+
+      <div v-if="backendHealth?.error" class="update-message warning">
+        {{ backendHealth.error }}
+      </div>
+
       <div v-if="updateStatus" class="update-status">
         <SettingItem label="Update Status">
           <div class="status-details">
             <p><strong>Status:</strong> {{ updateStatus.status }}</p>
+            <p v-if="updateStatus.phase">
+              <strong>Phase:</strong> {{ formatPhase(updateStatus.phase) }}
+            </p>
             <p v-if="updateStatus.message"><strong>Message:</strong> {{ updateStatus.message }}</p>
             <p v-if="updateStatus.progress !== undefined">
               <strong>Progress:</strong> {{ updateStatus.progress }}%
             </p>
+            <p v-if="updateStatus.started_at">
+              <strong>Started:</strong> {{ formatDateTime(updateStatus.started_at) }}
+            </p>
+            <p v-if="updateStatus.finished_at">
+              <strong>Finished:</strong> {{ formatDateTime(updateStatus.finished_at) }}
+            </p>
             <p v-if="updateStatus.log_file">
               <strong>Log file:</strong> {{ updateStatus.log_file }}
             </p>
+            <p v-if="updateStatus.error"><strong>Error:</strong> {{ updateStatus.error }}</p>
           </div>
         </SettingItem>
 
@@ -74,7 +120,7 @@
 </template>
 
 <script setup>
-import { ref, watch, onMounted } from "vue";
+import { computed, ref, watch, onMounted } from "vue";
 import { useSystem } from "@/composables";
 import { getGitBranches } from "@/services/configApi";
 import CollapsibleSection from "../../shared/CollapsibleSection.vue";
@@ -93,11 +139,69 @@ const props = defineProps({
 
 const emit = defineEmits(["update:gitRepoUrl", "update:gitBranch"]);
 
-const { updating, updateStatus, updateMessage, updateMessageClass, triggerUpdate } = useSystem();
+const {
+  updating,
+  updateStatus,
+  updateStatusLoading,
+  updateStatusCheckedAt,
+  updateMessage,
+  updateMessageClass,
+  backendHealth,
+  backendHealthLoading,
+  backendHealthCheckedAt,
+  triggerUpdate,
+  getUpdateStatus,
+  getBackendHealth,
+} = useSystem();
 
 const availableBranches = ref([props.gitBranch || "main"]);
 const localGitRepoUrl = ref(props.gitRepoUrl || "");
 const lastEmittedGitRepoUrl = ref(props.gitRepoUrl || "");
+const statusRefreshLoading = computed(
+  () => updateStatusLoading.value || backendHealthLoading.value
+);
+
+const backendHealthLabel = computed(() => {
+  if (backendHealthLoading.value) return "Checking";
+  return backendHealth.value?.status || "Unknown";
+});
+
+const backendHealthClass = computed(() => ({
+  success: backendHealth.value?.status === "healthy",
+  error: backendHealth.value?.status === "unhealthy",
+  neutral: !backendHealth.value,
+}));
+
+const updateStatusLabel = computed(() => {
+  if (updateStatusLoading.value) return "Checking";
+  return updateStatus.value?.status || "Unknown";
+});
+
+const updateStatusClass = computed(() => ({
+  success: updateStatus.value?.status === "idle",
+  info: updateStatus.value?.status === "running",
+  error: updateStatus.value?.status === "error",
+  neutral: !updateStatus.value || updateStatus.value?.status === "unknown",
+}));
+
+const formatPhase = phase => {
+  if (!phase) return "";
+  return String(phase)
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, char => char.toUpperCase());
+};
+
+const formatDateTime = value => {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};
 
 const handleGitRepoChange = () => {
   if (
@@ -117,6 +221,10 @@ const handleTriggerUpdate = async () => {
   await triggerUpdate();
 };
 
+const refreshSystemStatus = async () => {
+  await Promise.allSettled([getBackendHealth(), getUpdateStatus()]);
+};
+
 const loadBranches = async () => {
   try {
     const branches = await getGitBranches();
@@ -128,6 +236,7 @@ const loadBranches = async () => {
 
 onMounted(() => {
   loadBranches();
+  refreshSystemStatus();
 });
 
 watch(
@@ -150,18 +259,29 @@ watch(
 .button-group {
   display: flex;
   gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
-.btn-primary {
+.btn-primary,
+.btn-secondary {
   padding: 0.5rem 1rem;
-  background: var(--accent-primary);
-  color: white;
-  border: none;
   border-radius: 4px;
   font-size: 0.9rem;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.2s;
+}
+
+.btn-primary {
+  background: var(--accent-primary);
+  color: white;
+  border: none;
+}
+
+.btn-secondary {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
 }
 
 .btn-primary:hover:not(:disabled) {
@@ -170,7 +290,12 @@ watch(
   box-shadow: 0 2px 4px var(--shadow);
 }
 
-.btn-primary:disabled {
+.btn-secondary:hover:not(:disabled) {
+  border-color: var(--accent-primary);
+}
+
+.btn-primary:disabled,
+.btn-secondary:disabled {
   opacity: 0.6;
   cursor: not-allowed;
 }
@@ -208,6 +333,65 @@ watch(
 
 .update-status {
   margin-top: 1rem;
+}
+
+.health-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.status-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 0;
+  padding: 0.75rem;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+}
+
+.status-label,
+.status-meta {
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+}
+
+.status-value {
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  overflow-wrap: anywhere;
+}
+
+.status-pill {
+  align-self: flex-start;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.status-pill.success {
+  background: rgba(40, 167, 69, 0.14);
+  color: #1f7a39;
+}
+
+.status-pill.info {
+  background: rgba(23, 162, 184, 0.14);
+  color: #0c5460;
+}
+
+.status-pill.error {
+  background: rgba(220, 53, 69, 0.14);
+  color: #b02a37;
+}
+
+.status-pill.neutral {
+  background: rgba(108, 117, 125, 0.14);
+  color: var(--text-secondary);
 }
 
 .status-details {

--- a/frontend/src/composables/useSystem.js
+++ b/frontend/src/composables/useSystem.js
@@ -8,8 +8,13 @@ import * as systemApi from "../services/systemApi";
 // Singleton refs so any component using useSystem() shares the same status
 const updating = ref(false);
 const updateStatus = ref(null);
+const updateStatusLoading = ref(false);
+const updateStatusCheckedAt = ref(null);
 const updateMessage = ref("");
 const updateMessageClass = ref("");
+const backendHealth = ref(null);
+const backendHealthLoading = ref(false);
+const backendHealthCheckedAt = ref(null);
 
 let _clearMsgTimer = null;
 
@@ -52,6 +57,30 @@ export function useSystem() {
       await sleep(intervalMs);
     }
     return false;
+  };
+
+  const getBackendHealth = async () => {
+    backendHealthLoading.value = true;
+    try {
+      const health = await systemApi.getHealth();
+      backendHealth.value = {
+        status: health?.status || "healthy",
+        data: health,
+        error: null,
+      };
+      backendHealthCheckedAt.value = new Date().toISOString();
+      return backendHealth.value;
+    } catch (error) {
+      backendHealth.value = {
+        status: "unhealthy",
+        data: null,
+        error: error.response?.data?.detail || error.message || "Backend health check failed",
+      };
+      backendHealthCheckedAt.value = new Date().toISOString();
+      return backendHealth.value;
+    } finally {
+      backendHealthLoading.value = false;
+    }
   };
 
   // Display power control
@@ -311,13 +340,17 @@ export function useSystem() {
   };
 
   const getUpdateStatus = async () => {
+    updateStatusLoading.value = true;
     try {
       const status = await systemApi.getUpdateStatus();
       updateStatus.value = status;
+      updateStatusCheckedAt.value = new Date().toISOString();
       return status;
     } catch (error) {
       console.error("Failed to get update status:", error);
       throw error;
+    } finally {
+      updateStatusLoading.value = false;
     }
   };
 
@@ -328,12 +361,18 @@ export function useSystem() {
     displayTimeoutEnabled,
     updating,
     updateStatus,
+    updateStatusLoading,
+    updateStatusCheckedAt,
     updateMessage,
     updateMessageClass,
+    backendHealth,
+    backendHealthLoading,
+    backendHealthCheckedAt,
     // Methods
     turnDisplayOn,
     turnDisplayOff,
     configureDisplayTimeout,
+    getBackendHealth,
     restartBackend,
     restartFrontend,
     triggerUpdate,

--- a/frontend/tests/unit/components/UpdatesTab.spec.js
+++ b/frontend/tests/unit/components/UpdatesTab.spec.js
@@ -2,14 +2,23 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { flushPromises, mount } from "@vue/test-utils";
 import UpdatesTab from "@/components/settings/tabs/system/UpdatesTab.vue";
 
+const systemMock = vi.hoisted(() => ({
+  updating: { value: false, __v_isRef: true },
+  updateStatus: { value: null, __v_isRef: true },
+  updateStatusLoading: { value: false, __v_isRef: true },
+  updateStatusCheckedAt: { value: null, __v_isRef: true },
+  updateMessage: { value: "", __v_isRef: true },
+  updateMessageClass: { value: "", __v_isRef: true },
+  backendHealth: { value: null, __v_isRef: true },
+  backendHealthLoading: { value: false, __v_isRef: true },
+  backendHealthCheckedAt: { value: null, __v_isRef: true },
+  triggerUpdate: vi.fn(),
+  getUpdateStatus: vi.fn(() => Promise.resolve({ status: "unknown" })),
+  getBackendHealth: vi.fn(() => Promise.resolve({ status: "healthy" })),
+}));
+
 vi.mock("@/composables", () => ({
-  useSystem: () => ({
-    updating: false,
-    updateStatus: null,
-    updateMessage: "",
-    updateMessageClass: "",
-    triggerUpdate: vi.fn(),
-  }),
+  useSystem: () => systemMock,
 }));
 
 vi.mock("@/services/configApi", () => ({
@@ -19,6 +28,17 @@ vi.mock("@/services/configApi", () => ({
 describe("UpdatesTab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    systemMock.updating.value = false;
+    systemMock.updateStatus.value = null;
+    systemMock.updateStatusLoading.value = false;
+    systemMock.updateStatusCheckedAt.value = null;
+    systemMock.updateMessage.value = "";
+    systemMock.updateMessageClass.value = "";
+    systemMock.backendHealth.value = null;
+    systemMock.backendHealthLoading.value = false;
+    systemMock.backendHealthCheckedAt.value = null;
+    systemMock.getUpdateStatus.mockResolvedValue({ status: "unknown" });
+    systemMock.getBackendHealth.mockResolvedValue({ status: "healthy" });
   });
 
   it("does not save repo URL on every keystroke", async () => {
@@ -67,5 +87,41 @@ describe("UpdatesTab", () => {
     await branchSelect.setValue("develop");
 
     expect(wrapper.emitted("update:gitBranch")).toEqual([["develop"]]);
+  });
+
+  it("refreshes backend and update status on mount", async () => {
+    mount(UpdatesTab, {
+      props: {
+        gitRepoUrl: "https://github.com/example/calvin.git",
+        gitBranch: "main",
+      },
+    });
+
+    await flushPromises();
+
+    expect(systemMock.getBackendHealth).toHaveBeenCalled();
+    expect(systemMock.getUpdateStatus).toHaveBeenCalled();
+  });
+
+  it("shows backend health and structured update phase", async () => {
+    systemMock.backendHealth.value = { status: "healthy" };
+    systemMock.backendHealthCheckedAt.value = "2026-05-03T10:15:00Z";
+    systemMock.updateStatus.value = {
+      status: "running",
+      phase: "pulling_code",
+      message: "Pulling latest code",
+    };
+
+    const wrapper = mount(UpdatesTab, {
+      props: {
+        gitRepoUrl: "https://github.com/example/calvin.git",
+        gitBranch: "main",
+      },
+    });
+
+    expect(wrapper.text()).toContain("Backend API");
+    expect(wrapper.text()).toContain("healthy");
+    expect(wrapper.text()).toContain("Pulling Code");
+    expect(wrapper.text()).toContain("Pulling latest code");
   });
 });

--- a/frontend/tests/unit/composables/useSystem.spec.js
+++ b/frontend/tests/unit/composables/useSystem.spec.js
@@ -67,8 +67,36 @@ describe("useSystem", () => {
       expect(system.displayTimeoutEnabled.value).toBe(false);
       expect(system.updating.value).toBe(false);
       expect(system.updateStatus.value).toBe(null);
+      expect(system.updateStatusLoading.value).toBe(false);
       expect(system.updateMessage.value).toBe("");
       expect(system.updateMessageClass.value).toBe("");
+      expect(system.backendHealth.value).toBe(null);
+      expect(system.backendHealthLoading.value).toBe(false);
+    });
+  });
+
+  describe("getBackendHealth", () => {
+    it("stores healthy backend status", async () => {
+      systemApi.getHealth.mockResolvedValue({ status: "healthy" });
+
+      const system = useSystem();
+      const health = await system.getBackendHealth();
+
+      expect(systemApi.getHealth).toHaveBeenCalled();
+      expect(health.status).toBe("healthy");
+      expect(system.backendHealth.value.status).toBe("healthy");
+      expect(system.backendHealthCheckedAt.value).toBeTruthy();
+    });
+
+    it("stores unhealthy backend status on health check failure", async () => {
+      systemApi.getHealth.mockRejectedValue(new Error("down"));
+
+      const system = useSystem();
+      const health = await system.getBackendHealth();
+
+      expect(health.status).toBe("unhealthy");
+      expect(system.backendHealth.value.error).toBe("down");
+      expect(system.backendHealthLoading.value).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
- add backend health and update-status refresh state to useSystem
- show compact backend/update status tiles in the Updates settings tab
- render structured update phase/timestamps/errors when present while remaining compatible with legacy status responses

## Tests
- npm run test -- tests/unit/components/UpdatesTab.spec.js tests/unit/composables/useSystem.spec.js --run
- npm run lint
- npm run build
- git diff --check