### PR TITLE
Standardize dashboard region surfaces

### DIFF
--- a/backend/app/plugins/definitions.py
+++ b/backend/app/plugins/definitions.py
@@ -7,12 +7,13 @@ normalizes them into these models before the rest of the app consumes them.
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from app.plugins.base import PluginType
 
 CURRENT_PLUGIN_PROTOCOL_VERSION = 1
 SUPPORTED_PLUGIN_PROTOCOL_VERSIONS = {CURRENT_PLUGIN_PROTOCOL_VERSION}
+DISPLAY_PANEL_VARIANTS = {"default", "dense", "media", "iframe"}
 
 
 class ConfigFieldDefinition(BaseModel):
@@ -92,6 +93,18 @@ class PluginDefinition(BaseModel):
     plugin_class: type[Any] | None = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
+
+    @field_validator("display_schema")
+    @classmethod
+    def validate_display_schema(cls, value: dict[str, Any] | None) -> dict[str, Any] | None:
+        """Validate known display schema shell fields while allowing renderer-specific keys."""
+        if value is None:
+            return value
+        panel_variant = value.get("panel_variant")
+        if panel_variant is not None and panel_variant not in DISPLAY_PANEL_VARIANTS:
+            allowed = ", ".join(sorted(DISPLAY_PANEL_VARIANTS))
+            raise ValueError(f"display_schema.panel_variant must be one of: {allowed}")
+        return value
 
     @classmethod
     def from_raw(cls, raw: "PluginDefinition | dict[str, Any]") -> "PluginDefinition":

--- a/backend/tests/unit/test_plugin_definitions.py
+++ b/backend/tests/unit/test_plugin_definitions.py
@@ -47,3 +47,36 @@ class TestPluginDefinition:
                     "name": "Future Plugin",
                 }
             )
+
+    def test_display_schema_allows_shell_fields_and_renderer_specific_keys(self):
+        definition = PluginDefinition.from_raw(
+            {
+                "type_id": "weather",
+                "plugin_type": PluginType.SERVICE,
+                "name": "Weather",
+                "display_schema": {
+                    "kind": "weather-forecast",
+                    "title_path": "$.location",
+                    "title": "Weather",
+                    "panel_variant": "dense",
+                    "current_path": "$.current",
+                },
+            }
+        )
+
+        assert definition.display_schema["panel_variant"] == "dense"
+        assert definition.display_schema["current_path"] == "$.current"
+
+    def test_display_schema_rejects_unknown_panel_variant(self):
+        with pytest.raises(ValueError, match="display_schema.panel_variant"):
+            PluginDefinition.from_raw(
+                {
+                    "type_id": "weather",
+                    "plugin_type": PluginType.SERVICE,
+                    "name": "Weather",
+                    "display_schema": {
+                        "kind": "weather-forecast",
+                        "panel_variant": "compact",
+                    },
+                }
+            )

--- a/docs/plugins/PLUGIN_FRONTEND_COMPONENTS.md
+++ b/docs/plugins/PLUGIN_FRONTEND_COMPONENTS.md
@@ -103,8 +103,7 @@ Plugin frontends and built-in renderers should use Calvin's public dashboard bod
 
 These classes use `var(--bg-secondary)`, `var(--border-color)`, radius `6px`, standard spacing, and
 region-safe `min-width`/`min-height` rules. The panel body owns the outer overflow boundary, so
-renderers should avoid adding another outer frame. Classes named `dashboard-renderer-*` are internal
-to Calvin and should not be used by external plugins.
+renderers should avoid adding another outer frame.
 
 Example web component body layout:
 

--- a/docs/plugins/PLUGIN_FRONTEND_COMPONENTS.md
+++ b/docs/plugins/PLUGIN_FRONTEND_COMPONENTS.md
@@ -43,6 +43,83 @@ display_schema={
 
 The plugin's service data endpoint returns the data object that schema paths bind to.
 
+### Shared Dashboard Shell
+
+Dashboard service renderers are wrapped in Calvin's shared region shell. The shell provides the
+outer header, body padding, clipping, and scroll boundary for split layouts. Schema renderers should
+render only their body content and should not draw an outer dashboard header.
+
+Optional `display_schema` shell fields:
+
+- `title_path`: JSONPath-lite path resolved against the service data. This title wins when present.
+- `title`: literal fallback title.
+- `panel_variant`: one of `default`, `dense`, `media`, or `iframe`.
+
+Title resolution order is:
+
+1. `display_schema.title_path`
+2. `display_schema.title`
+3. service/plugin name
+
+Use `default` for ordinary cards and lists, `dense` for compact status-heavy renderers, `media` for
+flush image/video surfaces, and `iframe` for full-bleed embedded pages. Missing fields continue to
+work and fall back to the service name.
+
+Example title and variant metadata:
+
+```python
+display_schema={
+    "kind": "weather-forecast",
+    "title_path": "$.location.name",
+    "panel_variant": "default",
+    "current_path": "$.current",
+    "forecast_path": "$.forecast",
+    # ...
+}
+```
+
+```python
+display_schema={
+    "kind": "iframe",
+    "title": "Home Assistant",
+    "panel_variant": "iframe",
+    "url": "https://homeassistant.local/lovelace/default_view",
+}
+```
+
+Plugin frontends and built-in renderers should use Calvin's public dashboard body classes:
+
+- `calvin-plugin-fill` for a component root that should fill the panel body.
+- `calvin-plugin-grid` for tile/card grids.
+- `calvin-plugin-grid--auto`, `calvin-plugin-grid--dense`, `calvin-plugin-grid--2`, and
+  `calvin-plugin-grid--3` for common grid layouts.
+- `calvin-plugin-list` and `calvin-plugin-list--scroll` for vertical lists.
+- `calvin-plugin-surface`, `calvin-plugin-row`, and `calvin-plugin-metric` for repeated surfaces.
+- `calvin-plugin-clickable` for clickable cards or rows.
+- `calvin-plugin-section` for lightweight body grouping without drawing a nested outer card.
+- `calvin-plugin-toolbar` for small action rows inside the plugin body.
+- `calvin-plugin-media` for image/video/canvas content inside `panel_variant: "media"`.
+- `calvin-plugin-empty`, `calvin-plugin-loading`, and `calvin-plugin-error` for fallback states.
+
+These classes use `var(--bg-secondary)`, `var(--border-color)`, radius `6px`, standard spacing, and
+region-safe `min-width`/`min-height` rules. The panel body owns the outer overflow boundary, so
+renderers should avoid adding another outer frame. Classes named `dashboard-renderer-*` are internal
+to Calvin and should not be used by external plugins.
+
+Example web component body layout:
+
+```html
+<div class="calvin-plugin-fill calvin-plugin-section">
+  <div class="calvin-plugin-toolbar">
+    <button>Refresh</button>
+  </div>
+  <div class="calvin-plugin-grid calvin-plugin-grid--auto">
+    <article class="calvin-plugin-surface">...</article>
+    <article class="calvin-plugin-surface">...</article>
+  </div>
+</div>
+```
+
 ## Web Components
 
 Use `kind: "web-component"` only when the built-in schema renderers are not expressive enough.
@@ -79,6 +156,21 @@ At runtime, Calvin loads:
 
 The JavaScript module must register the custom element named by `display_schema.element`.
 Calvin assigns the latest service data to the element's `data` property.
+
+Web components are also wrapped by the shared region shell. Custom elements should fill the provided
+body area (`width: 100%; height: 100%`) and avoid rendering their own Calvin-style outer header.
+
+## Porting Existing Plugin Frontends
+
+When updating plugins for the shared shell:
+
+- Move dashboard titles into `display_schema.title_path` or `display_schema.title`.
+- Remove plugin-rendered outer headers that duplicate the Calvin region header.
+- Use `panel_variant: "iframe"` for iframe-like full-bleed services.
+- Use `panel_variant: "media"` only for image/video-heavy surfaces that should sit flush against the
+  panel body.
+- Ensure web components fill their host element instead of sizing themselves against the viewport.
+- Keep internal cards, lists, and metrics inside the provided body area.
 
 ## Installation Behavior
 

--- a/frontend/src/components/CalendarView.vue
+++ b/frontend/src/components/CalendarView.vue
@@ -1,126 +1,110 @@
 <template>
   <div ref="calendarView" class="calendar-view" tabindex="0" @keydown="handleKeydown">
-    <div v-if="showHeader" class="calendar-header">
-      <h2>Calendar</h2>
-      <div class="calendar-controls">
-        <button class="btn-icon" @click="previousMonth" @keydown.enter="previousMonth">‹</button>
-        <div class="calendar-title-group">
-          <span class="current-month">{{ currentMonthYear }}</span>
-          <span class="view-mode-indicator">{{ viewModeLabel }}</span>
-        </div>
-        <button class="btn-icon" @click="nextMonth" @keydown.enter="nextMonth">›</button>
-      </div>
-    </div>
-    <div v-else class="calendar-header-minimal">
-      <button
-        class="btn-icon-minimal"
-        title="Previous Month"
-        @click="previousMonth"
-        @keydown.enter="previousMonth"
-      >
-        ‹
-      </button>
-      <div class="calendar-title-group-minimal">
-        <span class="current-month-minimal">
-          {{ currentMonthYear }}
-        </span>
-        <span class="view-mode-indicator-minimal">
-          {{ viewModeLabel }}
-        </span>
-      </div>
-      <button
-        class="btn-icon-minimal"
-        title="Next Month"
-        @click="nextMonth"
-        @keydown.enter="nextMonth"
-      >
-        ›
-      </button>
-    </div>
-    <div class="calendar-content">
-      <!-- Loading indicator -->
-      <div v-if="loading" class="loading-overlay">
-        <div class="loading-spinner">
-          <div class="spinner" />
-          <div class="loading-text">Loading events...</div>
-        </div>
-      </div>
-      <div
-        class="calendar-grid"
-        :class="{
-          'rolling-view': viewMode === 'rolling',
-          'week-view': viewMode === 'week',
-          'day-view': viewMode === 'day',
-          loading: loading,
-        }"
-      >
-        <!-- Day headers -->
-        <div class="calendar-weekdays">
-          <div
-            v-for="day in viewMode === 'day' ? [getCurrentWeekdayName()] : weekDays"
-            :key="day"
-            class="weekday"
-          >
-            {{ day }}
+    <DashboardPanel title="Calendar" :subtitle="calendarSubtitle">
+      <template #actions>
+        <button
+          class="dashboard-panel__icon-button"
+          title="Previous"
+          @click="previousMonth"
+          @keydown.enter="previousMonth"
+        >
+          ‹
+        </button>
+        <button
+          class="dashboard-panel__icon-button"
+          title="Next"
+          @click="nextMonth"
+          @keydown.enter="nextMonth"
+        >
+          ›
+        </button>
+      </template>
+
+      <div class="calendar-content">
+        <!-- Loading indicator -->
+        <div v-if="loading" class="loading-overlay">
+          <div class="loading-spinner">
+            <div class="spinner" />
+            <div class="loading-text">Loading events...</div>
           </div>
         </div>
-        <!-- Calendar days -->
         <div
-          class="calendar-days"
+          class="calendar-grid"
           :class="{
