### PR TITLE
Stream structured update state events

### DIFF
--- a/backend/app/api/routes/system.py
+++ b/backend/app/api/routes/system.py
@@ -538,11 +538,44 @@ async def stream_update_log(log_offset: int = 0):
         timeout_sec = 10 * 60
         inactivity_timeout_sec = 90
         has_started = False
+        last_state_mtime = None
 
         while time.time() - start_time < timeout_sec:
             if time.time() - last_keepalive > 15:
                 yield ": keepalive\n\n"
                 last_keepalive = time.time()
+
+            state_file = _find_update_state()
+            if state_file:
+                try:
+                    state_mtime = state_file.stat().st_mtime
+                    if state_mtime != last_state_mtime:
+                        last_state_mtime = state_mtime
+                        state = _read_update_state(state_file)
+                        if state:
+                            status_data = _state_to_update_status(state, state_file)
+                            stream_status = status_data["status"]
+                            if stream_status == "idle":
+                                stream_status = "complete"
+
+                            yield (
+                                "data: "
+                                + json.dumps(
+                                    {
+                                        "type": "status",
+                                        "status": stream_status,
+                                        "state": status_data,
+                                        "message": status_data.get("message"),
+                                        "phase": status_data.get("phase"),
+                                    }
+                                )
+                                + "\n\n"
+                            )
+
+                            if stream_status in {"complete", "error"}:
+                                return
+                except Exception as e:
+                    yield f"data: {json.dumps({'type': 'log', 'line': f'[state stream error: {e}]'})}\n\n"
 
             log_file = _find_update_log()
             if log_file:

--- a/backend/app/api/routes/system.py
+++ b/backend/app/api/routes/system.py
@@ -551,6 +551,7 @@ async def stream_update_log(log_offset: int = 0):
                     state_mtime = state_file.stat().st_mtime
                     if state_mtime != last_state_mtime:
                         last_state_mtime = state_mtime
+                        last_activity = time.time()
                         state = _read_update_state(state_file)
                         if state:
                             status_data = _state_to_update_status(state, state_file)

--- a/backend/tests/integration/test_api_system.py
+++ b/backend/tests/integration/test_api_system.py
@@ -1,5 +1,6 @@
 """Integration tests for system API endpoints."""
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -251,6 +252,32 @@ class TestSystemUpdateEndpoints:
         popen_env = mock_popen.call_args.kwargs["env"]
         assert popen_env["UPDATE_STATE_FILE"].endswith("calvin-update-state.json")
         assert popen_env["UPDATE_LOG_FILE"].endswith("calvin-update.log")
+
+    def test_update_stream_emits_structured_state(self, test_client, tmp_path):
+        """SSE stream emits terminal status from structured state even without log output."""
+        state_file = tmp_path / "backend" / "logs" / "calvin-update-state.json"
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text(
+            json.dumps(
+                {
+                    "status": "success",
+                    "phase": "complete",
+                    "message": "Update completed successfully",
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.object(system_routes.settings, "repo_dir", tmp_path):
+            response = test_client.get("/api/system/update/stream")
+
+        if response.status_code == 404:
+            pytest.skip("Update stream route not available in test client")
+
+        assert response.status_code == 200
+        assert '"type": "status"' in response.text
+        assert '"status": "complete"' in response.text
+        assert "Update completed successfully" in response.text
 
 
 @pytest.mark.integration

--- a/backend/tests/integration/test_api_system.py
+++ b/backend/tests/integration/test_api_system.py
@@ -271,9 +271,6 @@ class TestSystemUpdateEndpoints:
         with patch.object(system_routes.settings, "repo_dir", tmp_path):
             response = test_client.get("/api/system/update/stream")
 
-        if response.status_code == 404:
-            pytest.skip("Update stream route not available in test client")
-
         assert response.status_code == 200
         assert '"type": "status"' in response.text
         assert '"status": "complete"' in response.text

--- a/frontend/src/composables/useSystem.js
+++ b/frontend/src/composables/useSystem.js
@@ -183,6 +183,18 @@ export function useSystem() {
             }
             updateMessageClass.value = "info";
           } else if (data.type === "status") {
+            if (data.state) {
+              updateStatus.value = {
+                ...(updateStatus.value || {}),
+                ...data.state,
+                last_log: updateStatus.value?.last_log || "",
+              };
+            }
+            if (data.status === "running") {
+              updateMessage.value = data.message || "Update in progress…";
+              updateMessageClass.value = "info";
+              return;
+            }
             es.close();
             resolve(data);
           } else if (data.type === "timeout") {

--- a/frontend/tests/unit/composables/useSystem.spec.js
+++ b/frontend/tests/unit/composables/useSystem.spec.js
@@ -306,6 +306,35 @@ describe("useSystem", () => {
       expect(system.updateMessage.value).toBe("Update failed: Build failed");
       expect(system.updateMessageClass.value).toBe("error");
     });
+
+    it("keeps streaming when the server sends a running state snapshot", async () => {
+      systemApi.triggerUpdate.mockResolvedValue({ log_offset: 0 });
+      systemApi.getHealth.mockResolvedValue({ status: "healthy" });
+      vi.useRealTimers();
+
+      const system = useSystem();
+      const promise = system.triggerUpdate();
+
+      await fireStreamEvent({
+        type: "status",
+        status: "running",
+        message: "Pulling latest code",
+        state: {
+          status: "running",
+          phase: "pulling_code",
+          message: "Pulling latest code",
+        },
+      });
+
+      expect(FakeEventSource.last.closed).toBe(false);
+      expect(system.updateStatus.value.phase).toBe("pulling_code");
+      expect(system.updateMessage.value).toBe("Pulling latest code");
+
+      await fireStreamEvent({ type: "status", status: "complete" });
+      await promise;
+
+      expect(system.updateMessageClass.value).toBe("success");
+    });
   });
 
   describe("getUpdateStatus", () => {


### PR DESCRIPTION
## Summary
- emit structured update state snapshots through the existing SSE update stream
- keep log-line streaming for compatibility and only close the stream on terminal state events
- teach the frontend stream handler to keep listening on running state snapshots

## Tests
- uv run pytest tests/unit/test_update_status_parsing.py tests/integration/test_api_system.py -v
- npm run test -- tests/unit/composables/useSystem.spec.js --run
- uv run ruff check app tests
- npm run lint
- git diff --check

Stacked on #28.