### PR TITLE
Add kiosk-only Pi deployment + rewrite Getting Started

### DIFF
--- a/deploy/systemd/calvin-kiosk-remote.service
+++ b/deploy/systemd/calvin-kiosk-remote.service
@@ -1,0 +1,61 @@
+[Unit]
+Description=Calvin Dashboard Kiosk (remote backend)
+After=network-online.target calvin-x.service
+Wants=network-online.target graphical.target calvin-x.service
+
+[Service]
+Type=simple
+User=calvin
+Group=calvin
+EnvironmentFile=/etc/default/calvin-kiosk
+Environment="DISPLAY=:0"
+Environment="HOME=/home/calvin"
+Environment="XAUTHORITY=/home/calvin/.Xauthority"
+ExecStartPre=/bin/bash -c 'timeout=240; elapsed=0; until curl -sf "${CALVIN_BACKEND_URL%/}/api/health" > /dev/null 2>&1; do if [ $elapsed -ge $timeout ]; then echo "Calvin backend at ${CALVIN_BACKEND_URL} not ready after $timeout seconds"; exit 1; fi; sleep 1; elapsed=$((elapsed+1)); done'
+ExecStartPre=/bin/bash -c 'timeout=60; elapsed=0; until [ -S /tmp/.X11-unix/X0 ] || pgrep -x Xorg > /dev/null 2>&1; do if [ $elapsed -ge $timeout ]; then echo "X server not available after $timeout seconds"; exit 1; fi; sleep 1; elapsed=$((elapsed+1)); done'
+ExecStartPre=/bin/sleep 2
+ExecStartPre=/bin/bash -c 'pkill -u calvin chromium || pkill -u calvin chromium-browser || true'
+ExecStartPre=/bin/sleep 1
+ExecStartPre=/bin/bash -c 'rm -rf /home/calvin/.cache/chromium/Default/Cache/* "/home/calvin/.cache/chromium/Default/Code Cache"/* 2>/dev/null || true'
+ExecStart=/bin/bash -c '/usr/bin/chromium \
+    --kiosk \
+    --noerrdialogs \
+    --disable-infobars \
+    --autoplay-policy=no-user-gesture-required \
+    --disable-features=TranslateUI,AudioServiceOutOfProcess \
+    --disable-ipc-flooding-protection \
+    --disable-background-networking \
+    --disable-background-timer-throttling \
+    --disable-renderer-backgrounding \
+    --disable-backgrounding-occluded-windows \
+    --disable-breakpad \
+    --disable-component-update \
+    --disable-domain-reliability \
+    --disable-hang-monitor \
+    --disable-prompt-on-repost \
+    --disable-sync \
+    --disable-web-resources \
+    --metrics-recording-only \
+    --mute-audio \
+    --no-first-run \
+    --no-default-browser-check \
+    --no-pings \
+    --no-sandbox \
+    --no-zygote \
+    --use-mock-keychain \
+    --force-device-scale-factor=1 \
+    --disable-lcd-text \
+    --disable-application-cache \
+    --aggressive-cache-discard \
+    --disable-background-downloads \
+    --disk-cache-size=0 \
+    --media-cache-size=0 \
+    "${CALVIN_BACKEND_URL}"'
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=calvin-kiosk
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,8 @@ New to Calvin? Get started quickly:
 3. **Docker Setup** - Containerized development and production setup; see `docker/README.md`
 4. **[Setup Scripts](setup/SETUP_SCRIPTS.md)** - Automated setup scripts for production and development
 5. **[Production Setup](setup/SETUP_LINUX.md)** - Install Calvin on Raspberry Pi or Linux
-6. **[Plugin Development](plugins/PLUGIN_DEVELOPMENT_GUIDE.md)** - Create your first plugin
+6. **[Deployment Topologies](setup/DEPLOYMENT_TOPOLOGIES.md)** - All-in-one Pi vs. remote backend + kiosk Pi
+7. **[Plugin Development](plugins/PLUGIN_DEVELOPMENT_GUIDE.md)** - Create your first plugin
 
 ## Documentation Structure
 