-            'rolling-days': viewMode === 'rolling',
+            'rolling-view': viewMode === 'rolling',
+            'week-view': viewMode === 'week',
+            'day-view': viewMode === 'day',
+            loading: loading,
           }"
         >
-          <div
-            v-for="(day, dayIndex) in calendarDays"
-            :key="day.date.toISOString()"
-            :class="[
-              'calendar-day',
-              {
-                'other-month': day.otherMonth,
-                today: day.isToday,
-                'week-start': isWeekStart(dayIndex),
-                weekend: isWeekend(day.date),
-                'red-day': showRedDays && isRedDay(day.date),
-              },
-            ]"
-          >
-            <div class="day-header">
-              <div class="day-number">
-                {{ day.date.getDate() }}
-              </div>
-              <div v-if="showWeekNumbers && isWeekStart(dayIndex)" class="week-number">
-                {{ getWeekNumberForDay(dayIndex) }}
-              </div>
+          <!-- Day headers -->
+          <div class="calendar-weekdays">
+            <div
+              v-for="day in viewMode === 'day' ? [getCurrentWeekdayName()] : weekDays"
+              :key="day"
+              class="weekday"
+            >
+              {{ day }}
             </div>
-            <div class="day-events">
-              <!-- Visible events for this day (limited) -->
-              <CalendarEventItem
-                v-for="(event, eventIndex) in getVisibleEvents(day.events)"
-                :key="`${event.id}-${day.date.toISOString()}-${eventIndex}`"
-                :ref="el => setEventRef(el, dayIndex, eventIndex)"
-                :event="event"
-                :day-index="dayIndex"
-                :event-index="eventIndex"
-                :day-date="day.date"
-                :is-focused="isFocused(dayIndex, eventIndex)"
-                :is-selected="isEventSelected(event, day.date)"
-                @click="selectEvent"
-                @focus="setFocusedEvent"
-              />
-              <!-- Overflow indicator -->
-              <div
-                v-if="getOverflowCount(day.events) > 0"
-                class="event-overflow-indicator"
-                :title="`${getOverflowCount(day.events)} more event${getOverflowCount(day.events) > 1 ? 's' : ''}`"
-              >
-                +{{ getOverflowCount(day.events) }} more
+          </div>
+          <!-- Calendar days -->
+          <div
+            class="calendar-days"
+            :class="{
+              'rolling-days': viewMode === 'rolling',
+            }"
+          >
+            <div
+              v-for="(day, dayIndex) in calendarDays"
+              :key="day.date.toISOString()"
+              :class="[
+                'calendar-day',
+                {
+                  'other-month': day.otherMonth,
+                  today: day.isToday,
+                  'week-start': isWeekStart(dayIndex),
+                  weekend: isWeekend(day.date),
+                  'red-day': showRedDays && isRedDay(day.date),
+                },
+              ]"
+            >
+              <div class="day-header">
+                <div class="day-number">
+                  {{ day.date.getDate() }}
+                </div>
+                <div v-if="showWeekNumbers && isWeekStart(dayIndex)" class="week-number">
+                  {{ getWeekNumberForDay(dayIndex) }}
+                </div>
+              </div>
+              <div class="day-events">
+                <!-- Visible events for this day (limited) -->
+                <CalendarEventItem
+                  v-for="(event, eventIndex) in getVisibleEvents(day.events)"
+                  :key="`${event.id}-${day.date.toISOString()}-${eventIndex}`"
+                  :ref="el => setEventRef(el, dayIndex, eventIndex)"
+                  :event="event"
+                  :day-index="dayIndex"
+                  :event-index="eventIndex"
+                  :day-date="day.date"
+                  :is-focused="isFocused(dayIndex, eventIndex)"
+                  :is-selected="isEventSelected(event, day.date)"
+                  @click="selectEvent"
+                  @focus="setFocusedEvent"
+                />
+                <!-- Overflow indicator -->
+                <div
+                  v-if="getOverflowCount(day.events) > 0"
+                  class="event-overflow-indicator"
+                  :title="`${getOverflowCount(day.events)} more event${getOverflowCount(day.events) > 1 ? 's' : ''}`"
+                >
+                  +{{ getOverflowCount(day.events) }} more
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </DashboardPanel>
     <!-- Event Detail Panel -->
     <EventDetailPanel
       v-if="calendarStore.selectedEvent"
@@ -143,9 +127,9 @@ import { useCalendarStore } from "../stores/calendar";
 import { useConfigStore } from "../stores/config";
 import EventDetailPanel from "./EventDetailPanel.vue";
 import CalendarEventItem from "./CalendarEventItem.vue";
+import DashboardPanel from "./DashboardPanel.vue";
 
 const configStore = useConfigStore();
-const showHeader = computed(() => configStore.shouldShowUI);
 const viewMode = computed(() => configStore.calendarViewMode);
 const showWeekNumbers = computed(() => configStore.showWeekNumbers);
 const weekStartDay = computed(() => configStore.weekStartDay ?? 1);
@@ -161,6 +145,8 @@ const viewModeLabel = computed(() => {
   };
   return labels[viewMode.value] || "Month";
 });
+
+const calendarSubtitle = computed(() => `${currentMonthYear.value} - ${viewModeLabel.value}`);
 
 const calendarStore = useCalendarStore();
 const route = useRoute();
