### PR TITLE
Vertical bar: weather/statusbar parity

### DIFF
--- a/frontend/src/components/ClockBarHorizontal.vue
+++ b/frontend/src/components/ClockBarHorizontal.vue
@@ -10,7 +10,7 @@
   >
     <div class="clock-bar-outer">
       <div class="clock-bar-side clock-bar-left">
-        <PluginStatusbarItems />
+        <PluginStatusbarItems v-if="showStatusbar" />
         <span v-if="isBackgroundRefreshing" class="clock-refresh-icon" aria-hidden="true" />
       </div>
 
@@ -88,6 +88,7 @@ const props = defineProps({
 const {
   shouldShow,
   showDate,
+  showStatusbar,
   formattedTime,
   formattedDate,
   fontSize,

--- a/frontend/src/components/ClockBarVertical.vue
+++ b/frontend/src/components/ClockBarVertical.vue
@@ -8,17 +8,21 @@
     aria-label="Status bar"
     aria-live="polite"
   >
-    <div
-      class="clock-bar-content"
-      :class="{
-        'layout-single-line': layout === 'single-line',
-        'layout-two-lines': layout === 'two-lines',
-      }"
-    >
-      <span class="clock-time" :style="{ fontSize: `${fontSize}px` }">{{ formattedTime }}</span>
-      <span v-if="showDate" class="clock-date" :style="{ fontSize: `${dateFontSize}px` }">{{
-        formattedDate
-      }}</span>
+    <div class="clock-bar-top">
+      <div
+        class="clock-bar-content"
+        :class="{
+          'layout-single-line': layout === 'single-line',
+          'layout-two-lines': layout === 'two-lines',
+        }"
+      >
+        <span class="clock-time" :style="{ fontSize: `${fontSize}px` }">{{ formattedTime }}</span>
+        <span v-if="showDate" class="clock-date" :style="{ fontSize: `${dateFontSize}px` }">{{
+          formattedDate
+        }}</span>
+      </div>
+
+      <PluginStatusbarItems v-if="showStatusbar" orientation="vertical" />
     </div>
 
     <BarActionCluster v-if="!previewMode" class="clock-bar-actions" :compact="true" />
@@ -28,6 +32,7 @@
 <script setup>
 import { useClockBar } from "../composables/useClockBar";
 import BarActionCluster from "./BarActionCluster.vue";
+import PluginStatusbarItems from "./PluginStatusbarItems.vue";
 
 defineOptions({
   name: "ClockBarVertical",
@@ -76,6 +81,7 @@ const props = defineProps({
 const {
   shouldShow,
   showDate,
+  showStatusbar,
   formattedTime,
   formattedDate,
   fontSize,
@@ -155,6 +161,13 @@ const {
 
 .clock-bar-vertical.position-between .clock-date {
   font-size: 0.75rem;
+}
+
+.clock-bar-top {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .clock-bar-actions {

--- a/frontend/src/components/PluginStatusbarItems.vue
+++ b/frontend/src/components/PluginStatusbarItems.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="plugin-statusbar-items" :class="{ ghost }">
+  <div class="plugin-statusbar-items" :class="[`orientation-${orientation}`, { ghost }]">
     <SchemaStatusbarItem
       v-for="service in schemaServices"
       :key="service.id"
@@ -20,6 +20,11 @@ defineProps({
   ghost: {
     type: Boolean,
     default: false,
+  },
+  orientation: {
+    type: String,
+    default: "horizontal",
+    validator: value => ["horizontal", "vertical"].includes(value),
   },
 });
 
@@ -53,6 +58,11 @@ onMounted(() => {
 .plugin-statusbar-items {
   display: flex;
   align-items: center;
+}
+
+.plugin-statusbar-items.orientation-vertical {
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .plugin-statusbar-items.ghost {

--- a/frontend/src/components/settings/tabs/dashboard/ClockSettingsTab.vue
+++ b/frontend/src/components/settings/tabs/dashboard/ClockSettingsTab.vue
@@ -100,7 +100,6 @@
       </SettingItem>
 
       <SettingItem
-        v-if="config.clockBarMode === 'horizontal'"
         label="Show Weather in Bar"
         help="Display current temperature and weather icon (requires a weather service to be configured)"
       >

--- a/frontend/src/composables/useClockBar.js
+++ b/frontend/src/composables/useClockBar.js
@@ -30,6 +30,7 @@ export function useClockBar(opts) {
   });
 
   const showDate = computed(() => !!configStore.clockShowDate);
+  const showStatusbar = computed(() => !!configStore.clockBarShowWeather);
   const showSeconds = computed(() => !!configStore.clockShowSeconds);
   const timezone = computed(() => configStore.timezone || null);
   const timeFormat = computed(() => configStore.timeFormat || "24h");
@@ -161,6 +162,7 @@ export function useClockBar(opts) {
   return {
     shouldShow,
     showDate,
+    showStatusbar,
     formattedTime,
     formattedDate,
     fontSize,


### PR DESCRIPTION
## Summary
- Render `PluginStatusbarItems` in `ClockBarVertical` below the clock (issue #37, layout option B), so the weather tile is reachable on the vertical bar.
- Gate `<PluginStatusbarItems>` on `clockBarShowWeather` in both bars — the flag was previously stored but never consumed.
- Drop the `clockBarMode === 'horizontal'` gate on the **Show Weather in Bar** setting; it's available for both modes now.
- New `orientation` prop on `PluginStatusbarItems` ("horizontal" | "vertical") — vertical mode stacks tiles in a column.

Closes #37.

## Test plan
- [x] Unit tests pass (`vitest run` — 544/544)
- [x] Frontend builds clean
- [ ] Toggle **Show Weather in Bar** in vertical mode — weather tile appears/disappears below the clock
- [ ] Toggle in horizontal mode — same gating behaviour as before
- [ ] Switch bar mode without losing the toggle state