--- a/docs/setup/DEPLOYMENT_TOPOLOGIES.md
+++ b/docs/setup/DEPLOYMENT_TOPOLOGIES.md
@@ -1,0 +1,157 @@
+# Deployment Topologies
+
+Calvin's backend serves both the API (`/api/*`) and the built frontend
+(`/`) from a single FastAPI process. That gives you flexibility in how
+you split the work across hosts. Two shapes are officially supported.
+
+## Mode A — All-in-one Pi (default)
+
+The Pi runs everything: backend, frontend, and the kiosk browser.
+
+```
+┌─────────────────────────── Raspberry Pi ───────────────────────────┐
+│                                                                    │
+│   Chromium (kiosk) ──> http://localhost:8000  ──> Calvin backend   │
+│                                                  │                 │
+│                                                  └── SQLite, data  │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+Use when:
+- One Pi, simple setup.
+- You want the SD card / SSD to be the single source of truth.
+
+Setup:
+
+```bash
+sudo bash scripts/setup.sh --mode prod
+```
+
+See [SETUP_LINUX.md](SETUP_LINUX.md) for the full walkthrough.
+
+## Mode B — Remote backend + kiosk Pi
+
+The backend (and its data) live on a home server. One or more Pis run
+**only** Chromium, pointed at the server's URL.
+
+```
+┌─────── Home server ───────┐         ┌──── Raspberry Pi ────┐
+│                           │         │                      │
+│   Calvin backend          │ <─────  │   Chromium (kiosk)   │
+│   ├── SQLite, photos      │   LAN   │                      │
+│   └── plugin data         │         │                      │
+└───────────────────────────┘         └──────────────────────┘
+```
+
+Use when:
+- You already run a 24/7 server and don't want SQLite / photos / plugin
+  data on the Pi's SD card.
+- You want multiple kiosk Pis sharing one backend (each just runs
+  Chromium against the same URL).
+- Plugin syncs are heavy and you want them on a beefier host.
+
+### Why no proxy on the Pi?
+
+The kiosk Pi opens the server's URL directly in Chromium. From the
+browser's view it's same-origin: the server hosts both `/` and
+`/api/*`. No CORS, no reverse proxy on the Pi, no env vars baked into
+the frontend. The Pi is genuinely "dumb."
+
+### What stays on the Pi
+
+- X server, openbox, Chromium — installed by `setup-kiosk.sh`.
+- Display / cursor / screensaver tweaks.
+- Anything OS-level you've added (e.g. a hardware reboot button script
+  driven by `evdev`). Calvin's app code does not handle hardware input
+  in the browser path; physical buttons are wired up at the OS level.
+
+### What moves to the server
+
+- The backend Docker container (or whatever you use to run it).
+- `/var/lib/calvin/` — SQLite database, photos, plugin install dirs.
+- The frontend rebuild that runs after a plugin install (the server
+  has more headroom than a Pi 3).
+
+### Setup
+
+**1. Server.** Run the standard backend deployment, but bind the port
+to a LAN-reachable interface. The simplest path is the same Docker
+compose used in Mode A:
+
+```bash
+# On the server (any Linux box with Docker):
+git clone https://github.com/osterbergsimon/calvin.git
+cd calvin
+cp deploy/calvin.env.example docker/.env
+# Edit docker/.env — set CALVIN_PORT, DATABASE_URL, etc. as needed.
+docker compose -f docker/docker-compose.yml up -d
+```
+
+Verify it answers from another host on the LAN:
+
+```bash
+curl http://<server-host>:8000/api/health
+```
+
+Pin the server to a stable hostname (mDNS `homeserver.local`, a static
+DHCP lease, or a DNS entry) so the kiosk URL doesn't drift.
+
+**2. Pi.** Run the kiosk-only setup:
+
+```bash
+sudo bash scripts/setup-kiosk.sh --backend-url http://homeserver.local:8000
+```
+
+The script installs `xserver-xorg`, `openbox`, `chromium`, and friends;
+writes `/etc/default/calvin-kiosk` with the backend URL; and enables
+two systemd units:
+
+- `calvin-x.service` — starts the X server on tty1.
+- `calvin-kiosk-remote.service` — waits for the backend to answer,
+  then launches Chromium in kiosk mode against `CALVIN_BACKEND_URL`.
+
+Reboot. Chromium opens to the dashboard.
+
+### Changing the backend URL later
+
+```bash
+sudo nano /etc/default/calvin-kiosk
+sudo systemctl restart calvin-kiosk-remote.service
+```
+
+### CORS
+
+Mode B does **not** require any CORS configuration: the browser hits
+the server's URL directly, so requests to `/api/*` are same-origin.
+
+CORS only matters if you run `npm run dev` on a different host than
+the backend (e.g. hacking on the frontend from a laptop while pointing
+at the home server). For that case the backend already exposes
+`CORS_ORIGINS` and `CORS_ALLOW_ALL` env vars — see
+[backend/app/config.py](../../backend/app/config.py).
+
+### Security note
+
+Calvin's backend has no built-in authentication. Mode B exposes it on
+your LAN, so:
+
+- Bind to the LAN interface, not `0.0.0.0` on a host that's reachable
+  from the internet.
+- Don't port-forward it. If you need remote access, put it behind a
+  VPN or reverse proxy with auth.
+
+## Picking a mode
+
+| Question                                           | Mode A  | Mode B   |
+| -------------------------------------------------- | ------- | -------- |
+| Single Pi, no other hardware                       | ✅      |          |
+| Already run a 24/7 home server                     |         | ✅       |
+| Multiple displays sharing one dashboard            |         | ✅       |
+| Want SQLite + photos off the SD card               |         | ✅       |
+| Want everything reachable on first boot, no LAN    | ✅      |          |
+| Plugin installs are heavy (image processing)       |         | ✅       |
+
+You can switch later — both modes use the same backend image and the
+same `/var/lib/calvin/` data layout. Migrating is mostly: stop the
+backend on the Pi, copy `/var/lib/calvin/` to the server, start it
+there, and reflash the Pi with `setup-kiosk.sh`.

--- a/docs/setup/GETTING_STARTED.md
+++ b/docs/setup/GETTING_STARTED.md
@@ -1,365 +1,175 @@
 # Getting Started with Calvin
 
-Welcome to Calvin! This guide will help you get started with Calvin Dashboard, whether you're setting up for development or production deployment.
+Calvin is a self-hosted Raspberry Pi dashboard — calendars, photos, web
+services — with a Vue 3 frontend and a FastAPI backend. This page gets
+you running in development and points you at the right deployment doc
+for production.
 
-## Choose Your Setup Method
+## Two things you might want to do
 
-Calvin supports multiple setup methods depending on your needs:
-
-1. **[Native Installation](#native-installation)** - Direct installation on your system (recommended for development)
-   - **Windows**: Automated PowerShell script
-   - **Linux/Raspberry Pi**: Automated bash scripts
-   - **Manual Setup**: Step-by-step manual installation
-
-2. **[Docker Setup](#docker-setup)** - Containerized deployment (recommended for production and consistent environments)
-   - Development with hot-reload
-   - Production deployment
-   - Distributed deployment (backend and frontend on separate machines)
-
-3. **[VS Code Dev Containers](#vs-code-dev-containers)** - Fully configured development environment in containers
+- **Run Calvin in development** to hack on it. → [Development](#development)
+- **Deploy Calvin to a Raspberry Pi** to actually use it. →
+  [Deployment](#deployment)
 
 ## Prerequisites
 
-Before you begin, ensure you have:
+- **Docker** (with Compose v2) — required for the dev workflow.
+- **Git**.
+- **`uv`** and **Node.js 20+** — only needed if you want to run native
+  tests, linters, or formatters in your editor. Not needed to run the
+  app.
 
-- **Python 3.11+** - [Download Python](https://www.python.org/downloads/)
-- **Node.js 20+** (LTS recommended) - [Download Node.js](https://nodejs.org/)
-- **Git** - [Download Git](https://git-scm.com/downloads)
-- **UV** - Python package manager (installed automatically by setup scripts)
+The backend targets Python 3.12+, but you don't install Python locally
+unless you're running native tooling — the dev container ships with
+the right interpreter.
 
-### Platform-Specific Notes
+## Development
 
-- **Windows**: Keyboard input uses a mock handler (normal for development). Full keyboard support works on Linux/Raspberry Pi.
-- **Linux/Raspberry Pi**: Full keyboard support available via `evdev` package.
-- **Docker**: Works on all platforms that support Docker.
+The dev workflow is Docker Compose. One stack runs the backend with
+hot-reload (`uvicorn --reload`) and the frontend with the Vite dev
+server, both bind-mounting your checkout.
 
-## Native Installation
-
-### Windows Development Setup
-
-The easiest way to get started on Windows is using the automated setup script.
-
-#### Quick Start
-
-```powershell
-# 1. Clone the repository
+```bash
 git clone https://github.com/osterbergsimon/calvin.git
 cd calvin
 
-# 2. Run the setup script
-.\setup-windows.ps1
+make install   # creates docker/.env from the example, one-time
+make dev       # starts the dev stack, streams logs
+```
 
-# 3. Start development servers
+Windows uses the same targets through a PowerShell wrapper:
+
+```powershell
+.\make.ps1 install
 .\make.ps1 dev
 ```
 
-The setup script will:
-- Check for Python 3.11+, Node.js 20+, and Git
-- Install UV if not present
-- Switch to the `develop` branch (if Git is available)
-- Install all backend dependencies (with dev extras)
-- Install all frontend dependencies
+**Access points:**
+- Backend + API: <http://localhost:8000>
+- Frontend dev server (with HMR): <http://localhost:5173>
+- API docs: <http://localhost:8000/docs>
 
-#### Manual Setup
+`make dev-down` stops the stack. `make doctor` checks your Docker
+install and shows what ports are in use. `make clean` tears the stack
+down and removes dev data.
 
-If you prefer manual setup or the script doesn't work for your environment:
+### VS Code Dev Containers
 
-```powershell
-# Install backend dependencies
-cd backend
-uv sync --extra dev
-cd ..
+The repo ships a `.devcontainer/` config. Open the folder in VS Code,
+run **Dev Containers: Reopen in Container**, and you get the same dev
+stack with extensions pre-installed.
 
-# Install frontend dependencies
-cd frontend
-npm install
-cd ..
+### Running tests, lint, format, type-check natively
 
-# Start development servers (in separate terminals)
-# Terminal 1 - Backend:
-cd backend
-uv run uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
-
-# Terminal 2 - Frontend:
-cd frontend
-npm run dev
-```
-
-**Access Points:**
-- Backend API: http://localhost:8000
-- Frontend Dev Server: http://localhost:5173
-- API Documentation: http://localhost:8000/docs
-
-For more details, see [Windows Setup Guide](SETUP_WINDOWS.md) or [Quick Start - Windows](QUICKSTART_WINDOWS.md).
-
-### Linux/Raspberry Pi Setup
-
-Calvin provides automated setup scripts for Raspberry Pi and Linux systems. These scripts handle complete system configuration including user creation, service setup, and display configuration.
-
-#### Production Setup (Raspberry Pi)
-
-For production deployment on Raspberry Pi:
+These targets shell out to `uv` and `npm` directly (faster than
+round-tripping through Docker, and they integrate with editors):
 
 ```bash
-# One-command installation
-wget -O- https://raw.githubusercontent.com/osterbergsimon/calvin/main/scripts/setup.sh | sudo bash
+make test          # backend pytest + frontend vitest
+make lint          # ruff + eslint
+make format        # ruff format + prettier
+make type-check    # mypy + vue-tsc
+```
 
-# Or using curl
+If you don't have `uv`/`node` installed, the Windows setup script
+(`.\setup-windows.ps1`) and the Linux dev script
+(`scripts/setup-dev.sh`) install them for you. They are otherwise
+unnecessary.
+
+## Deployment
+
+Production runs in one of two shapes — see
+**[Deployment Topologies](DEPLOYMENT_TOPOLOGIES.md)** for the full
+comparison and the security caveats.
+
+**Mode A — All-in-one Pi.** One Pi runs backend, frontend, and the
+kiosk browser. Easiest to set up. From the Pi:
+
+```bash
 curl -fsSL https://raw.githubusercontent.com/osterbergsimon/calvin/main/scripts/setup.sh | sudo bash
-```
-
-**What it does:**
-- Creates `calvin` user if needed
-- Installs Docker, the Compose plugin, and kiosk dependencies (X server, Chromium, openbox)
-- Clones the repository to `/home/calvin/calvin` (used for systemd unit files and update scripts only — the app itself runs from the published container image)
-- Drops `docker/docker-compose.yml` and a populated `.env` into `/etc/calvin/`
-- Installs and enables three systemd units from `deploy/systemd/`: `calvin-app.service` (runs `docker compose up -d` against `ghcr.io/osterbergsimon/calvin`), `calvin-x.service`, and `calvin-kiosk.service`
-- Configures auto-login and X server so the kiosk launches on boot
-
-The backend, frontend `dist/`, and Python/Node toolchains all live inside the container image — nothing is installed natively on the host.
-
-**After setup:**
-```bash
 sudo reboot
 ```
 
-After reboot, the dashboard will automatically start and be available at `http://localhost:8000`.
+The script installs Docker, the kiosk dependencies, the published
+runtime image, and three systemd units. The dashboard comes up at
+`http://localhost:8000` after reboot.
 
-#### Development Setup (Raspberry Pi)
+Use `GIT_BRANCH=develop` (with `sudo -E`) to track the develop branch,
+or `--mode dev` for a hot-reload Pi. Details in
+[SETUP_LINUX.md](SETUP_LINUX.md).
 
-For development with hot-reload on Raspberry Pi:
-
-```bash
-# Development installation with hot-reload
-wget -O- https://raw.githubusercontent.com/osterbergsimon/calvin/main/scripts/setup.sh | sudo bash -s -- --mode dev
-
-# Or using curl
-curl -fsSL https://raw.githubusercontent.com/osterbergsimon/calvin/main/scripts/setup.sh | sudo bash -s -- --mode dev
-```
-
-**What it does:**
-- Same base setup as production (kiosk + Docker)
-- Installs `docker/docker-compose.dev.yml` to `/etc/calvin/docker-compose.yml`
-- Bind-mounts the checkout into the app container; backend runs `uvicorn --reload` and the frontend runs the Vite dev server, both inside containers
-- Keeps the kiosk pointed at `http://localhost:8000`
-
-**After setup:**
-```bash
-sudo reboot
-```
-
-After reboot:
-- Docker Compose runs the hot-reload dev stack
-- Dashboard available at `http://localhost:8000`
-
-#### Using Different Branches
+**Mode B — Remote backend + kiosk Pi.** A home server runs the
+backend; one or more Pis run only Chromium pointed at the server's
+URL. Move SQLite and photos off the SD card, share one backend across
+multiple displays.
 
 ```bash
-# Production setup with develop branch
-export GIT_BRANCH=develop
-wget -O- https://raw.githubusercontent.com/osterbergsimon/calvin/main/scripts/setup.sh | sudo -E bash
-
-# Development setup with develop branch
-export GIT_BRANCH=develop
-curl -fsSL https://raw.githubusercontent.com/osterbergsimon/calvin/main/scripts/setup.sh | sudo -E bash -s -- --mode dev
-```
-
-> **Note:** Use `sudo -E` to preserve environment variables. Without `-E`, `sudo` will not pass `GIT_BRANCH` or `GIT_REPO` to the script, and it will default to the `main` branch.
-> 
-> **Important:** Export the variable first (`export GIT_BRANCH=develop`) rather than setting it inline (`GIT_BRANCH=develop wget ...`), as inline assignments don't propagate through pipes to `sudo`.
-
-#### Using a Fork or Custom Repository
-
-```bash
-GIT_REPO=https://github.com/yourusername/calvin.git GIT_BRANCH=your-branch \
-  wget -O- https://raw.githubusercontent.com/osterbergsimon/calvin/main/scripts/setup.sh | sudo bash
-```
-
-#### Linux Development Setup (Non-Raspberry Pi)
-
-For development on a Linux machine (not Raspberry Pi):
-
-```bash
-# Clone repository
-git clone https://github.com/osterbergsimon/calvin.git
-cd calvin
-
-# Install dependencies (includes evdev for keyboard support)
-make install
-
-# Start development servers
-make dev
-```
-
-Or manually:
-
-```bash
-# Install backend dependencies (includes evdev for keyboard support)
-cd backend
-uv sync --extra linux --extra dev
-cd ../frontend
-npm install
-
-# Start development servers (in separate terminals)
-# Terminal 1 - Backend:
-cd backend
-uv run uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
-
-# Terminal 2 - Frontend:
-cd frontend
-npm run dev
-```
-
-**Note:** The `scripts/setup.sh` script is for **Raspberry Pi deployment** (requires root, Docker, and systemd services). For Linux development, use the Makefile, Docker Compose dev file, or manual commands above.
-
-For more details, see [Linux Setup Guide](SETUP_LINUX.md) or [Setup Scripts Documentation](SETUP_SCRIPTS.md).
-
-## Docker Setup
-
-Docker provides a consistent, isolated environment for both development and production. Calvin now uses one runtime image for production and a separate hot-reload compose file for development.
-
-### Development Mode (Hot-Reload)
-
-```bash
-# From project root, one-time setup:
-cp deploy/calvin.env.example docker/.env
-docker compose -f docker/docker-compose.dev.yml up
-```
-
-**Access Points:**
-- Backend API: http://localhost:8000
-- Frontend Dev Server: http://localhost:5173
-- API Documentation: http://localhost:8000/docs
-
-**Features:**
-- Hot-reload for both backend and frontend
-- Source code mounted as volumes
-- Fast iteration cycle
-
-### Production Mode
-
-```bash
-# From project root, one-time setup:
-cp deploy/calvin.env.example docker/.env
-# edit docker/.env
+# Server: same Docker compose as Mode A.
 docker compose -f docker/docker-compose.yml up -d
+
+# Pi (kiosk only):
+sudo bash scripts/setup-kiosk.sh --backend-url http://homeserver.local:8000
+sudo reboot
 ```
 
-**Access Points:**
-- Application: http://localhost:8000
-- API Documentation: http://localhost:8000/docs
+Details and the picker table live in
+[DEPLOYMENT_TOPOLOGIES.md](DEPLOYMENT_TOPOLOGIES.md).
 
-For current Docker details, see `docker/README.md`.
+## Verifying it works
 
-## VS Code Dev Containers
+After `make dev` (or after a Pi reboot), check:
 
-VS Code Dev Containers provide a fully configured development environment in containers.
+- `http://localhost:8000/api/health` returns `{"status":"healthy"}`.
+- `http://localhost:8000/` shows the dashboard.
+- `http://localhost:8000/docs` shows the API.
 
-### Prerequisites
-
-- VS Code with [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
-- Docker Desktop or Docker Engine
-
-### Opening in Dev Container
-
-1. Open VS Code in the project root
-2. Press `F1` or `Ctrl+Shift+P` (Windows/Linux) / `Cmd+Shift+P` (Mac)
-3. Select "Dev Containers: Reopen in Container"
-4. VS Code will build and start the containers automatically
-
-### Features
-
-- Pre-configured Python and Node.js environments
-- VS Code extensions automatically installed
-- Port forwarding configured (8000, 5173)
-- Full development environment in container
-- Code mounted as volumes for hot-reload
-
-### Customization
-
-Edit `.devcontainer/devcontainer.json` to customize:
-- VS Code extensions
-- Settings
-- Port forwarding
-- Features
-
-**Note:** If you don't have a `.devcontainer` directory yet, you can create one based on the Docker development setup in `docker/README.md`.
-
-## Verification
-
-After setup, verify your installation:
-
-1. **Backend Health Check**: http://localhost:8000/api/health
-2. **API Documentation**: http://localhost:8000/docs
-3. **Frontend**: http://localhost:5173 (dev) or http://localhost:80 (production)
-
-## Next Steps
-
-1. **Configure Calvin**: Set up your calendars, image sources, and plugins
-2. **Explore Plugins**: Check out the [Plugin Development Guide](../plugins/PLUGIN_DEVELOPMENT_GUIDE.md)
-3. **Read Documentation**: Browse the [documentation index](../index.md) for more information
-4. **Contribute**: See [Contributing Guide](../CONTRIBUTING.md) for development guidelines
+In dev, `http://localhost:5173/` is the Vite-served frontend with HMR;
+it proxies API calls to the backend on `:8000`.
 
 ## Troubleshooting
 
-### Common Issues
+**Port already in use** (`8000` or `5173`):
 
-#### Port Already in Use
-
-**Windows:**
-```powershell
-netstat -ano | findstr :8000
-taskkill /PID <PID> /F
-```
-
-**Linux/Mac:**
 ```bash
-lsof -i :8000
-kill -9 <PID>
+make dev-down       # stop the dev stack first
+lsof -i :8000       # Linux/macOS — find the holdout
+# Windows: netstat -ano | findstr :8000  ;  taskkill /PID <pid> /F
 ```
 
-#### UV Not Found
-
-**Windows:**
-- Restart PowerShell after installing UV
-- Or add UV to PATH: `C:\Users\<username>\.cargo\bin\`
-
-**Linux:**
-```bash
-export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
-```
-
-#### Docker Permission Issues (Linux)
+**Docker permission denied (Linux)**: add yourself to the `docker`
+group, then re-login.
 
 ```bash
 sudo usermod -aG docker $USER
 newgrp docker
 ```
 
-#### Services Not Starting (Raspberry Pi)
+**Pi services not starting**:
 
 ```bash
-# Check service status
 sudo systemctl status calvin-app
-sudo systemctl status calvin-kiosk
-
-# Check logs
 sudo journalctl -u calvin-app -n 50
-sudo journalctl -u calvin-kiosk -n 50
+sudo systemctl status calvin-kiosk        # Mode A
+sudo systemctl status calvin-kiosk-remote # Mode B
 ```
 
-### Getting Help
+**Native tooling missing** (only matters if you run `make test` /
+`lint` / etc.): re-run `.\setup-windows.ps1` or
+`scripts/setup-dev.sh`, or install `uv` and Node 20+ manually.
 
-- Check the [documentation index](../index.md) for detailed guides
-- Review [Setup Scripts Documentation](SETUP_SCRIPTS.md) for script-specific issues
-- See `docker/README.md` for Docker-specific issues
-- Open an issue on [GitHub](https://github.com/osterbergsimon/calvin/issues)
+## Next steps
 
-## Related Documentation
+- [Plugin Development Guide](../plugins/PLUGIN_DEVELOPMENT_GUIDE.md) —
+  write your own plugin.
+- [Deployment Topologies](DEPLOYMENT_TOPOLOGIES.md) — pick a runtime
+  shape.
+- [Documentation index](../index.md) — everything else.
 
-- [Windows Setup Guide](SETUP_WINDOWS.md) - Detailed Windows setup
-- [Linux Setup Guide](SETUP_LINUX.md) - Detailed Linux setup
-- [Setup Scripts Documentation](SETUP_SCRIPTS.md) - Automated setup scripts
-- [Quick Start - Development](QUICKSTART_DEVELOP.md) - Fast development setup
-- [Quick Start - Windows](QUICKSTART_WINDOWS.md) - Fast Windows setup
-- `docker/README.md` - Current Docker guide
+## Related docs
+
+- [Deployment Topologies](DEPLOYMENT_TOPOLOGIES.md) — Mode A vs Mode B.
+- [SETUP_LINUX.md](SETUP_LINUX.md) — full Pi production walkthrough.
+- [SETUP_WINDOWS.md](SETUP_WINDOWS.md) — native Windows tooling setup.
+- [SETUP_SCRIPTS.md](SETUP_SCRIPTS.md) — setup-script reference.
+- [QUICKSTART_DEVELOP.md](QUICKSTART_DEVELOP.md) — terse dev setup.
+- `docker/README.md` — Docker compose reference.

--- a/scripts/setup-kiosk.sh
+++ b/scripts/setup-kiosk.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+# Calvin Dashboard - Raspberry Pi kiosk-only setup.
+#
+# Installs only the kiosk side: X server, openbox, Chromium, and a
+# systemd unit that points the browser at a remote Calvin backend
+# (typically running on a home server). No Docker, no Calvin source
+# tree, no SQLite.
+#
+# Use this when you want one host to run the backend (e.g. a NAS or
+# always-on Linux box) and one or more Raspberry Pis to act as dumb
+# kiosks displaying the dashboard.
+#
+# Tested on Raspberry Pi OS (Bookworm). Other Debian-based distros may
+# work but are not supported.
+
+set -euo pipefail
+
+_ENV_GIT_BRANCH="${GIT_BRANCH:-}"
+_ENV_GIT_REPO="${GIT_REPO:-}"
+
+COMMON_SCRIPT=""
+if [ -f "./setup-common.sh" ]; then
+    COMMON_SCRIPT="./setup-common.sh"
+fi
+
+if [ -z "${COMMON_SCRIPT}" ] && [ -n "${BASH_VERSION:-}" ]; then
+    _script_source="${BASH_SOURCE[0]:-}"
+    _script_dir=""
+    if [ -n "${_script_source}" ] && [ "${_script_source}" != "-" ]; then
+        _script_dir=$(cd "$(dirname "${_script_source}")" && pwd 2>/dev/null || echo "")
+    fi
+    if [ -n "${_script_dir}" ] && [ -f "${_script_dir}/setup-common.sh" ]; then
+        COMMON_SCRIPT="${_script_dir}/setup-common.sh"
+    fi
+fi
+
+if [ -n "${COMMON_SCRIPT}" ] && [ -f "${COMMON_SCRIPT}" ]; then
+    . "${COMMON_SCRIPT}"
+else
+    echo "Downloading setup-common.sh from GitHub..." >&2
+    TEMP_DIR="$(mktemp -d)"
+    trap "rm -rf '${TEMP_DIR}'" EXIT 2>/dev/null || true
+
+    GIT_REPO="${_ENV_GIT_REPO:-${GIT_REPO:-https://github.com/osterbergsimon/calvin.git}}"
+    GIT_BRANCH="${_ENV_GIT_BRANCH:-${GIT_BRANCH:-main}}"
+    repo_owner=$(echo "${GIT_REPO}" | sed -E 's|.*github\.com[:/]([^/]+)/([^/]+)(\.git)?$|\1|')
+    repo_name=$(echo "${GIT_REPO}" | sed -E 's|.*github\.com[:/]([^/]+)/([^/]+)(\.git)?$|\2|' | sed 's|\.git$||')
+
+    if [ -z "${repo_owner}" ] || [ -z "${repo_name}" ]; then
+        echo "Error: Could not extract repo owner/name from ${GIT_REPO}" >&2
+        exit 1
+    fi
+
+    common_url="https://raw.githubusercontent.com/${repo_owner}/${repo_name}/${GIT_BRANCH}/scripts/setup-common.sh"
+    if command -v curl &> /dev/null; then
+        curl -fsSL -o "${TEMP_DIR}/setup-common.sh" "${common_url}" || {
+            echo "Error: Failed to download setup-common.sh from ${common_url}" >&2
+            exit 1
+        }
+    elif command -v wget &> /dev/null; then
+        wget -q -O "${TEMP_DIR}/setup-common.sh" "${common_url}" || {
+            echo "Error: Failed to download setup-common.sh from ${common_url}" >&2
+            exit 1
+        }
+    else
+        echo "Error: Neither curl nor wget is available. Please install one of them." >&2
+        exit 1
+    fi
+
+    . "${TEMP_DIR}/setup-common.sh"
+fi
+
+GIT_REPO="${_ENV_GIT_REPO:-${GIT_REPO:-$DEFAULT_GIT_REPO}}"
+GIT_BRANCH="${_ENV_GIT_BRANCH:-${GIT_BRANCH:-$DEFAULT_GIT_BRANCH}}"
+CALVIN_DIR="${CALVIN_DIR:-$DEFAULT_CALVIN_DIR}"
+CALVIN_USER="${CALVIN_USER:-$DEFAULT_CALVIN_USER}"
+LOG_FILE="${LOG_FILE:-$DEFAULT_LOG_FILE}"
+BACKEND_URL=""
+
+usage() {
+    cat <<EOF
+Usage: setup-kiosk.sh --backend-url <URL>
+
+Sets up a Raspberry Pi as a dumb kiosk pointed at a remote Calvin
+backend. Installs X, openbox, and Chromium, then enables a systemd
+unit that opens the dashboard URL on boot.
+
+Required:
+  --backend-url <URL>   Where the Calvin backend lives, e.g.
+                        http://homeserver.local:8000
+
+Environment overrides:
+  GIT_REPO, GIT_BRANCH, CALVIN_DIR, CALVIN_USER
+EOF
+}
+
+parse_args() {
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --backend-url)
+                BACKEND_URL="${2:-}"
+                shift 2
+                ;;
+            --backend-url=*)
+                BACKEND_URL="${1#*=}"
+                shift
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                echo "Unknown argument: $1" >&2
+                usage >&2
+                exit 1
+                ;;
+        esac
+    done
+
+    if [ -z "${BACKEND_URL}" ]; then
+        echo "Error: --backend-url is required" >&2
+        usage >&2
+        exit 1
+    fi
+
+    if ! echo "${BACKEND_URL}" | grep -qE '^https?://'; then
+        echo "Error: --backend-url must start with http:// or https:// (got: ${BACKEND_URL})" >&2
+        exit 1
+    fi
+}
+
+install_kiosk_config() {
+    log "Writing /etc/default/calvin-kiosk..."
+    install -m 0644 /dev/null /etc/default/calvin-kiosk
+    upsert_env_value /etc/default/calvin-kiosk CALVIN_BACKEND_URL "${BACKEND_URL}"
+}
+
+ensure_repo_for_unit_files() {
+    # We only need the systemd unit files from the repo. The cheapest
+    # honest way is a shallow clone via the existing helper — same path
+    # as the all-in-one setup so future maintenance touches one place.
+    ensure_git_repo "${GIT_REPO}" "${GIT_BRANCH}" "${CALVIN_DIR}" "${CALVIN_USER}"
+}
+
+systemd_available() {
+    [ -d /run/systemd/system ] && systemctl list-unit-files >/dev/null 2>&1
+}
+
+install_kiosk_services() {
+    log "Installing systemd services..."
+    install_systemd_service "${CALVIN_DIR}/deploy/systemd/calvin-x.service" "${CALVIN_DIR}"
+    install_systemd_service "${CALVIN_DIR}/deploy/systemd/calvin-kiosk-remote.service" "${CALVIN_DIR}"
+
+    if systemd_available; then
+        enable_systemd_service "calvin-x.service"
+        enable_systemd_service "calvin-kiosk-remote.service"
+    else
+        log_warn "systemd is not running; installed service files but skipped enable"
+    fi
+}
+
+start_kiosk_services() {
+    log "Starting kiosk services..."
+    if systemd_available; then
+        start_systemd_service "calvin-x.service"
+        sleep 3
+        start_systemd_service "calvin-kiosk-remote.service"
+    else
+        log_warn "systemd is not running; skipped service start"
+    fi
+}
+
+main() {
+    parse_args "$@"
+
+    log "=========================================="
+    log "Calvin Raspberry Pi Kiosk Setup"
+    log "=========================================="
+    log "Backend URL: ${BACKEND_URL}"
+    log "Repository:  ${GIT_REPO}"
+    log "Branch:      ${GIT_BRANCH}"
+    log "User:        ${CALVIN_USER}"
+    log ""
+
+    check_root
+    mkdir -p "$(dirname "${LOG_FILE}")"
+
+    ensure_user_exists "${CALVIN_USER}"
+    update_system_packages
+
+    log "Installing kiosk dependencies..."
+    install_system_packages \
+        curl \
+        git \
+        xserver-xorg \
+        xinit \
+        openbox \
+        chromium \
+        unclutter \
+        xdotool \
+        x11-xserver-utils
+
+    ensure_repo_for_unit_files
+    install_kiosk_config
+
+    configure_display "${CALVIN_USER}"
+    # Chromium is managed by calvin-kiosk-remote.service; openbox
+    # autostart only needs to launch openbox itself plus the usual
+    # screensaver/cursor tweaks.
+    configure_openbox_autostart "${CALVIN_USER}" "${BACKEND_URL}" "false"
+
+    install_kiosk_services
+    start_kiosk_services
+
+    log ""
+    log "=========================================="
+    log "Calvin Kiosk Setup Complete!"
+    log "=========================================="
+    log "Backend URL:    ${BACKEND_URL}"
+    log "Config file:    /etc/default/calvin-kiosk"
+    log "Systemd units:  calvin-x.service, calvin-kiosk-remote.service"
+    log ""
+    log "To change the backend URL later:"
+    log "  sudo nano /etc/default/calvin-kiosk"
+    log "  sudo systemctl restart calvin-kiosk-remote.service"
+    log ""
+    log "Reboot to start the kiosk:"
+    log "  sudo reboot"
+    log ""
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds a second deployment topology — **Mode B**: backend on a home server, Pi runs only Chromium pointed at the server URL — alongside the existing all-in-one Pi setup (**Mode A**). Same backend image either way; the kiosk Pi is genuinely dumb (no proxy, no CORS, no SQLite, no plugin data on the SD card).

Also rewrites Getting Started, which had drifted out of date since the [#32](https://github.com/osterbergsimon/calvin/pull/32) move to a Docker Compose dev workflow.

### What's new

- **`deploy/systemd/calvin-kiosk-remote.service`** — kiosk unit that reads `CALVIN_BACKEND_URL` from `/etc/default/calvin-kiosk` and points Chromium at it. No `Requires=calvin-app.service`.
- **`scripts/setup-kiosk.sh`** — RPi-OS-only installer for kiosk-only Pis. Takes `--backend-url`, installs X / openbox / Chromium, enables `calvin-x.service` + `calvin-kiosk-remote.service`. No Docker, no app source tree, no `/var/lib/calvin`.
- **`docs/setup/DEPLOYMENT_TOPOLOGIES.md`** — Mode A vs Mode B walkthrough, picker table, security note (backend has no auth — keep it on the LAN).

### Getting Started rewrite

- Dev workflow leads with `make install && make dev` (Docker Compose). Native `uv`/`npm` only mentioned for `make test` / `lint` / `format` / `type-check`, which matches the Makefile.
- Deploy section delegates to the new topologies doc.
- Fixed: Python 3.12+ (was 3.11+); dropped the stale "frontend on port 80 in production" claim; trimmed misleading evdev language (browser handles app-level keys; evdev is OS-level only); removed the "if you don't have a `.devcontainer` directory" hint (the repo has one).
- 400 lines → 107.

## Test plan

- [ ] `bash -n scripts/setup-kiosk.sh` passes (verified locally).
- [ ] On a fresh Raspberry Pi OS install, run `sudo bash scripts/setup-kiosk.sh --backend-url http://<server>:8000`, reboot, confirm Chromium opens to the dashboard.
- [ ] Confirm `sudo systemctl restart calvin-kiosk-remote.service` re-reads `/etc/default/calvin-kiosk` after editing the URL.
- [ ] Skim the rewritten Getting Started for any links/sections I missed.