### PR TITLE
Tidy plugin installer logging and harden plugin DB writes

### DIFF
--- a/backend/app/api/routes/plugins/management.py
+++ b/backend/app/api/routes/plugins/management.py
@@ -703,7 +703,13 @@ async def _update_plugin_type(
         if enabled is not None:
             previous_enabled = db_type.enabled
             db_type.enabled = enabled
-            await db_type.save_with_timestamp()
+            from app.utils.db_retry import retry_on_db_locked
+
+            @retry_on_db_locked(max_retries=5, initial_delay=0.1, max_delay=1.0)
+            async def _save_theme_db_type():
+                await db_type.save_with_timestamp()
+
+            await _save_theme_db_type()
 
             # Emit plugin_enabled or plugin_disabled events if enabled status changed
             if previous_enabled is not None and previous_enabled != enabled:
@@ -758,15 +764,23 @@ async def _update_plugin_type(
             f"Creating new plugin type {plugin_id} with schema: {initial_schema}, "
             f"config={config}, metadata_schema={metadata_schema}"
         )
-        db_type = await PluginTypeDB.objects.create(
-            type_id=plugin_id,
-            plugin_type=plugin_type.value if hasattr(plugin_type, "value") else str(plugin_type),
-            name=type_info.get("name", ""),
-            description=type_info.get("description", ""),
-            version=type_info.get("version"),
-            common_config_schema=initial_schema,
-            enabled=enabled if enabled is not None else True,
-        )
+        from app.utils.db_retry import retry_on_db_locked
+
+        @retry_on_db_locked(max_retries=5, initial_delay=0.1, max_delay=1.0)
+        async def _create_plugin_type():
+            return await PluginTypeDB.objects.create(
+                type_id=plugin_id,
+                plugin_type=plugin_type.value
+                if hasattr(plugin_type, "value")
+                else str(plugin_type),
+                name=type_info.get("name", ""),
+                description=type_info.get("description", ""),
+                version=type_info.get("version"),
+                common_config_schema=initial_schema,
+                enabled=enabled if enabled is not None else True,
+            )
+
+        db_type = await _create_plugin_type()
     else:
         # Update existing plugin type
         if enabled is not None:
@@ -782,7 +796,13 @@ async def _update_plugin_type(
                 f"Updated plugin {plugin_id} common_config_schema: "
                 f"old={current_schema}, new={updated_schema}, config={config}"
             )
-        await db_type.save_with_timestamp()
+        from app.utils.db_retry import retry_on_db_locked
+
+        @retry_on_db_locked(max_retries=5, initial_delay=0.1, max_delay=1.0)
+        async def _save_plugin_type():
+            await db_type.save_with_timestamp()
+
+        await _save_plugin_type()
 
     # Save common config to config service for backward compatibility
     if config:

--- a/backend/app/services/plugin_installer.py
+++ b/backend/app/services/plugin_installer.py
@@ -159,9 +159,6 @@ class PluginInstaller:
         if plugin_path.exists():
             if force:
                 # Force reinstall: uninstall existing plugin first
-                import logging
-
-                logger = logging.getLogger(__name__)
                 logger.info(f"Force installing plugin {install_id}, removing existing installation")
                 self.uninstall_plugin(install_id)
             else:
@@ -182,11 +179,17 @@ class PluginInstaller:
                                     "Uninstall the existing plugin first."
                                 )
                         except ImportError:
-                            # packaging not available, skip version check
-                            pass
-                        except Exception:
-                            # If version parsing fails, allow install but warn
-                            pass
+                            logger.warning(
+                                f"`packaging` library not available; skipping version check "
+                                f"for plugin {install_id} (existing={existing_version}, "
+                                f"new={new_version})"
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                f"Version comparison failed for plugin {install_id} "
+                                f"(existing={existing_version}, new={new_version}): {e}. "
+                                "Proceeding with install."
+                            )
 
                 raise ValueError(
                     f"Plugin {install_id} is already installed. "
@@ -391,10 +394,7 @@ class PluginInstaller:
                     manifest = json.load(f)
                 manifest["_installed_path"] = str(plugin_dir)
                 plugins.append(manifest)
-            except (json.JSONDecodeError, Exception) as e:
-                import logging
-
-                logger = logging.getLogger(__name__)
+            except (json.JSONDecodeError, OSError, ValueError) as e:
                 logger.warning(f"Error reading plugin manifest for {plugin_dir.name}: {e}")
                 continue
 
@@ -567,9 +567,6 @@ class PluginInstaller:
                 # Plugin is actually installed and valid
                 if force:
                     # Force reinstall: uninstall existing plugin first
-                    import logging
-
-                    logger = logging.getLogger(__name__)
                     logger.info(
                         f"Force installing plugin {install_id}, removing existing installation"
                     )
@@ -579,10 +576,6 @@ class PluginInstaller:
             else:
                 # Plugin directory exists but is invalid/corrupted (no manifest)
                 # Remove it and allow reinstallation
-                import logging
-                import shutil
-
-                logger = logging.getLogger(__name__)
                 logger.warning(
                     f"Found corrupted/invalid plugin directory for {install_id}, "
                     "removing and allowing reinstallation"


### PR DESCRIPTION
## Summary

Quick-wins sweep on the plugin install / config paths.

- **Bug:** version-check `except ImportError` / `except Exception` blocks in `PluginInstaller.install_plugin` silently swallowed failures — now logged as warnings so admins can see when version checks were skipped.
- **Bug:** `PluginTypeDB.objects.create` and `save_with_timestamp` calls in the plugin/theme update endpoint weren't wrapped in `retry_on_db_locked`, so they could fail under SQLite contention during plugin config edits or theme toggles. Wrapped using the same pattern as `plugins/registry/manager.py`.
- **Cleanup:** dropped 4 redundant inline `import logging` / `logger = logging.getLogger(__name__)` blocks in `plugin_installer.py` (the module already has a logger at top).
- **Cleanup:** narrowed `except (json.JSONDecodeError, Exception)` to `(json.JSONDecodeError, OSError, ValueError)` when listing plugin manifests.

The wider stdlib-`logging` → `loguru` migration called out in CLAUDE.md is tracked separately in #44.

## Test plan

- [ ] `uv run pytest backend/tests` passes
- [ ] Install a plugin from a zip — confirm install/uninstall/force-reinstall still work
- [ ] Toggle a theme via the settings UI — confirm save still succeeds and `db_type.enabled` updates
- [ ] Update a plugin type's common config — confirm `common_config_schema` is persisted