@@ -989,145 +975,8 @@ onActivated(() => {
   outline: none;
 }
 
-.calendar-header {
-  padding: 1rem;
-  background: var(--bg-secondary);
-  border-bottom: 1px solid var(--border-color);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-shrink: 0;
-}
-
-.calendar-header-minimal {
-  padding: 0.5rem;
-  background: rgba(0, 0, 0, 0.05);
-  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 1rem;
-  flex-shrink: 0;
-  opacity: 0.7;
-  transition: opacity 0.2s;
-}
-
-.calendar-header-minimal:hover {
-  opacity: 1;
-}
-
-.btn-icon-minimal {
-  background: transparent;
-  border: none;
-  border-radius: 4px;
-  width: 28px;
-  height: 28px;
-  font-size: 1.2rem;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-primary);
-  transition: all 0.2s;
-}
-
-.btn-icon-minimal:hover {
-  background: rgba(0, 0, 0, 0.1);
-}
-
-.current-month-minimal {
-  font-size: 0.9rem;
-  font-weight: 500;
-  color: var(--text-primary);
-  min-width: 120px;
-  text-align: center;
-}
-
-.calendar-header h2 {
-  margin: 0;
-  font-size: 1.5rem;
-  color: var(--text-primary);
-}
-
-.calendar-controls {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.calendar-title-group {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.25rem;
-  min-width: 150px;
-}
-
-.current-month {
-  font-size: 1.1rem;
-  font-weight: 500;
-  color: var(--text-primary);
-  text-align: center;
-}
-
-.view-mode-indicator {
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: var(--accent-primary);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  opacity: 0.8;
-}
-
-.calendar-title-group-minimal {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.125rem;
-  min-width: 120px;
-}
-
-.view-mode-indicator-minimal {
-  font-size: 0.65rem;
-  font-weight: 600;
-  color: var(--accent-primary);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  opacity: 0.7;
-}
-
-.btn-icon {
-  background: var(--bg-primary);
-  border: 1px solid var(--border-color);
-  border-radius: 4px;
-  width: 32px;
-  height: 32px;
-  font-size: 1.5rem;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-primary);
-  transition: all 0.2s;
-}
-
-.btn-icon:hover {
-  background: var(--bg-secondary);
-  border-color: var(--text-secondary);
-}
-
-.btn-icon:active {
-  background: var(--bg-tertiary);
-}
-
-.btn-icon:focus {
-  outline: 2px solid var(--accent-primary);
-  outline-offset: 2px;
-}
-
 .calendar-content {
   flex: 1;
-  padding: 1rem;
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -1138,10 +987,6 @@ onActivated(() => {
   box-sizing: border-box;
   /* Force hardware acceleration for consistent rendering on RPI */
   transform: translateZ(0);
-}
-
-.calendar-view:has(.calendar-header-minimal) .calendar-content {
-  padding: 0.5rem;
 }
 
 .loading-overlay {
@@ -1443,13 +1288,6 @@ onActivated(() => {
 /* Responsive styles for smaller screens and portrait mode */
 /* Use viewport units and scale everything proportionally */
 @media (max-width: 768px), (orientation: portrait) {
-  .calendar-content {
-    padding: clamp(0.25rem, 1vw, 0.75rem);
-    width: 100%;
-    max-width: 100%;
-    box-sizing: border-box;
-  }
-
   .calendar-grid {
     padding: clamp(0.25rem, 1vw, 0.75rem);
     width: 100%;
@@ -1488,22 +1326,6 @@ onActivated(() => {
     font-size: clamp(0.7rem, 2vw, 0.9rem);
   }
 
-  .calendar-header {
-    padding: clamp(0.5rem, 1.5vw, 1rem);
-  }
-
-  .calendar-header h2 {
-    font-size: clamp(1rem, 3vw, 1.5rem);
-  }
-
-  .current-month {
-    font-size: clamp(0.85rem, 2.5vw, 1.1rem);
-  }
-
-  .view-mode-indicator {
-    font-size: clamp(0.6rem, 1.5vw, 0.75rem);
-  }
-
   .day-header {
     margin-bottom: clamp(0.1rem, 0.5vw, 0.25rem);
   }
@@ -1516,13 +1338,6 @@ onActivated(() => {
 
 /* Extra small screens - more aggressive scaling */
 @media (max-width: 480px) {
-  .calendar-content {
-    padding: clamp(0.15rem, 1vw, 0.5rem);
-    width: 100%;
-    max-width: 100%;
-    box-sizing: border-box;
-  }
-
   .calendar-grid {
     padding: clamp(0.15rem, 1vw, 0.5rem);
     width: 100%;
@@ -1563,13 +1378,6 @@ onActivated(() => {
 
 /* Portrait mode with limited height - ensure everything fits */
 @media (orientation: portrait) and (max-height: 800px) {
-  .calendar-content {
-    padding: clamp(0.15rem, 1vh, 0.5rem);
-    width: 100%;
-    max-width: 100%;
-    box-sizing: border-box;
-  }
-
   .calendar-grid {
     padding: clamp(0.15rem, 1vh, 0.5rem);
     width: 100%;
@@ -1611,13 +1419,6 @@ onActivated(() => {
 
 /* Very small portrait screens - maximum compression */
 @media (orientation: portrait) and (max-height: 600px) {
-  .calendar-content {
-    padding: 0.15rem;
-    width: 100%;
-    max-width: 100%;
-    box-sizing: border-box;
-  }
-
   .calendar-grid {
     padding: 0.15rem;
     width: 100%;

--- a/frontend/src/components/DashboardPanel.vue
+++ b/frontend/src/components/DashboardPanel.vue
@@ -1,0 +1,191 @@
+<template>
+  <section :class="panelClasses">
+    <header v-if="showPanelHeader" class="dashboard-panel__header">
+      <div class="dashboard-panel__title-group">
+        <h2 class="dashboard-panel__title">{{ title }}</h2>
+        <p v-if="subtitle" class="dashboard-panel__subtitle">{{ subtitle }}</p>
+      </div>
+      <div v-if="$slots.actions" class="dashboard-panel__actions">
+        <slot name="actions" />
+      </div>
+    </header>
+    <div class="dashboard-panel__body">
+      <slot />
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed } from "vue";
+import { useConfigStore } from "../stores/config";
+
+const props = defineProps({
+  title: {
+    type: String,
+    required: true,
+  },
+  subtitle: {
+    type: String,
+    default: "",
+  },
+  variant: {
+    type: String,
+    default: "default",
+    validator: value => ["default", "dense", "media", "iframe"].includes(value),
+  },
+  headerVisible: {
+    type: Boolean,
+    default: true,
+  },
+});
+
+const configStore = useConfigStore();
+
+const showPanelHeader = computed(() => props.headerVisible && configStore.shouldShowUI);
+const panelClasses = computed(() => [
+  "dashboard-panel",
+  `dashboard-panel--${props.variant}`,
+  { "dashboard-panel--header-hidden": !showPanelHeader.value },
+]);
+</script>
+
+<style scoped>
+.dashboard-panel {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--bg-primary);
+  border-radius: 8px;
+}
+
+.dashboard-panel--media {
+  background: #000;
+}
+
+.dashboard-panel__header {
+  min-height: 72px;
+  padding: 1rem;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.dashboard-panel__title-group {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.dashboard-panel__title {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dashboard-panel__subtitle {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  font-weight: 500;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dashboard-panel__actions {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.dashboard-panel__body {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.dashboard-panel--dense .dashboard-panel__body {
+  padding: 0.75rem;
+}
+
+.dashboard-panel--media .dashboard-panel__body,
+.dashboard-panel--iframe .dashboard-panel__body {
+  padding: 0;
+}
+
+:slotted(.dashboard-panel__icon-button) {
+  width: 32px;
+  height: 32px;
+  border-radius: 4px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  line-height: 1;
+  transition:
+    background 0.2s,
+    border-color 0.2s;
+}
+
+:slotted(.dashboard-panel__icon-button:hover) {
+  background: var(--bg-secondary);
+  border-color: var(--text-secondary);
+}
+
+:slotted(.dashboard-panel__icon-button:focus) {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}
+
+@media (max-width: 768px), (orientation: portrait) {
+  .dashboard-panel__header {
+    min-height: 64px;
+    padding: clamp(0.5rem, 1.5vw, 1rem);
+  }
+
+  .dashboard-panel__title {
+    font-size: clamp(1rem, 3vw, 1.5rem);
+  }
+
+  .dashboard-panel__subtitle {
+    font-size: clamp(0.65rem, 1.6vw, 0.85rem);
+  }
+
+  .dashboard-panel__body {
+    padding: clamp(0.25rem, 1vw, 0.75rem);
+  }
+
+  .dashboard-panel--dense .dashboard-panel__body {
+    padding: clamp(0.2rem, 0.8vw, 0.5rem);
+  }
+
+  .dashboard-panel--media .dashboard-panel__body,
+  .dashboard-panel--iframe .dashboard-panel__body {
+    padding: 0;
+  }
+}
+</style>

--- a/frontend/src/components/DashboardPanel.vue
+++ b/frontend/src/components/DashboardPanel.vue
@@ -133,34 +133,6 @@ const panelClasses = computed(() => [
   padding: 0;
 }
 
-:slotted(.dashboard-panel__icon-button) {
-  width: 32px;
-  height: 32px;
-  border-radius: 4px;
-  border: 1px solid var(--border-color);
-  background: var(--bg-primary);
-  color: var(--text-primary);
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.2rem;
-  line-height: 1;
-  transition:
-    background 0.2s,
-    border-color 0.2s;
-}
-
-:slotted(.dashboard-panel__icon-button:hover) {
-  background: var(--bg-secondary);
-  border-color: var(--text-secondary);
-}
-
-:slotted(.dashboard-panel__icon-button:focus) {
-  outline: 2px solid var(--accent-primary);
-  outline-offset: 2px;
-}
-
 @media (max-width: 768px), (orientation: portrait) {
   .dashboard-panel__header {
     min-height: 64px;

--- a/frontend/src/components/PhotoSlideshow.vue
+++ b/frontend/src/components/PhotoSlideshow.vue
@@ -1,50 +1,52 @@
 <template>
   <div class="photo-slideshow" :class="{ fullscreen: isFullscreen }">
-    <div v-if="!isFullscreen && showHeader" class="slideshow-header">
-      <h2>Photos</h2>
-      <div class="slideshow-controls">
-        <div v-if="imagesStore.error" class="error-message">
-          {{ imagesStore.error }}
+    <DashboardPanel title="Photos" variant="media" :header-visible="!isFullscreen">
+      <template #actions>
+        <div class="slideshow-controls">
+          <div v-if="imagesStore.error" class="error-message">
+            {{ imagesStore.error }}
+          </div>
+          <button
+            v-if="imagesStore.images.length > 1"
+            class="dashboard-panel__icon-button"
+            title="Previous image"
+            @click="imagesStore.previousImage"
+          >
+            ‹
+          </button>
+          <button
+            v-if="imagesStore.images.length > 1"
+            class="dashboard-panel__icon-button"
+            title="Next image"
+            @click="imagesStore.nextImage"
+          >
+            ›
+          </button>
         </div>
-        <button
-          v-if="imagesStore.images.length > 1"
-          class="btn-icon"
-          title="Previous image"
-          @click="imagesStore.previousImage"
-        >
-          ‹
-        </button>
-        <button
-          v-if="imagesStore.images.length > 1"
-          class="btn-icon"
-          title="Next image"
-          @click="imagesStore.nextImage"
-        >
-          ›
-        </button>
+      </template>
+
+      <div class="slideshow-content">
+        <div v-if="imagesStore.loading" class="loading">
+          <p>Loading images...</p>
+        </div>
+        <div v-else-if="!currentImageUrl" class="photo-placeholder">
+          <p>No images available</p>
+          <p class="photo-info">Add images to <code>data/images</code> directory</p>
+        </div>
+        <div v-else class="photo-container">
+          <img
+            :src="currentImageUrl"
+            :alt="imagesStore.currentImage?.filename || 'Photo'"
+            :class="['photo-image', `photo-image-${displayMode}`]"
+            :style="imageStyle"
+            decoding="async"
+            loading="eager"
+            @load="onImageLoad"
+            @error="onImageError"
+          />
+        </div>
       </div>
-    </div>
-    <div class="slideshow-content">
-      <div v-if="imagesStore.loading" class="loading">
-        <p>Loading images...</p>
-      </div>
-      <div v-else-if="!currentImageUrl" class="photo-placeholder">
-        <p>No images available</p>
-        <p class="photo-info">Add images to <code>data/images</code> directory</p>
-      </div>
-      <div v-else class="photo-container">
-        <img
-          :src="currentImageUrl"
-          :alt="imagesStore.currentImage?.filename || 'Photo'"
-          :class="['photo-image', `photo-image-${displayMode}`]"
-          :style="imageStyle"
-          decoding="async"
-          loading="eager"
-          @load="onImageLoad"
-          @error="onImageError"
-        />
-      </div>
-    </div>
+    </DashboardPanel>
   </div>
 </template>
 
@@ -52,9 +54,9 @@
 import { computed, onMounted, onUnmounted, watch } from "vue";
 import { useImagesStore } from "../stores/images";
 import { useConfigStore } from "../stores/config";
+import DashboardPanel from "./DashboardPanel.vue";
 
 const configStore = useConfigStore();
-const showHeader = computed(() => configStore.shouldShowUI);
 
 const props = defineProps({
   isFullscreen: {
@@ -212,55 +214,10 @@ watch(
   border-radius: 0;
 }
 
-.slideshow-header {
-  padding: 1.4rem;
-  background: var(--bg-secondary);
-  border-bottom: 1px solid var(--border-color);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-shrink: 0;
-}
-
 .slideshow-controls {
   display: flex;
   align-items: center;
-  gap: 1rem;
-}
-
-.slideshow-header h2 {
-  margin: 0;
-  font-size: 1.5rem;
-  color: var(--text-primary);
-}
-
-.btn-icon {
-  background: var(--bg-primary);
-  border: 1px solid var(--border-color);
-  border-radius: 4px;
-  width: 32px;
-  height: 32px;
-  font-size: 1.5rem;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-primary);
-  transition: all 0.2s;
-}
-
-.btn-icon:hover {
-  background: var(--bg-secondary);
-  border-color: var(--text-secondary);
-}
-
-.btn-icon:active {
-  background: var(--bg-tertiary);
-}
-
-.btn-icon:focus {
-  outline: 2px solid var(--accent-primary);
-  outline-offset: 2px;
+  gap: 0.5rem;
 }
 
 .error-message {

--- a/frontend/src/components/WebServiceViewer.vue
+++ b/frontend/src/components/WebServiceViewer.vue
@@ -13,35 +13,11 @@
 
     <!-- Viewer Content -->
     <div class="viewer-content">
-      <!-- Loading State -->
-      <DashboardPanel v-if="loading" title="Web Services" :header-visible="!isFullscreen">
-        <div class="loading-state">
-          <div class="spinner" />
-          <p>Loading service...</p>
-        </div>
-      </DashboardPanel>
-
-      <!-- No Services -->
-      <DashboardPanel
-        v-else-if="services.length === 0"
-        title="Web Services"
-        :header-visible="!isFullscreen"
-      >
-        <div class="no-services">
-          <p>No web services configured</p>
-          <p class="help-text">Add web services in Settings</p>
-        </div>
-      </DashboardPanel>
-
-      <!-- Explicit service missing or disabled -->
-      <DashboardPanel
-        v-else-if="serviceUnavailable"
-        title="Web Services"
-        :header-visible="!isFullscreen"
-      >
-        <div class="no-services">
-          <p>Selected service is unavailable</p>
-          <p class="help-text">Choose another service in Settings</p>
+      <DashboardPanel v-if="emptyState" title="Web Services" :header-visible="!isFullscreen">
+        <div :class="emptyState.className">
+          <div v-if="emptyState.loading" class="spinner" />
+          <p>{{ emptyState.message }}</p>
+          <p v-if="emptyState.helpText" class="help-text">{{ emptyState.helpText }}</p>
         </div>
       </DashboardPanel>
 
@@ -136,6 +112,26 @@ const serviceSubtitle = computed(() =>
     ? `Service ${currentServiceIndex.value + 1} of ${services.value.length}`
     : ""
 );
+const emptyState = computed(() => {
+  if (loading.value) {
+    return { className: "loading-state", loading: true, message: "Loading service..." };
+  }
+  if (services.value.length === 0) {
+    return {
+      className: "no-services",
+      message: "No web services configured",
+      helpText: "Add web services in Settings",
+    };
+  }
+  if (serviceUnavailable.value) {
+    return {
+      className: "no-services",
+      message: "Selected service is unavailable",
+      helpText: "Choose another service in Settings",
+    };
+  }
+  return null;
+});
 
 // ServiceViewer now handles all service rendering logic
 

--- a/frontend/src/components/WebServiceViewer.vue
+++ b/frontend/src/components/WebServiceViewer.vue
@@ -11,81 +11,83 @@
       </button>
     </div>
 
-    <!-- Header (hidden in fullscreen mode) -->
-    <div v-if="showHeader && !isFullscreen" class="viewer-header">
-      <div class="header-left">
-        <h2>{{ currentService?.name || "Web Services" }}</h2>
-        <div v-if="canNavigateServices && services.length > 1" class="service-indicator">
-          Service {{ currentServiceIndex + 1 }} of {{ services.length }}
-        </div>
-      </div>
-      <div class="header-right">
-        <button
-          v-if="canNavigateServices && services.length > 1"
-          class="btn-nav"
-          title="Previous Service"
-          @click="previousService"
-        >
-          ‹
-        </button>
-        <button
-          v-if="canNavigateServices && services.length > 1"
-          class="btn-nav"
-          title="Next Service"
-          @click="nextService"
-        >
-          ›
-        </button>
-        <button
-          class="btn-fullscreen"
-          :title="isFullscreen ? 'Exit Fullscreen' : 'Enter Fullscreen'"
-          @click.stop="handleToggleFullscreen"
-        >
-          {{ isFullscreen ? "⤓" : "⤢" }}
-        </button>
-        <button class="btn-close" title="Close" @click.stop="handleClose">×</button>
-      </div>
-    </div>
-
-    <!-- Service Selection (if multiple services) -->
-    <div
-      v-if="showHeader && !isFullscreen && canNavigateServices && services.length > 1"
-      class="service-selector"
-    >
-      <button
-        v-for="(service, index) in services"
-        :key="service.id"
-        class="service-btn"
-        :class="{ active: index === currentServiceIndex }"
-        @click="setServiceIndex(index)"
-      >
-        {{ service.name }}
-      </button>
-    </div>
-
     <!-- Viewer Content -->
     <div class="viewer-content">
       <!-- Loading State -->
-      <div v-if="loading" class="loading-state">
-        <div class="spinner" />
-        <p>Loading service...</p>
-      </div>
+      <DashboardPanel v-if="loading" title="Web Services" :header-visible="!isFullscreen">
+        <div class="loading-state">
+          <div class="spinner" />
+          <p>Loading service...</p>
+        </div>
+      </DashboardPanel>
 
       <!-- No Services -->
-      <div v-else-if="services.length === 0" class="no-services">
-        <p>No web services configured</p>
-        <p class="help-text">Add web services in Settings</p>
-      </div>
+      <DashboardPanel
+        v-else-if="services.length === 0"
+        title="Web Services"
+        :header-visible="!isFullscreen"
+      >
+        <div class="no-services">
+          <p>No web services configured</p>
+          <p class="help-text">Add web services in Settings</p>
+        </div>
+      </DashboardPanel>
 
       <!-- Explicit service missing or disabled -->
-      <div v-else-if="serviceUnavailable" class="no-services">
-        <p>Selected service is unavailable</p>
-        <p class="help-text">Choose another service in Settings</p>
-      </div>
+      <DashboardPanel
+        v-else-if="serviceUnavailable"
+        title="Web Services"
+        :header-visible="!isFullscreen"
+      >
+        <div class="no-services">
+          <p>Selected service is unavailable</p>
+          <p class="help-text">Choose another service in Settings</p>
+        </div>
+      </DashboardPanel>
 
       <!-- Service Content (uses ServiceViewer for routing) -->
       <div v-else-if="currentService" class="service-container">
-        <ServiceViewer :key="currentService.id" :service="currentService" />
+        <ServiceViewer
+          :key="currentService.id"
+          :service="currentService"
+          :subtitle="serviceSubtitle"
+          :header-visible="!isFullscreen"
+        >
+          <template #actions>
+            <button
+              v-if="canNavigateServices && services.length > 1"
+              class="dashboard-panel__icon-button"
+              title="Previous Service"
+              @click="previousService"
+            >
+              ‹
+            </button>
+            <button
+              v-if="canNavigateServices && services.length > 1"
+              class="dashboard-panel__icon-button"
+              title="Next Service"
+              @click="nextService"
+            >
+              ›
+            </button>
+            <button
+              v-if="!isFullscreen"
+              class="dashboard-panel__icon-button"
+              title="Enter Fullscreen"
+              @click.stop="handleToggleFullscreen"
+            >
+              ⤢
+            </button>
+            <button
+              v-if="!isFullscreen"
+              class="dashboard-panel__icon-button"
+              title="Close"
+              @click.stop="handleClose"
+            >
+              ×
+            </button>
+          </template>
+        </ServiceViewer>
       </div>
     </div>
   </div>
@@ -93,9 +95,9 @@
 
 <script setup>
 import { computed, onMounted, onUnmounted } from "vue";
-import { useConfigStore } from "../stores/config";
 import { useWebServicesStore } from "../stores/webServices";
 import { useModeStore } from "../stores/mode";
+import DashboardPanel from "./DashboardPanel.vue";
 import ServiceViewer from "./service/ServiceViewer.vue";
 
 const props = defineProps({
@@ -109,11 +111,9 @@ const props = defineProps({
   },
 });
 
-const configStore = useConfigStore();
 const webServicesStore = useWebServicesStore();
 const modeStore = useModeStore();
 
-const showHeader = computed(() => configStore.shouldShowUI);
 const services = computed(() => webServicesStore.services);
 const currentServiceIndex = computed(() => webServicesStore.currentServiceIndex);
 const canNavigateServices = computed(() => !props.serviceId);
@@ -130,6 +130,11 @@ const serviceUnavailable = computed(
     services.value.length > 0 &&
     (Boolean(props.serviceId) || !props.isFullscreen) &&
     !currentService.value
+);
+const serviceSubtitle = computed(() =>
+  canNavigateServices.value && services.value.length > 1
+    ? `Service ${currentServiceIndex.value + 1} of ${services.value.length}`
+    : ""
 );
 
 // ServiceViewer now handles all service rendering logic
@@ -204,11 +209,6 @@ const previousService = () => {
   webServicesStore.previousService();
 };
 
-const setServiceIndex = index => {
-  if (props.serviceId) return;
-  webServicesStore.setServiceIndex(index);
-};
-
 // ServiceViewer handles all service rendering logic
 
 // Handle Escape key to close fullscreen
@@ -251,98 +251,6 @@ onUnmounted(() => {
   right: 0;
   bottom: 0;
   z-index: 1000;
-}
-
-.viewer-header {
-  padding: 1rem;
-  background: var(--bg-secondary);
-  border-bottom: 1px solid var(--border-color);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-shrink: 0;
-}
-
-.header-left {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
-
-.viewer-header h2 {
-  margin: 0;
-  font-size: 1.5rem;
-  color: var(--text-primary);
-}
-
-.service-indicator {
-  font-size: 0.9rem;
-  color: var(--text-secondary);
-  padding: 0.25rem 0.75rem;
-  background: var(--bg-tertiary);
-  border-radius: 12px;
-}
-
-.header-right {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.btn-nav,
-.btn-fullscreen,
-.btn-close {
-  background: var(--bg-primary);
-  border: 1px solid var(--border-color);
-  border-radius: 4px;
-  width: 32px;
-  height: 32px;
-  font-size: 1.2rem;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-primary);
-  transition: all 0.2s;
-}
-
-.btn-nav:hover,
-.btn-fullscreen:hover,
-.btn-close:hover {
-  background: var(--bg-secondary);
-  border-color: var(--text-secondary);
-}
-
-.service-selector {
-  padding: 0.75rem 1rem;
-  background: var(--bg-tertiary);
-  border-bottom: 1px solid var(--border-color);
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-  flex-shrink: 0;
-}
-
-.service-btn {
-  padding: 0.5rem 1rem;
-  background: var(--bg-primary);
-  border: 1px solid var(--border-color);
-  border-radius: 4px;
-  font-size: 0.9rem;
-  cursor: pointer;
-  transition: all 0.2s;
-  color: var(--text-primary);
-}
-
-.service-btn:hover {
-  background: var(--bg-secondary);
-  border-color: var(--text-secondary);
-}
-
-.service-btn.active {
-  background: var(--accent-primary);
-  color: #fff; /* Keep white for contrast on accent background */
-  border-color: var(--accent-primary);
 }
 
 .viewer-content {

--- a/frontend/src/components/plugins/SchemaRenderer.vue
+++ b/frontend/src/components/plugins/SchemaRenderer.vue
@@ -8,7 +8,7 @@
     :data="data"
     :plugin-id="pluginId"
   />
-  <component v-else :is="renderer" :schema="schema" :data="data" />
+  <component v-else :is="renderer" class="schema-renderer__body" :schema="schema" :data="data" />
 </template>
 
 <script setup>
@@ -52,5 +52,9 @@ const renderer = computed(() => renderers[props.schema?.kind] || null);
   color: var(--text-secondary);
   font-size: 0.85em;
   font-style: italic;
+}
+
+.schema-renderer__body {
+  min-height: 0;
 }
 </style>

--- a/frontend/src/components/plugins/renderers/CardGrid.vue
+++ b/frontend/src/components/plugins/renderers/CardGrid.vue
@@ -1,10 +1,6 @@
 <template>
-  <div class="card-grid calvin-plugin-grid dashboard-renderer-grid" :style="gridStyle">
-    <article
-      v-for="(card, idx) in cards"
-      :key="idx"
-      class="card-grid__card calvin-plugin-surface dashboard-renderer-card"
-    >
+  <div class="card-grid calvin-plugin-grid" :style="gridStyle">
+    <article v-for="(card, idx) in cards" :key="idx" class="card-grid__card calvin-plugin-surface">
       <header v-if="cardTitle(card)" class="card-grid__title">{{ cardTitle(card) }}</header>
       <ul v-if="cardItems(card).length" class="card-grid__items">
         <li
@@ -14,7 +10,6 @@
           :class="{
             'card-grid__item--clickable': itemUrl(item),
             'calvin-plugin-clickable': itemUrl(item),
-            'dashboard-renderer-clickable': itemUrl(item),
           }"
           @click="open(itemUrl(item))"
         >
@@ -22,7 +17,7 @@
           <span v-if="itemValue(item)" class="card-grid__item-value">{{ itemValue(item) }}</span>
         </li>
       </ul>
-      <p v-else class="card-grid__empty calvin-plugin-empty dashboard-renderer-empty">
+      <p v-else class="card-grid__empty calvin-plugin-empty">
         {{ schema.empty_text || "—" }}
       </p>
     </article>

--- a/frontend/src/components/plugins/renderers/CardGrid.vue
+++ b/frontend/src/components/plugins/renderers/CardGrid.vue
@@ -1,20 +1,30 @@
 <template>
-  <div class="card-grid" :style="gridStyle">
-    <article v-for="(card, idx) in cards" :key="idx" class="card-grid__card">
+  <div class="card-grid calvin-plugin-grid dashboard-renderer-grid" :style="gridStyle">
+    <article
+      v-for="(card, idx) in cards"
+      :key="idx"
+      class="card-grid__card calvin-plugin-surface dashboard-renderer-card"
+    >
       <header v-if="cardTitle(card)" class="card-grid__title">{{ cardTitle(card) }}</header>
       <ul v-if="cardItems(card).length" class="card-grid__items">
         <li
           v-for="(item, j) in cardItems(card)"
           :key="j"
           class="card-grid__item"
-          :class="{ 'card-grid__item--clickable': itemUrl(item) }"
+          :class="{
+            'card-grid__item--clickable': itemUrl(item),
+            'calvin-plugin-clickable': itemUrl(item),
+            'dashboard-renderer-clickable': itemUrl(item),
+          }"
           @click="open(itemUrl(item))"
         >
           <span v-if="itemLabel(item)" class="card-grid__item-label">{{ itemLabel(item) }}</span>
           <span v-if="itemValue(item)" class="card-grid__item-value">{{ itemValue(item) }}</span>
         </li>
       </ul>
-      <p v-else class="card-grid__empty">{{ schema.empty_text || "—" }}</p>
+      <p v-else class="card-grid__empty calvin-plugin-empty dashboard-renderer-empty">
+        {{ schema.empty_text || "—" }}
+      </p>
     </article>
   </div>
 </template>
@@ -93,23 +103,13 @@ function open(url) {
 
 <style scoped>
 .card-grid {
-  display: grid;
-  gap: 1rem;
-  width: 100%;
-  height: 100%;
   overflow: hidden;
-  align-content: start;
 }
 
 .card-grid__card {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: 12px;
-  padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  min-width: 0;
   overflow: hidden;
 }
 
@@ -146,11 +146,6 @@ function open(url) {
   cursor: pointer;
 }
 
-.card-grid__item--clickable:hover {
-  background: var(--bg-tertiary);
-  border-color: var(--accent-primary);
-}
-
 .card-grid__item-label {
   font-weight: 600;
   font-size: 0.8rem;
@@ -169,7 +164,6 @@ function open(url) {
 .card-grid__empty {
   color: var(--text-secondary);
   font-style: italic;
-  font-size: 0.85rem;
   margin: 0;
 }
 </style>

--- a/frontend/src/components/plugins/renderers/IframeRenderer.vue
+++ b/frontend/src/components/plugins/renderers/IframeRenderer.vue
@@ -12,7 +12,7 @@
       @error="handleError"
     />
 
-    <div v-if="error" class="iframe-renderer__error">
+    <div v-if="error" class="iframe-renderer__error calvin-plugin-error dashboard-renderer-error">
       <div class="iframe-renderer__error-content">
         <h3>⚠️ Cannot Display Service</h3>
         <p>

--- a/frontend/src/components/plugins/renderers/IframeRenderer.vue
+++ b/frontend/src/components/plugins/renderers/IframeRenderer.vue
@@ -12,7 +12,7 @@
       @error="handleError"
     />
 
-    <div v-if="error" class="iframe-renderer__error calvin-plugin-error dashboard-renderer-error">
+    <div v-if="error" class="iframe-renderer__error calvin-plugin-error">
       <div class="iframe-renderer__error-content">
         <h3>⚠️ Cannot Display Service</h3>
         <p>

--- a/frontend/src/components/plugins/renderers/ItemList.vue
+++ b/frontend/src/components/plugins/renderers/ItemList.vue
@@ -1,17 +1,13 @@
 <template>
-  <ul
-    class="item-list calvin-plugin-list calvin-plugin-list--scroll dashboard-renderer-list dashboard-renderer-list--scroll"
-  >
+  <ul class="item-list calvin-plugin-list calvin-plugin-list--scroll">
     <li
       v-for="(item, i) in items"
       :key="i"
       class="item-list__row"
       :class="{
         'calvin-plugin-row': true,
-        'dashboard-renderer-row': true,
         'item-list__row--clickable': urlFor(item),
         'calvin-plugin-clickable': urlFor(item),
-        'dashboard-renderer-clickable': urlFor(item),
       }"
       @click="open(urlFor(item))"
     >
@@ -21,10 +17,7 @@
         <span v-if="valueFor(item)" class="item-list__value">{{ valueFor(item) }}</span>
       </div>
     </li>
-    <li
-      v-if="items.length === 0"
-      class="item-list__empty calvin-plugin-empty dashboard-renderer-empty"
-    >
+    <li v-if="items.length === 0" class="item-list__empty calvin-plugin-empty">
       {{ schema.empty_text || "No items" }}
     </li>
   </ul>

--- a/frontend/src/components/plugins/renderers/ItemList.vue
+++ b/frontend/src/components/plugins/renderers/ItemList.vue
@@ -1,10 +1,18 @@
 <template>
-  <ul class="item-list">
+  <ul
+    class="item-list calvin-plugin-list calvin-plugin-list--scroll dashboard-renderer-list dashboard-renderer-list--scroll"
+  >
     <li
       v-for="(item, i) in items"
       :key="i"
       class="item-list__row"
-      :class="{ 'item-list__row--clickable': urlFor(item) }"
+      :class="{
+        'calvin-plugin-row': true,
+        'dashboard-renderer-row': true,
+        'item-list__row--clickable': urlFor(item),
+        'calvin-plugin-clickable': urlFor(item),
+        'dashboard-renderer-clickable': urlFor(item),
+      }"
       @click="open(urlFor(item))"
     >
       <span v-if="timestampFor(item)" class="item-list__timestamp">{{ timestampFor(item) }}</span>
@@ -13,7 +21,10 @@
         <span v-if="valueFor(item)" class="item-list__value">{{ valueFor(item) }}</span>
       </div>
     </li>
-    <li v-if="items.length === 0" class="item-list__empty">
+    <li
+      v-if="items.length === 0"
+      class="item-list__empty calvin-plugin-empty dashboard-renderer-empty"
+    >
       {{ schema.empty_text || "No items" }}
     </li>
   </ul>
@@ -57,31 +68,16 @@ function open(url) {
 
 <style scoped>
 .item-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
   gap: 0.4rem;
-  overflow-y: auto;
 }
 
 .item-list__row {
   display: flex;
   gap: 0.75rem;
-  padding: 0.5rem 0.75rem;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
 }
 
 .item-list__row--clickable {
   cursor: pointer;
-}
-
-.item-list__row--clickable:hover {
-  background: var(--bg-tertiary);
-  border-color: var(--accent-primary);
 }
 
 .item-list__timestamp {
@@ -112,9 +108,5 @@ function open(url) {
 }
 
 .item-list__empty {
-  color: var(--text-secondary);
-  font-style: italic;
-  text-align: center;
-  padding: 1rem;
 }
 </style>

--- a/frontend/src/components/plugins/renderers/MetricDashboard.vue
+++ b/frontend/src/components/plugins/renderers/MetricDashboard.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="metric-dashboard" :style="gridStyle">
+  <div class="metric-dashboard calvin-plugin-grid dashboard-renderer-grid" :style="gridStyle">
     <div
       v-for="(metric, i) in metrics"
       :key="i"
-      class="metric-dashboard__tile"
+      class="metric-dashboard__tile calvin-plugin-metric dashboard-renderer-metric"
       :class="statusClass(metric)"
     >
       <span v-if="iconFor(metric)" class="metric-dashboard__icon">{{ iconFor(metric) }}</span>
@@ -68,21 +68,12 @@ function statusClass(metric) {
 
 <style scoped>
 .metric-dashboard {
-  display: grid;
-  gap: 1rem;
-  width: 100%;
-  height: 100%;
-  align-content: start;
 }
 
 .metric-dashboard__tile {
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
-  padding: 1.25rem;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: 12px;
   align-items: flex-start;
   justify-content: center;
 }

--- a/frontend/src/components/plugins/renderers/MetricDashboard.vue
+++ b/frontend/src/components/plugins/renderers/MetricDashboard.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="metric-dashboard calvin-plugin-grid dashboard-renderer-grid" :style="gridStyle">
+  <div class="metric-dashboard calvin-plugin-grid" :style="gridStyle">
     <div
       v-for="(metric, i) in metrics"
       :key="i"
-      class="metric-dashboard__tile calvin-plugin-metric dashboard-renderer-metric"
+      class="metric-dashboard__tile calvin-plugin-metric"
       :class="statusClass(metric)"
     >
       <span v-if="iconFor(metric)" class="metric-dashboard__icon">{{ iconFor(metric) }}</span>

--- a/frontend/src/components/plugins/renderers/StatusList.vue
+++ b/frontend/src/components/plugins/renderers/StatusList.vue
@@ -1,6 +1,10 @@
 <template>
-  <ul class="status-list">
-    <li v-for="(item, idx) in items" :key="idx" class="status-list__row">
+  <ul class="status-list calvin-plugin-list dashboard-renderer-list">
+    <li
+      v-for="(item, idx) in items"
+      :key="idx"
+      class="status-list__row calvin-plugin-row dashboard-renderer-row"
+    >
       <StatusTile :schema="itemSchemaFor(item)" :data="item" />
     </li>
   </ul>
@@ -39,9 +43,5 @@ function itemSchemaFor() {
 }
 
 .status-list__row {
-  padding: 0.5rem 0.75rem;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
 }
 </style>

--- a/frontend/src/components/plugins/renderers/StatusList.vue
+++ b/frontend/src/components/plugins/renderers/StatusList.vue
@@ -1,10 +1,6 @@
 <template>
-  <ul class="status-list calvin-plugin-list dashboard-renderer-list">
-    <li
-      v-for="(item, idx) in items"
-      :key="idx"
-      class="status-list__row calvin-plugin-row dashboard-renderer-row"
-    >
+  <ul class="status-list calvin-plugin-list">
+    <li v-for="(item, idx) in items" :key="idx" class="status-list__row calvin-plugin-row">
       <StatusTile :schema="itemSchemaFor(item)" :data="item" />
     </li>
   </ul>

--- a/frontend/src/components/plugins/renderers/WeatherForecast.vue
+++ b/frontend/src/components/plugins/renderers/WeatherForecast.vue
@@ -1,9 +1,5 @@
 <template>
   <section v-if="data && !data.error" class="weather-forecast-renderer">
-    <header class="weather-forecast-renderer__header">
-      <h3>{{ title }}</h3>
-    </header>
-
     <div v-if="current" class="weather-forecast-renderer__current">
       <div class="weather-forecast-renderer__main">
         <svg class="weather-forecast-renderer__icon" viewBox="0 0 24 24" aria-hidden="true">
@@ -19,23 +15,35 @@
       </div>
 
       <div class="weather-forecast-renderer__details">
-        <div v-if="hasValue(feelsLike)" class="weather-forecast-renderer__detail">
+        <div
+          v-if="hasValue(feelsLike)"
+          class="weather-forecast-renderer__detail calvin-plugin-surface dashboard-renderer-card"
+        >
           <span class="weather-forecast-renderer__detail-label">Feels like</span>
           <span class="weather-forecast-renderer__detail-value">
             {{ round(feelsLike) }}{{ temperatureUnit }}
           </span>
         </div>
-        <div v-if="hasValue(humidity)" class="weather-forecast-renderer__detail">
+        <div
+          v-if="hasValue(humidity)"
+          class="weather-forecast-renderer__detail calvin-plugin-surface dashboard-renderer-card"
+        >
           <span class="weather-forecast-renderer__detail-label">Humidity</span>
           <span class="weather-forecast-renderer__detail-value">{{ round(humidity) }}%</span>
         </div>
-        <div v-if="hasValue(windSpeed)" class="weather-forecast-renderer__detail">
+        <div
+          v-if="hasValue(windSpeed)"
+          class="weather-forecast-renderer__detail calvin-plugin-surface dashboard-renderer-card"
+        >
           <span class="weather-forecast-renderer__detail-label">Wind</span>
           <span class="weather-forecast-renderer__detail-value">
             {{ round(windSpeed) }} {{ windUnit }}
           </span>
         </div>
-        <div v-if="hasValue(pressure)" class="weather-forecast-renderer__detail">
+        <div
+          v-if="hasValue(pressure)"
+          class="weather-forecast-renderer__detail calvin-plugin-surface dashboard-renderer-card"
+        >
           <span class="weather-forecast-renderer__detail-label">Pressure</span>
           <span class="weather-forecast-renderer__detail-value">{{ round(pressure) }} hPa</span>
         </div>
@@ -48,7 +56,7 @@
         <article
           v-for="(day, index) in forecast"
           :key="dateFor(day) || index"
-          class="weather-forecast-renderer__item"
+          class="weather-forecast-renderer__item calvin-plugin-surface dashboard-renderer-card"
         >
           <div class="weather-forecast-renderer__date">{{ formatForecastDate(dateFor(day)) }}</div>
           <svg class="weather-forecast-renderer__small-icon" viewBox="0 0 24 24" aria-hidden="true">
@@ -89,9 +97,6 @@ const currentSpec = computed(() => props.schema.current || {});
 const forecastSpec = computed(() => props.schema.forecast || {});
 const units = computed(() => props.schema.units || {});
 
-const title = computed(
-  () => pick(props.data, props.schema.title_path, props.schema.title) || "Weather"
-);
 const current = computed(() =>
   props.schema.current_path
     ? resolvePath(props.data, props.schema.current_path)
@@ -173,24 +178,11 @@ function capitalize(value) {
 .weather-forecast-renderer {
   width: 100%;
   height: 100%;
-  padding: 1.5rem;
   display: flex;
   flex-direction: column;
   gap: 1rem;
   overflow: hidden;
   box-sizing: border-box;
-}
-
-.weather-forecast-renderer__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.weather-forecast-renderer__header h3 {
-  margin: 0;
-  font-size: 1.5rem;
-  color: var(--text-primary);
 }
 
 .weather-forecast-renderer__current {
@@ -206,7 +198,7 @@ function capitalize(value) {
   gap: 0.75rem;
   padding: 1.5rem;
   background: var(--bg-secondary);
-  border-radius: 8px;
+  border-radius: 6px;
   flex-shrink: 0;
 }
 
@@ -251,9 +243,6 @@ function capitalize(value) {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  padding: 1rem;
-  background: var(--bg-secondary);
-  border-radius: 6px;
 }
 
 .weather-forecast-renderer__detail-label {
@@ -299,9 +288,6 @@ function capitalize(value) {
   flex-direction: column;
   align-items: center;
   gap: 0.5rem;
-  padding: 1rem;
-  background: var(--bg-secondary);
-  border-radius: 6px;
   text-align: center;
 }
 

--- a/frontend/src/components/plugins/renderers/WeatherForecast.vue
+++ b/frontend/src/components/plugins/renderers/WeatherForecast.vue
@@ -17,7 +17,7 @@
       <div class="weather-forecast-renderer__details">
         <div
           v-if="hasValue(feelsLike)"
-          class="weather-forecast-renderer__detail calvin-plugin-surface dashboard-renderer-card"
+          class="weather-forecast-renderer__detail calvin-plugin-surface"
         >
           <span class="weather-forecast-renderer__detail-label">Feels like</span>
           <span class="weather-forecast-renderer__detail-value">
@@ -26,14 +26,14 @@
         </div>
         <div
           v-if="hasValue(humidity)"
-          class="weather-forecast-renderer__detail calvin-plugin-surface dashboard-renderer-card"
+          class="weather-forecast-renderer__detail calvin-plugin-surface"
         >
           <span class="weather-forecast-renderer__detail-label">Humidity</span>
           <span class="weather-forecast-renderer__detail-value">{{ round(humidity) }}%</span>
         </div>
         <div
           v-if="hasValue(windSpeed)"
-          class="weather-forecast-renderer__detail calvin-plugin-surface dashboard-renderer-card"
+          class="weather-forecast-renderer__detail calvin-plugin-surface"
         >
           <span class="weather-forecast-renderer__detail-label">Wind</span>
           <span class="weather-forecast-renderer__detail-value">
@@ -42,7 +42,7 @@
         </div>
         <div
           v-if="hasValue(pressure)"
-          class="weather-forecast-renderer__detail calvin-plugin-surface dashboard-renderer-card"
+          class="weather-forecast-renderer__detail calvin-plugin-surface"
         >
           <span class="weather-forecast-renderer__detail-label">Pressure</span>
           <span class="weather-forecast-renderer__detail-value">{{ round(pressure) }} hPa</span>
@@ -56,7 +56,7 @@
         <article
           v-for="(day, index) in forecast"
           :key="dateFor(day) || index"
-          class="weather-forecast-renderer__item calvin-plugin-surface dashboard-renderer-card"
+          class="weather-forecast-renderer__item calvin-plugin-surface"
         >
           <div class="weather-forecast-renderer__date">{{ formatForecastDate(dateFor(day)) }}</div>
           <svg class="weather-forecast-renderer__small-icon" viewBox="0 0 24 24" aria-hidden="true">

--- a/frontend/src/components/service/ServiceViewer.vue
+++ b/frontend/src/components/service/ServiceViewer.vue
@@ -1,24 +1,37 @@
 <template>
   <div :key="service.id" class="service-viewer">
-    <SchemaRenderer
-      v-if="schemaKind"
-      :schema="service.display_schema"
-      :data="schemaData"
-      :plugin-id="service.id"
-    />
-    <div v-else class="unknown-service">
-      <p>Service has no display schema.</p>
-      <p class="error-text">
-        display_schema.kind is missing — this plugin may need updating to the v2 contract.
-      </p>
-    </div>
+    <DashboardPanel
+      :title="panelTitle"
+      :subtitle="subtitle"
+      :variant="panelVariant"
+      :header-visible="headerVisible"
+    >
+      <template v-if="$slots.actions" #actions>
+        <slot name="actions" />
+      </template>
+
+      <SchemaRenderer
+        v-if="schemaKind"
+        :schema="service.display_schema"
+        :data="schemaData"
+        :plugin-id="service.id"
+      />
+      <div v-else class="unknown-service">
+        <p>Service has no display schema.</p>
+        <p class="error-text">
+          display_schema.kind is missing - this plugin may need updating to the v2 contract.
+        </p>
+      </div>
+    </DashboardPanel>
   </div>
 </template>
 
 <script setup>
 import { computed, watch } from "vue";
+import DashboardPanel from "../DashboardPanel.vue";
 import SchemaRenderer from "../plugins/SchemaRenderer.vue";
 import { useSchemaData } from "../../composables/useSchemaData";
+import { resolvePath } from "../../utils/jsonPath";
 import { logDebug } from "../../utils/logger";
 
 const props = defineProps({
@@ -26,15 +39,35 @@ const props = defineProps({
     type: Object,
     required: true,
   },
+  subtitle: {
+    type: String,
+    default: "",
+  },
+  headerVisible: {
+    type: Boolean,
+    default: true,
+  },
 });
 
 const schemaKind = computed(() => props.service.display_schema?.kind || null);
+const displaySchema = computed(() => props.service.display_schema || {});
 const schemaQuery = useSchemaData(
   computed(() => props.service.id),
-  computed(() => props.service.display_schema || {}),
+  displaySchema,
   computed(() => Boolean(schemaKind.value))
 );
 const schemaData = computed(() => schemaQuery.data.value);
+const panelTitle = computed(() => {
+  const pathTitle = displaySchema.value.title_path
+    ? resolvePath(schemaData.value, displaySchema.value.title_path)
+    : null;
+  return pathTitle || displaySchema.value.title || props.service.name || "Service";
+});
+const panelVariant = computed(() => {
+  const variant = displaySchema.value.panel_variant;
+  if (["default", "dense", "media", "iframe"].includes(variant)) return variant;
+  return schemaKind.value === "iframe" ? "iframe" : "default";
+});
 
 watch(
   () => props.service,
@@ -56,6 +89,8 @@ watch(
 .service-viewer {
   width: 100%;
   height: 100%;
+  min-width: 0;
+  min-height: 0;
 }
 
 .unknown-service {

--- a/frontend/src/components/service/ServiceViewer.vue
+++ b/frontend/src/components/service/ServiceViewer.vue
@@ -61,7 +61,9 @@ const panelTitle = computed(() => {
   const pathTitle = displaySchema.value.title_path
     ? resolvePath(schemaData.value, displaySchema.value.title_path)
     : null;
-  return pathTitle || displaySchema.value.title || props.service.name || "Service";
+  const resolvedTitle =
+    typeof pathTitle === "string" || typeof pathTitle === "number" ? String(pathTitle) : null;
+  return resolvedTitle || displaySchema.value.title || props.service.name || "Service";
 });
 const panelVariant = computed(() => {
   const variant = displaySchema.value.panel_variant;

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -17,3 +17,176 @@ body {
   width: 100%;
   height: 100vh;
 }
+
+.dashboard-panel__icon-button {
+  width: 32px;
+  height: 32px;
+  border-radius: 4px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  line-height: 1;
+  transition:
+    background 0.2s,
+    border-color 0.2s;
+}
+
+.dashboard-panel__icon-button:hover {
+  background: var(--bg-secondary);
+  border-color: var(--text-secondary);
+}
+
+.dashboard-panel__icon-button:focus {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}
+
+.calvin-plugin-fill {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+}
+
+.calvin-plugin-grid,
+.dashboard-renderer-grid {
+  display: grid;
+  gap: 1rem;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  align-content: start;
+}
+
+.calvin-plugin-grid--dense {
+  grid-template-columns: repeat(auto-fit, minmax(min(120px, 100%), 1fr));
+  gap: 0.5rem;
+}
+
+.calvin-plugin-grid--auto {
+  grid-template-columns: repeat(auto-fit, minmax(min(180px, 100%), 1fr));
+}
+
+.calvin-plugin-grid--2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.calvin-plugin-grid--3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.calvin-plugin-list,
+.dashboard-renderer-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 0;
+  min-height: 0;
+}
+
+.calvin-plugin-list--scroll,
+.dashboard-renderer-list--scroll {
+  overflow-y: auto;
+}
+
+.calvin-plugin-surface,
+.dashboard-renderer-card,
+.dashboard-renderer-row,
+.dashboard-renderer-metric {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  min-width: 0;
+}
+
+.calvin-plugin-surface,
+.dashboard-renderer-card {
+  padding: 1rem;
+}
+
+.calvin-plugin-row,
+.dashboard-renderer-row {
+  padding: 0.5rem 0.75rem;
+}
+
+.calvin-plugin-metric,
+.dashboard-renderer-metric {
+  padding: 1.25rem;
+}
+
+.calvin-plugin-clickable,
+.dashboard-renderer-clickable {
+  cursor: pointer;
+}
+
+.calvin-plugin-clickable:hover,
+.dashboard-renderer-clickable:hover {
+  background: var(--bg-tertiary);
+  border-color: var(--accent-primary);
+}
+
+.calvin-plugin-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-width: 0;
+  min-height: 0;
+}
+
+.calvin-plugin-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  min-width: 0;
+  flex-shrink: 0;
+}
+
+.calvin-plugin-media {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background: #000;
+}
+
+.calvin-plugin-media > img,
+.calvin-plugin-media > video,
+.calvin-plugin-media > canvas {
+  max-width: 100%;
+  max-height: 100%;
+}
+
+.calvin-plugin-empty,
+.calvin-plugin-loading,
+.calvin-plugin-error,
+.dashboard-renderer-empty,
+.dashboard-renderer-loading,
+.dashboard-renderer-error {
+  color: var(--text-secondary);
+  text-align: center;
+  padding: 1rem;
+}
+
+.calvin-plugin-empty,
+.dashboard-renderer-empty {
+  font-style: italic;
+}
+
+.calvin-plugin-error,
+.dashboard-renderer-error {
+  color: var(--accent-error);
+}

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -53,8 +53,7 @@ body {
   min-height: 0;
 }
 
-.calvin-plugin-grid,
-.dashboard-renderer-grid {
+.calvin-plugin-grid {
   display: grid;
   gap: 1rem;
   width: 100%;
@@ -81,8 +80,7 @@ body {
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
-.calvin-plugin-list,
-.dashboard-renderer-list {
+.calvin-plugin-list {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -93,43 +91,34 @@ body {
   min-height: 0;
 }
 
-.calvin-plugin-list--scroll,
-.dashboard-renderer-list--scroll {
+.calvin-plugin-list--scroll {
   overflow-y: auto;
 }
 
-.calvin-plugin-surface,
-.dashboard-renderer-card,
-.dashboard-renderer-row,
-.dashboard-renderer-metric {
+.calvin-plugin-surface {
   background: var(--bg-secondary);
   border: 1px solid var(--border-color);
   border-radius: 6px;
   min-width: 0;
 }
 
-.calvin-plugin-surface,
-.dashboard-renderer-card {
+.calvin-plugin-surface {
   padding: 1rem;
 }
 
-.calvin-plugin-row,
-.dashboard-renderer-row {
+.calvin-plugin-row {
   padding: 0.5rem 0.75rem;
 }
 
-.calvin-plugin-metric,
-.dashboard-renderer-metric {
+.calvin-plugin-metric {
   padding: 1.25rem;
 }
 
-.calvin-plugin-clickable,
-.dashboard-renderer-clickable {
+.calvin-plugin-clickable {
   cursor: pointer;
 }
 
-.calvin-plugin-clickable:hover,
-.dashboard-renderer-clickable:hover {
+.calvin-plugin-clickable:hover {
   background: var(--bg-tertiary);
   border-color: var(--accent-primary);
 }
@@ -172,21 +161,16 @@ body {
 
 .calvin-plugin-empty,
 .calvin-plugin-loading,
-.calvin-plugin-error,
-.dashboard-renderer-empty,
-.dashboard-renderer-loading,
-.dashboard-renderer-error {
+.calvin-plugin-error {
   color: var(--text-secondary);
   text-align: center;
   padding: 1rem;
 }
 
-.calvin-plugin-empty,
-.dashboard-renderer-empty {
+.calvin-plugin-empty {
   font-style: italic;
 }
 
-.calvin-plugin-error,
-.dashboard-renderer-error {
+.calvin-plugin-error {
   color: var(--accent-error);
 }

--- a/frontend/tests/unit/components/DashboardPanel.spec.js
+++ b/frontend/tests/unit/components/DashboardPanel.spec.js
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import DashboardPanel from "@/components/DashboardPanel.vue";
+import { useConfigStore } from "@/stores/config";
+
+describe("DashboardPanel", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it("renders header title, subtitle, actions, and body when UI is visible", () => {
+    const configStore = useConfigStore();
+    configStore.showUI = true;
+
+    const wrapper = mount(DashboardPanel, {
+      props: { title: "Weather", subtitle: "Service 1 of 2" },
+      slots: {
+        actions: '<button class="dashboard-panel__icon-button">Next</button>',
+        default: '<div class="panel-body-stub">Body</div>',
+      },
+    });
+
+    expect(wrapper.find(".dashboard-panel__header").exists()).toBe(true);
+    expect(wrapper.find(".dashboard-panel__title").text()).toBe("Weather");
+    expect(wrapper.find(".dashboard-panel__subtitle").text()).toBe("Service 1 of 2");
+    expect(wrapper.find(".dashboard-panel__actions button").exists()).toBe(true);
+    expect(wrapper.find(".panel-body-stub").text()).toBe("Body");
+  });
+
+  it("hides the shared header when dashboard UI is hidden", () => {
+    const configStore = useConfigStore();
+    configStore.showUI = false;
+
+    const wrapper = mount(DashboardPanel, {
+      props: { title: "Calendar" },
+      slots: { default: "<div>Body remains</div>" },
+    });
+
+    expect(wrapper.find(".dashboard-panel__header").exists()).toBe(false);
+    expect(wrapper.text()).toContain("Body remains");
+  });
+
+  it("applies panel variants to the root shell", () => {
+    const configStore = useConfigStore();
+    configStore.showUI = true;
+
+    const wrapper = mount(DashboardPanel, {
+      props: { title: "Photos", variant: "media" },
+    });
+
+    expect(wrapper.classes()).toContain("dashboard-panel--media");
+  });
+});

--- a/frontend/tests/unit/components/DashboardRegionSurfaces.spec.js
+++ b/frontend/tests/unit/components/DashboardRegionSurfaces.spec.js
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { ref } from "vue";
+import CalendarView from "@/components/CalendarView.vue";
+import PhotoSlideshow from "@/components/PhotoSlideshow.vue";
+import ServiceViewer from "@/components/service/ServiceViewer.vue";
+import { useCalendarStore } from "@/stores/calendar";
+import { useConfigStore } from "@/stores/config";
+import { useImagesStore } from "@/stores/images";
+
+const schemaData = ref(null);
+
+vi.mock("vue-router", () => ({
+  useRoute: () => ({ path: "/" }),
+}));
+
+vi.mock("@/composables/useSchemaData", () => ({
+  useSchemaData: () => ({ data: schemaData }),
+}));
+
+describe("dashboard region surfaces", () => {
+  let wrappers;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    wrappers = [];
+    schemaData.value = { value: "ok" };
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const configStore = useConfigStore();
+    configStore.showUI = false;
+    configStore.calendarViewMode = "month";
+    configStore.showWeekNumbers = false;
+    configStore.showRedDays = false;
+
+    const calendarStore = useCalendarStore();
+    calendarStore.fetchSources = vi.fn().mockResolvedValue({ sources: [] });
+    calendarStore.fetchEvents = vi.fn().mockResolvedValue({ events: [] });
+    calendarStore.events = [];
+    calendarStore.sources = [];
+    calendarStore.loading = false;
+
+    const imagesStore = useImagesStore();
+    imagesStore.fetchImages = vi.fn().mockResolvedValue({ images: [] });
+    imagesStore.fetchCurrentImage = vi.fn().mockResolvedValue(undefined);
+    imagesStore.loading = false;
+    imagesStore.error = null;
+    imagesStore.images = [];
+    imagesStore.currentImage = null;
+  });
+
+  afterEach(() => {
+    wrappers.forEach(wrapper => wrapper.unmount());
+    vi.restoreAllMocks();
+  });
+
+  function track(wrapper) {
+    wrappers.push(wrapper);
+    return wrapper;
+  }
+
+  it("hides shared headers consistently when dashboard UI is hidden", () => {
+    const calendar = track(mount(CalendarView));
+    const photos = track(mount(PhotoSlideshow, { props: { isFullscreen: false } }));
+    const service = track(
+      mount(ServiceViewer, {
+        props: {
+          service: {
+            id: "service",
+            name: "Weather",
+            display_schema: { kind: "status-tile", title: "Weather" },
+          },
+        },
+        global: {
+          stubs: {
+            SchemaRenderer: {
+              template: '<div class="schema-renderer-stub" />',
+            },
+          },
+        },
+      })
+    );
+
+    expect(calendar.find(".dashboard-panel__header").exists()).toBe(false);
+    expect(calendar.find(".calendar-header-minimal").exists()).toBe(false);
+    expect(photos.find(".dashboard-panel__header").exists()).toBe(false);
+    expect(photos.find(".slideshow-header").exists()).toBe(false);
+    expect(service.find(".dashboard-panel__header").exists()).toBe(false);
+  });
+});

--- a/frontend/tests/unit/components/PhotoSlideshow.spec.js
+++ b/frontend/tests/unit/components/PhotoSlideshow.spec.js
@@ -111,7 +111,7 @@ describe("PhotoSlideshow", () => {
       configStore.showUI = true;
       const wrapper = createWrapper({ isFullscreen: false });
 
-      expect(wrapper.find(".slideshow-header").exists()).toBe(true);
+      expect(wrapper.find(".dashboard-panel__header").exists()).toBe(true);
       expect(wrapper.find("h2").text()).toBe("Photos");
     });
 
@@ -119,14 +119,14 @@ describe("PhotoSlideshow", () => {
       configStore.showUI = true;
       const wrapper = createWrapper({ isFullscreen: true });
 
-      expect(wrapper.find(".slideshow-header").exists()).toBe(false);
+      expect(wrapper.find(".dashboard-panel__header").exists()).toBe(false);
     });
 
     it("should hide header when UI is hidden", () => {
       configStore.showUI = false;
       const wrapper = createWrapper({ isFullscreen: false });
 
-      expect(wrapper.find(".slideshow-header").exists()).toBe(false);
+      expect(wrapper.find(".dashboard-panel__header").exists()).toBe(false);
     });
   });
 

--- a/frontend/tests/unit/components/ServiceViewer.spec.js
+++ b/frontend/tests/unit/components/ServiceViewer.spec.js
@@ -58,6 +58,22 @@ describe("ServiceViewer", () => {
     expect(wrapper.find(".dashboard-panel__title").text()).toBe("Literal Title");
   });
 
+  it("ignores object title_path values instead of rendering them", () => {
+    schemaData.value = { location: { name: "Stockholm" } };
+
+    const wrapper = mountViewer({
+      id: "weather",
+      name: "Fallback Service",
+      display_schema: {
+        kind: "weather-forecast",
+        title_path: "$.location",
+        title: "Literal Weather",
+      },
+    });
+
+    expect(wrapper.find(".dashboard-panel__title").text()).toBe("Literal Weather");
+  });
+
   it("falls back to service name when schema title fields are missing", () => {
     const wrapper = mountViewer({
       id: "service",

--- a/frontend/tests/unit/components/ServiceViewer.spec.js
+++ b/frontend/tests/unit/components/ServiceViewer.spec.js
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { ref } from "vue";
+import ServiceViewer from "@/components/service/ServiceViewer.vue";
+import { useConfigStore } from "@/stores/config";
+
+const schemaData = ref(null);
+
+vi.mock("@/composables/useSchemaData", () => ({
+  useSchemaData: () => ({ data: schemaData }),
+}));
+
+describe("ServiceViewer", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    schemaData.value = null;
+    useConfigStore().showUI = true;
+  });
+
+  const mountViewer = service =>
+    mount(ServiceViewer, {
+      props: { service },
+      global: {
+        stubs: {
+          SchemaRenderer: {
+            props: ["schema", "data", "pluginId"],
+            template:
+              '<div class="schema-renderer-stub" :data-plugin-id="pluginId">{{ schema.kind }}</div>',
+          },
+        },
+      },
+    });
+
+  it("resolves panel title from title_path before literal title and service name", () => {
+    schemaData.value = { location: "Stockholm" };
+
+    const wrapper = mountViewer({
+      id: "weather",
+      name: "Fallback Service",
+      display_schema: {
+        kind: "weather-forecast",
+        title_path: "$.location",
+        title: "Literal Weather",
+      },
+    });
+
+    expect(wrapper.find(".dashboard-panel__title").text()).toBe("Stockholm");
+  });
+
+  it("falls back to literal title before service name", () => {
+    const wrapper = mountViewer({
+      id: "service",
+      name: "Service Name",
+      display_schema: { kind: "status-tile", title: "Literal Title" },
+    });
+
+    expect(wrapper.find(".dashboard-panel__title").text()).toBe("Literal Title");
+  });
+
+  it("falls back to service name when schema title fields are missing", () => {
+    const wrapper = mountViewer({
+      id: "service",
+      name: "Service Name",
+      display_schema: { kind: "status-tile" },
+    });
+
+    expect(wrapper.find(".dashboard-panel__title").text()).toBe("Service Name");
+  });
+
+  it("can hide the shared panel header for fullscreen service rendering", () => {
+    const wrapper = mount(ServiceViewer, {
+      props: {
+        headerVisible: false,
+        service: {
+          id: "service",
+          name: "Service Name",
+          display_schema: { kind: "status-tile" },
+        },
+      },
+      global: {
+        stubs: {
+          SchemaRenderer: {
+            template: '<div class="schema-renderer-stub" />',
+          },
+        },
+      },
+    });
+
+    expect(wrapper.find(".dashboard-panel__header").exists()).toBe(false);
+  });
+});

--- a/frontend/tests/unit/components/WebServiceViewer.spec.js
+++ b/frontend/tests/unit/components/WebServiceViewer.spec.js
@@ -39,8 +39,9 @@ describe("WebServiceViewer", () => {
       global: {
         stubs: {
           ServiceViewer: {
-            props: ["service"],
-            template: '<div class="service-viewer-stub">{{ service.name }}</div>',
+            props: ["service", "subtitle"],
+            template:
+              '<div class="service-viewer-stub"><h2>{{ service.name }}</h2><p>{{ subtitle }}</p><slot name="actions" /></div>',
           },
         },
       },
@@ -50,7 +51,7 @@ describe("WebServiceViewer", () => {
   it("renders the cycling current service in fullscreen when no service id is provided", () => {
     const wrapper = mountViewer({ isFullscreen: true });
 
-    expect(wrapper.find(".service-viewer-stub").text()).toBe("Weather");
+    expect(wrapper.find(".service-viewer-stub h2").text()).toBe("Weather");
   });
 
   it("shows an unavailable state for an embedded region without a service id", () => {
@@ -63,10 +64,16 @@ describe("WebServiceViewer", () => {
   it("renders a specific service and disables local navigation when service id is provided", () => {
     const wrapper = mountViewer({ isFullscreen: false, serviceId: "meals" });
 
-    expect(wrapper.find(".viewer-header h2").text()).toBe("Meals");
-    expect(wrapper.find(".service-viewer-stub").text()).toBe("Meals");
-    expect(wrapper.find(".service-selector").exists()).toBe(false);
-    expect(wrapper.findAll(".btn-nav")).toHaveLength(0);
+    expect(wrapper.find(".service-viewer-stub h2").text()).toBe("Meals");
+    expect(wrapper.find(".service-viewer-stub").text()).toContain("Meals");
+    expect(wrapper.findAll(".dashboard-panel__icon-button")).toHaveLength(2);
+  });
+
+  it("passes service count and local navigation actions in fullscreen cycling mode", () => {
+    const wrapper = mountViewer({ isFullscreen: true });
+
+    expect(wrapper.find(".service-viewer-stub").text()).toContain("Service 1 of 2");
+    expect(wrapper.findAll(".dashboard-panel__icon-button")).toHaveLength(2);
   });
 
   it("shows an unavailable state for a missing explicit service id", () => {

--- a/frontend/tests/unit/components/plugins/Renderers.spec.js
+++ b/frontend/tests/unit/components/plugins/Renderers.spec.js
@@ -77,9 +77,7 @@ describe("StatusList", () => {
     const rows = wrapper.findAll(".status-list__row");
     expect(rows).toHaveLength(2);
     expect(wrapper.classes()).toContain("calvin-plugin-list");
-    expect(wrapper.classes()).toContain("dashboard-renderer-list");
     expect(rows[0].classes()).toContain("calvin-plugin-row");
-    expect(rows[0].classes()).toContain("dashboard-renderer-row");
     expect(rows[0].text()).toContain("CPU");
     expect(rows[1].text()).toContain("1.2 GB");
   });
@@ -150,9 +148,7 @@ describe("CardGrid", () => {
     const cards = wrapper.findAll(".card-grid__card");
     expect(cards).toHaveLength(2);
     expect(wrapper.classes()).toContain("calvin-plugin-grid");
-    expect(wrapper.classes()).toContain("dashboard-renderer-grid");
     expect(cards[0].classes()).toContain("calvin-plugin-surface");
-    expect(cards[0].classes()).toContain("dashboard-renderer-card");
     expect(cards[0].text()).toContain("dinner");
     expect(cards[0].text()).toContain("Pasta");
     expect(cards[1].text()).toContain("Salad");
@@ -178,7 +174,6 @@ describe("CardGrid", () => {
     const items = wrapper.findAll(".card-grid__item");
     expect(items[0].classes()).toContain("card-grid__item--clickable");
     expect(items[0].classes()).toContain("calvin-plugin-clickable");
-    expect(items[0].classes()).toContain("dashboard-renderer-clickable");
     expect(items[1].classes()).not.toContain("card-grid__item--clickable");
   });
 });
@@ -205,9 +200,7 @@ describe("ItemList", () => {
     expect(wrapper.text()).toContain("Hello");
     expect(wrapper.text()).toContain("world");
     expect(wrapper.classes()).toContain("calvin-plugin-list");
-    expect(wrapper.classes()).toContain("dashboard-renderer-list");
     expect(wrapper.find(".item-list__row").classes()).toContain("calvin-plugin-row");
-    expect(wrapper.find(".item-list__row").classes()).toContain("dashboard-renderer-row");
   });
 
   it("shows empty state when items is empty", () => {
@@ -281,9 +274,7 @@ describe("MetricDashboard", () => {
     const tiles = wrapper.findAll(".metric-dashboard__tile");
     expect(tiles).toHaveLength(2);
     expect(wrapper.classes()).toContain("calvin-plugin-grid");
-    expect(wrapper.classes()).toContain("dashboard-renderer-grid");
     expect(tiles[0].classes()).toContain("calvin-plugin-metric");
-    expect(tiles[0].classes()).toContain("dashboard-renderer-metric");
     expect(tiles[0].text()).toContain("21.5");
     expect(tiles[0].classes()).toContain("metric-dashboard__tile--ok");
     expect(tiles[1].classes()).toContain("metric-dashboard__tile--warn");

--- a/frontend/tests/unit/components/plugins/Renderers.spec.js
+++ b/frontend/tests/unit/components/plugins/Renderers.spec.js
@@ -76,6 +76,10 @@ describe("StatusList", () => {
     });
     const rows = wrapper.findAll(".status-list__row");
     expect(rows).toHaveLength(2);
+    expect(wrapper.classes()).toContain("calvin-plugin-list");
+    expect(wrapper.classes()).toContain("dashboard-renderer-list");
+    expect(rows[0].classes()).toContain("calvin-plugin-row");
+    expect(rows[0].classes()).toContain("dashboard-renderer-row");
     expect(rows[0].text()).toContain("CPU");
     expect(rows[1].text()).toContain("1.2 GB");
   });
@@ -145,6 +149,10 @@ describe("CardGrid", () => {
     const wrapper = mount(CardGrid, { props: { schema, data: mealData } });
     const cards = wrapper.findAll(".card-grid__card");
     expect(cards).toHaveLength(2);
+    expect(wrapper.classes()).toContain("calvin-plugin-grid");
+    expect(wrapper.classes()).toContain("dashboard-renderer-grid");
+    expect(cards[0].classes()).toContain("calvin-plugin-surface");
+    expect(cards[0].classes()).toContain("dashboard-renderer-card");
     expect(cards[0].text()).toContain("dinner");
     expect(cards[0].text()).toContain("Pasta");
     expect(cards[1].text()).toContain("Salad");
@@ -169,6 +177,8 @@ describe("CardGrid", () => {
     const wrapper = mount(CardGrid, { props: { schema, data: mealData } });
     const items = wrapper.findAll(".card-grid__item");
     expect(items[0].classes()).toContain("card-grid__item--clickable");
+    expect(items[0].classes()).toContain("calvin-plugin-clickable");
+    expect(items[0].classes()).toContain("dashboard-renderer-clickable");
     expect(items[1].classes()).not.toContain("card-grid__item--clickable");
   });
 });
@@ -194,6 +204,10 @@ describe("ItemList", () => {
     });
     expect(wrapper.text()).toContain("Hello");
     expect(wrapper.text()).toContain("world");
+    expect(wrapper.classes()).toContain("calvin-plugin-list");
+    expect(wrapper.classes()).toContain("dashboard-renderer-list");
+    expect(wrapper.find(".item-list__row").classes()).toContain("calvin-plugin-row");
+    expect(wrapper.find(".item-list__row").classes()).toContain("dashboard-renderer-row");
   });
 
   it("shows empty state when items is empty", () => {
@@ -266,6 +280,10 @@ describe("MetricDashboard", () => {
     });
     const tiles = wrapper.findAll(".metric-dashboard__tile");
     expect(tiles).toHaveLength(2);
+    expect(wrapper.classes()).toContain("calvin-plugin-grid");
+    expect(wrapper.classes()).toContain("dashboard-renderer-grid");
+    expect(tiles[0].classes()).toContain("calvin-plugin-metric");
+    expect(tiles[0].classes()).toContain("dashboard-renderer-metric");
     expect(tiles[0].text()).toContain("21.5");
     expect(tiles[0].classes()).toContain("metric-dashboard__tile--ok");
     expect(tiles[1].classes()).toContain("metric-dashboard__tile--warn");
@@ -325,7 +343,7 @@ describe("WeatherForecast", () => {
       },
     });
 
-    expect(wrapper.find("h3").text()).toBe("Oslo");
+    expect(wrapper.find("h3").exists()).toBe(false);
     expect(wrapper.find(".weather-forecast-renderer__temp-value").text()).toBe("8");
     expect(wrapper.text()).toContain("Light rain");
     expect(wrapper.text()).toContain("Humidity");


### PR DESCRIPTION
## Summary
- add a shared DashboardPanel shell for dashboard region headers, body sizing, variants, and hidden-UI behavior
- refactor calendar, photos, service plugins, and schema renderers to use the shared shell
- add public calvin-plugin-* body building blocks and document title/panel variant schema options

## Tests
- npm run lint
- npm test -- --run
- npm run build