### PR TITLE
[codex] Add per-region source selection

### DIFF
--- a/backend/app/api/routes/images.py
+++ b/backend/app/api/routes/images.py
@@ -3,7 +3,7 @@
 import logging
 from pathlib import Path
 
-from fastapi import APIRouter, File, UploadFile
+from fastapi import APIRouter, File, Query, UploadFile
 from fastapi.responses import FileResponse
 
 from app.services import plugin_image_service
@@ -14,8 +14,17 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def _parse_source_ids(source_ids: str | None) -> list[str] | None:
+    if not source_ids:
+        return None
+    parsed = [source_id.strip() for source_id in source_ids.split(",") if source_id.strip()]
+    return parsed or None
+
+
 @router.get("/images/list")
-async def list_images():
+async def list_images(
+    source_ids: str | None = Query(None, description="Comma-separated source IDs"),
+):
     """
     Get list of all images from all enabled image plugins.
 
@@ -33,14 +42,18 @@ async def list_images():
 
     # Use plugin service to aggregate images from all plugins
     logger.debug("Calling plugin_image_service.get_images()...")
-    images = await plugin_image_service.get_images(randomize=randomize)
+    images = await plugin_image_service.get_images(
+        randomize=randomize, source_ids=_parse_source_ids(source_ids)
+    )
     logger.debug(f"plugin_image_service.get_images() returned {len(images)} images")
 
     return {"images": images, "total": len(images)}
 
 
 @router.get("/images/current")
-async def get_current_image():
+async def get_current_image(
+    source_ids: str | None = Query(None, description="Comma-separated source IDs"),
+):
     """
     Get current image metadata from plugin service.
 
@@ -53,7 +66,9 @@ async def get_current_image():
     randomize_value = await config_service.get_value("randomize_images")
     randomize = randomize_value == "true" if randomize_value else False
 
-    image = await plugin_image_service.get_current_image(randomize=randomize)
+    image = await plugin_image_service.get_current_image(
+        randomize=randomize, source_ids=_parse_source_ids(source_ids)
+    )
     if not image:
         return {"image": None, "message": "No images available"}
 
@@ -212,7 +227,9 @@ async def get_image_thumbnail(image_id: str):
 
 
 @router.post("/images/next")
-async def next_image():
+async def next_image(
+    source_ids: str | None = Query(None, description="Comma-separated source IDs"),
+):
     """
     Move to next image and return it from plugin service.
 
@@ -225,7 +242,9 @@ async def next_image():
     randomize_value = await config_service.get_value("randomize_images")
     randomize = randomize_value == "true" if randomize_value else False
 
-    image = await plugin_image_service.next_image(randomize=randomize)
+    image = await plugin_image_service.next_image(
+        randomize=randomize, source_ids=_parse_source_ids(source_ids)
+    )
     if not image:
         return {"image": None, "message": "No images available"}
 
@@ -233,7 +252,9 @@ async def next_image():
 
 
 @router.post("/images/previous")
-async def previous_image():
+async def previous_image(
+    source_ids: str | None = Query(None, description="Comma-separated source IDs"),
+):
     """
     Move to previous image and return it from plugin service.
 
@@ -246,7 +267,9 @@ async def previous_image():
     randomize_value = await config_service.get_value("randomize_images")
     randomize = randomize_value == "true" if randomize_value else False
 
-    image = await plugin_image_service.previous_image(randomize=randomize)
+    image = await plugin_image_service.previous_image(
+        randomize=randomize, source_ids=_parse_source_ids(source_ids)
+    )
     if not image:
         return {"image": None, "message": "No images available"}
 

--- a/backend/app/services/plugin_image_service.py
+++ b/backend/app/services/plugin_image_service.py
@@ -24,6 +24,7 @@ class PluginImageService:
         self._current_image_ids_by_source_key: dict[str, str] = {}
         self._all_images: list[dict[str, Any]] = []
         self._randomized_order: list[dict[str, Any]] = []
+        self._randomized_orders_by_source_key: dict[str, list[dict[str, Any]]] = {}
         self._images_cache_time: datetime | None = None
         self._images_cache_ttl = timedelta(seconds=30)  # Cache for 30 seconds
 
@@ -162,23 +163,29 @@ class PluginImageService:
 
         # Store original aggregate order for lookup endpoints.
         self._all_images = images.copy()
+        self._randomized_order = []
+        self._randomized_orders_by_source_key = {}
         self._images_cache_time = datetime.now()
         logger.info("Total images collected: {}", len(images))
 
+        source_key = self._source_key(source_ids)
         if source_ids:
-            selected_sources = set(source_ids)
-            images = [img for img in images if img.get("source") in selected_sources]
+            images = self._filter_images_by_source(images, source_ids)
 
         # Apply global randomization if requested (overrides per-plugin randomization)
         if randomize and images:
             randomized = images.copy()
             random.shuffle(randomized)
-            self._randomized_order = randomized
+            if source_key == "__all__":
+                self._randomized_order = randomized
+            else:
+                self._randomized_orders_by_source_key[source_key] = randomized
             logger.debug("Returning {} randomized images", len(randomized))
             return randomized
 
         # Store original order as randomized order when not randomizing
-        self._randomized_order = images.copy()
+        if source_key == "__all__":
+            self._randomized_order = images.copy()
         logger.debug("Returning {} images (not randomized)", len(images))
         return images
 
@@ -195,13 +202,13 @@ class PluginImageService:
             Current image metadata or None if no images
         """
         # Get images (with randomization if requested), only refresh if cache is stale
-        if not self._all_images or self._is_cache_stale() or source_ids:
-            images = await self.get_images(randomize=randomize, source_ids=source_ids)
-        elif randomize and not self._randomized_order:
+        if not self._all_images or self._is_cache_stale():
+            await self.get_images(randomize=False)
+        elif randomize and not self._randomized_order and not source_ids:
             # Re-randomize if requested
-            images = await self.get_images(randomize=True, source_ids=source_ids)
-        else:
-            images = self._randomized_order if randomize else self._all_images
+            await self.get_images(randomize=True)
+
+        images = self._get_ordered_images(randomize=randomize, source_ids=source_ids)
 
         source_key = self._source_key(source_ids)
         current_image_id = self._current_image_ids_by_source_key.get(
@@ -233,13 +240,13 @@ class PluginImageService:
             Next image metadata or None if no images
         """
         # Only refresh images if cache is stale (not on every navigation)
-        if not self._all_images or self._is_cache_stale() or source_ids:
-            images = await self.get_images(randomize=randomize, source_ids=source_ids)
-        elif randomize and not self._randomized_order:
+        if not self._all_images or self._is_cache_stale():
+            await self.get_images(randomize=False)
+        elif randomize and not self._randomized_order and not source_ids:
             # Need randomized order but don't have it
-            images = await self.get_images(randomize=True, source_ids=source_ids)
-        else:
-            images = self._randomized_order if randomize else self._all_images
+            await self.get_images(randomize=True)
+
+        images = self._get_ordered_images(randomize=randomize, source_ids=source_ids)
 
         source_key = self._source_key(source_ids)
         current_image_id = self._current_image_ids_by_source_key.get(
@@ -280,13 +287,13 @@ class PluginImageService:
             Previous image metadata or None if no images
         """
         # Only refresh images if cache is stale (not on every navigation)
-        if not self._all_images or self._is_cache_stale() or source_ids:
-            images = await self.get_images(randomize=randomize, source_ids=source_ids)
-        elif randomize and not self._randomized_order:
+        if not self._all_images or self._is_cache_stale():
+            await self.get_images(randomize=False)
+        elif randomize and not self._randomized_order and not source_ids:
             # Need randomized order but don't have it
-            images = await self.get_images(randomize=True, source_ids=source_ids)
-        else:
-            images = self._randomized_order if randomize else self._all_images
+            await self.get_images(randomize=True)
+
+        images = self._get_ordered_images(randomize=randomize, source_ids=source_ids)
 
         source_key = self._source_key(source_ids)
         current_image_id = self._current_image_ids_by_source_key.get(
@@ -503,8 +510,36 @@ class PluginImageService:
         self._images_cache_time = None
         self._all_images = []
         self._randomized_order = []
+        self._randomized_orders_by_source_key = {}
 
     def _source_key(self, source_ids: list[str] | None = None) -> str:
         if not source_ids:
             return "__all__"
         return ",".join(sorted({source_id for source_id in source_ids if source_id}))
+
+    def _filter_images_by_source(
+        self, images: list[dict[str, Any]], source_ids: list[str] | None = None
+    ) -> list[dict[str, Any]]:
+        if not source_ids:
+            return images
+        selected_sources = {source_id for source_id in source_ids if source_id}
+        return [img for img in images if img.get("source") in selected_sources]
+
+    def _get_ordered_images(
+        self, randomize: bool = False, source_ids: list[str] | None = None
+    ) -> list[dict[str, Any]]:
+        source_key = self._source_key(source_ids)
+        if not randomize:
+            return self._filter_images_by_source(self._all_images, source_ids)
+
+        if source_key == "__all__":
+            if not self._randomized_order:
+                self._randomized_order = self._all_images.copy()
+                random.shuffle(self._randomized_order)
+            return self._randomized_order
+
+        if source_key not in self._randomized_orders_by_source_key:
+            randomized = self._filter_images_by_source(self._all_images, source_ids).copy()
+            random.shuffle(randomized)
+            self._randomized_orders_by_source_key[source_key] = randomized
+        return self._randomized_orders_by_source_key[source_key]

--- a/backend/app/services/plugin_image_service.py
+++ b/backend/app/services/plugin_image_service.py
@@ -201,19 +201,15 @@ class PluginImageService:
         Returns:
             Current image metadata or None if no images
         """
-        # Get images (with randomization if requested), only refresh if cache is stale
+        # Refresh the aggregate image cache first. Source-specific ordering, including
+        # randomization, is resolved lazily below so independent regions keep separate order.
         if not self._all_images or self._is_cache_stale():
             await self.get_images(randomize=False)
-        elif randomize and not self._randomized_order and not source_ids:
-            # Re-randomize if requested
-            await self.get_images(randomize=True)
 
         images = self._get_ordered_images(randomize=randomize, source_ids=source_ids)
 
         source_key = self._source_key(source_ids)
-        current_image_id = self._current_image_ids_by_source_key.get(
-            source_key, self._current_image_id
-        )
+        current_image_id = self._current_image_id_for_source_key(source_key)
 
         if not images:
             return None
@@ -242,16 +238,11 @@ class PluginImageService:
         # Only refresh images if cache is stale (not on every navigation)
         if not self._all_images or self._is_cache_stale():
             await self.get_images(randomize=False)
-        elif randomize and not self._randomized_order and not source_ids:
-            # Need randomized order but don't have it
-            await self.get_images(randomize=True)
 
         images = self._get_ordered_images(randomize=randomize, source_ids=source_ids)
 
         source_key = self._source_key(source_ids)
-        current_image_id = self._current_image_ids_by_source_key.get(
-            source_key, self._current_image_id
-        )
+        current_image_id = self._current_image_id_for_source_key(source_key)
 
         if not images:
             return None
@@ -289,16 +280,11 @@ class PluginImageService:
         # Only refresh images if cache is stale (not on every navigation)
         if not self._all_images or self._is_cache_stale():
             await self.get_images(randomize=False)
-        elif randomize and not self._randomized_order and not source_ids:
-            # Need randomized order but don't have it
-            await self.get_images(randomize=True)
 
         images = self._get_ordered_images(randomize=randomize, source_ids=source_ids)
 
         source_key = self._source_key(source_ids)
-        current_image_id = self._current_image_ids_by_source_key.get(
-            source_key, self._current_image_id
-        )
+        current_image_id = self._current_image_id_for_source_key(source_key)
 
         if not images:
             return None
@@ -516,6 +502,11 @@ class PluginImageService:
         if not source_ids:
             return "__all__"
         return ",".join(sorted({source_id for source_id in source_ids if source_id}))
+
+    def _current_image_id_for_source_key(self, source_key: str) -> str | None:
+        if source_key == "__all__":
+            return self._current_image_ids_by_source_key.get(source_key, self._current_image_id)
+        return self._current_image_ids_by_source_key.get(source_key)
 
     def _filter_images_by_source(
         self, images: list[dict[str, Any]], source_ids: list[str] | None = None

--- a/backend/app/services/plugin_image_service.py
+++ b/backend/app/services/plugin_image_service.py
@@ -21,13 +21,17 @@ class PluginImageService:
         """Initialize image service."""
         self._current_image_id: str | None = None
         self._current_plugin_id: str | None = None
+        self._current_image_ids_by_source_key: dict[str, str] = {}
         self._all_images: list[dict[str, Any]] = []
         self._randomized_order: list[dict[str, Any]] = []
         self._images_cache_time: datetime | None = None
         self._images_cache_ttl = timedelta(seconds=30)  # Cache for 30 seconds
 
     async def get_images(
-        self, randomize: bool = False, randomize_per_plugin: bool = False
+        self,
+        randomize: bool = False,
+        randomize_per_plugin: bool = False,
+        source_ids: list[str] | None = None,
     ) -> list[dict[str, Any]]:
         """
         Get list of all images from all enabled image plugins, ordered by display_order.
@@ -156,10 +160,14 @@ class PluginImageService:
             else:
                 images.extend(plugin_images)
 
-        # Store original order
+        # Store original aggregate order for lookup endpoints.
         self._all_images = images.copy()
         self._images_cache_time = datetime.now()
         logger.info("Total images collected: {}", len(images))
+
+        if source_ids:
+            selected_sources = set(source_ids)
+            images = [img for img in images if img.get("source") in selected_sources]
 
         # Apply global randomization if requested (overrides per-plugin randomization)
         if randomize and images:
@@ -174,7 +182,9 @@ class PluginImageService:
         logger.debug("Returning {} images (not randomized)", len(images))
         return images
 
-    async def get_current_image(self, randomize: bool = False) -> dict[str, Any] | None:
+    async def get_current_image(
+        self, randomize: bool = False, source_ids: list[str] | None = None
+    ) -> dict[str, Any] | None:
         """
         Get current image metadata.
 
@@ -185,28 +195,34 @@ class PluginImageService:
             Current image metadata or None if no images
         """
         # Get images (with randomization if requested), only refresh if cache is stale
-        if not self._all_images or self._is_cache_stale():
-            await self.get_images(randomize=randomize)
+        if not self._all_images or self._is_cache_stale() or source_ids:
+            images = await self.get_images(randomize=randomize, source_ids=source_ids)
         elif randomize and not self._randomized_order:
             # Re-randomize if requested
-            await self.get_images(randomize=True)
+            images = await self.get_images(randomize=True, source_ids=source_ids)
+        else:
+            images = self._randomized_order if randomize else self._all_images
 
-        # Use randomized order if randomize is True, otherwise use original order
-        images = self._randomized_order if randomize else self._all_images
+        source_key = self._source_key(source_ids)
+        current_image_id = self._current_image_ids_by_source_key.get(
+            source_key, self._current_image_id
+        )
 
         if not images:
             return None
 
         # Find current image by ID
-        if self._current_image_id:
+        if current_image_id:
             for img in images:
-                if img["id"] == self._current_image_id:
+                if img["id"] == current_image_id:
                     return img
 
         # Return first image if no current image set
         return images[0]
 
-    async def next_image(self, randomize: bool = False) -> dict[str, Any] | None:
+    async def next_image(
+        self, randomize: bool = False, source_ids: list[str] | None = None
+    ) -> dict[str, Any] | None:
         """
         Move to next image and return it.
 
@@ -217,23 +233,27 @@ class PluginImageService:
             Next image metadata or None if no images
         """
         # Only refresh images if cache is stale (not on every navigation)
-        if not self._all_images or self._is_cache_stale():
-            await self.get_images(randomize=randomize)
+        if not self._all_images or self._is_cache_stale() or source_ids:
+            images = await self.get_images(randomize=randomize, source_ids=source_ids)
         elif randomize and not self._randomized_order:
             # Need randomized order but don't have it
-            await self.get_images(randomize=True)
+            images = await self.get_images(randomize=True, source_ids=source_ids)
+        else:
+            images = self._randomized_order if randomize else self._all_images
 
-        # Use randomized order if randomize is True, otherwise use original order
-        images = self._randomized_order if randomize else self._all_images
+        source_key = self._source_key(source_ids)
+        current_image_id = self._current_image_ids_by_source_key.get(
+            source_key, self._current_image_id
+        )
 
         if not images:
             return None
 
         # Find current index
         current_index = 0
-        if self._current_image_id:
+        if current_image_id:
             for i, img in enumerate(images):
-                if img["id"] == self._current_image_id:
+                if img["id"] == current_image_id:
                     current_index = i
                     break
 
@@ -243,10 +263,13 @@ class PluginImageService:
 
         self._current_image_id = next_image["id"]
         self._current_plugin_id = next_image.get("source")
+        self._current_image_ids_by_source_key[source_key] = next_image["id"]
 
         return next_image
 
-    async def previous_image(self, randomize: bool = False) -> dict[str, Any] | None:
+    async def previous_image(
+        self, randomize: bool = False, source_ids: list[str] | None = None
+    ) -> dict[str, Any] | None:
         """
         Move to previous image and return it.
 
@@ -257,23 +280,27 @@ class PluginImageService:
             Previous image metadata or None if no images
         """
         # Only refresh images if cache is stale (not on every navigation)
-        if not self._all_images or self._is_cache_stale():
-            await self.get_images(randomize=randomize)
+        if not self._all_images or self._is_cache_stale() or source_ids:
+            images = await self.get_images(randomize=randomize, source_ids=source_ids)
         elif randomize and not self._randomized_order:
             # Need randomized order but don't have it
-            await self.get_images(randomize=True)
+            images = await self.get_images(randomize=True, source_ids=source_ids)
+        else:
+            images = self._randomized_order if randomize else self._all_images
 
-        # Use randomized order if randomize is True, otherwise use original order
-        images = self._randomized_order if randomize else self._all_images
+        source_key = self._source_key(source_ids)
+        current_image_id = self._current_image_ids_by_source_key.get(
+            source_key, self._current_image_id
+        )
 
         if not images:
             return None
 
         # Find current index
         current_index = 0
-        if self._current_image_id:
+        if current_image_id:
             for i, img in enumerate(images):
-                if img["id"] == self._current_image_id:
+                if img["id"] == current_image_id:
                     current_index = i
                     break
 
@@ -283,6 +310,7 @@ class PluginImageService:
 
         self._current_image_id = prev_image["id"]
         self._current_plugin_id = prev_image.get("source")
+        self._current_image_ids_by_source_key[source_key] = prev_image["id"]
 
         return prev_image
 
@@ -475,3 +503,8 @@ class PluginImageService:
         self._images_cache_time = None
         self._all_images = []
         self._randomized_order = []
+
+    def _source_key(self, source_ids: list[str] | None = None) -> str:
+        if not source_ids:
+            return "__all__"
+        return ",".join(sorted({source_id for source_id in source_ids if source_id}))

--- a/backend/tests/contract/openapi.json
+++ b/backend/tests/contract/openapi.json
@@ -1689,6 +1689,26 @@
       "get": {
         "description": "Get current image metadata from plugin service.\n\nReturns:\n    Current image metadata",
         "operationId": "get_current_image_api_images_current_get",
+        "parameters": [
+          {
+            "description": "Comma-separated source IDs",
+            "in": "query",
+            "name": "source_ids",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated source IDs",
+              "title": "Source Ids"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -1697,6 +1717,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "Get Current Image",
@@ -1709,6 +1739,26 @@
       "get": {
         "description": "Get list of all images from all enabled image plugins.\n\nReturns:\n    List of image metadata",
         "operationId": "list_images_api_images_list_get",
+        "parameters": [
+          {
+            "description": "Comma-separated source IDs",
+            "in": "query",
+            "name": "source_ids",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated source IDs",
+              "title": "Source Ids"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -1717,6 +1767,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "List Images",
@@ -1729,6 +1789,26 @@
       "post": {
         "description": "Move to next image and return it from plugin service.\n\nReturns:\n    Next image metadata",
         "operationId": "next_image_api_images_next_post",
+        "parameters": [
+          {
+            "description": "Comma-separated source IDs",
+            "in": "query",
+            "name": "source_ids",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated source IDs",
+              "title": "Source Ids"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -1737,6 +1817,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "Next Image",
@@ -1749,6 +1839,26 @@
       "post": {
         "description": "Move to previous image and return it from plugin service.\n\nReturns:\n    Previous image metadata",
         "operationId": "previous_image_api_images_previous_post",
+        "parameters": [
+          {
+            "description": "Comma-separated source IDs",
+            "in": "query",
+            "name": "source_ids",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated source IDs",
+              "title": "Source Ids"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
@@ -1757,6 +1867,16 @@
               }
             },
             "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
           }
         },
         "summary": "Previous Image",

--- a/backend/tests/unit/test_plugin_image_service.py
+++ b/backend/tests/unit/test_plugin_image_service.py
@@ -169,6 +169,33 @@ class TestPluginImageService:
                 assert result is not None
                 assert result["id"] == "img1"
 
+    async def test_get_images_filters_by_source_ids(self):
+        """Test get_images can filter to selected image plugin instances."""
+        service = PluginImageService()
+
+        mock_plugin_type = MagicMock(
+            type_id="local", enabled=True, common_config_schema={"display_order": "0"}
+        )
+        mock_db_plugins = [
+            MagicMock(id="family-images", type_id="local", display_order=0),
+            MagicMock(id="personal-images", type_id="local", display_order=1),
+        ]
+
+        family_images = [{"id": "family-img", "source": "family-images"}]
+        personal_images = [{"id": "personal-img", "source": "personal-images"}]
+
+        type_patch, db_patch = create_mock_ormar_models([mock_plugin_type], mock_db_plugins)
+        with type_patch, db_patch:
+            with patch("app.services.plugin_image_service.plugin_manager") as mock_manager:
+                mock_manager.get_plugins.return_value = [
+                    MockImagePlugin("family-images", family_images),
+                    MockImagePlugin("personal-images", personal_images),
+                ]
+
+                result = await service.get_images(source_ids=["personal-images"])
+
+                assert result == personal_images
+
     async def test_get_current_image_returns_current(self):
         """Test get_current_image returns current image when set."""
         service = PluginImageService()

--- a/backend/tests/unit/test_plugin_image_service.py
+++ b/backend/tests/unit/test_plugin_image_service.py
@@ -230,6 +230,43 @@ class TestPluginImageService:
                     "personal-img",
                 }
 
+    async def test_source_specific_navigation_does_not_inherit_global_cursor(self):
+        """Test first navigation for a source set starts within that source."""
+        service = PluginImageService()
+
+        mock_plugin_type = MagicMock(
+            type_id="local", enabled=True, common_config_schema={"display_order": "0"}
+        )
+        mock_db_plugins = [
+            MagicMock(id="family-images", type_id="local", display_order=0),
+            MagicMock(id="personal-images", type_id="local", display_order=1),
+        ]
+
+        family_images = [
+            {"id": "family-1", "source": "family-images"},
+            {"id": "family-2", "source": "family-images"},
+        ]
+        personal_images = [
+            {"id": "personal-1", "source": "personal-images"},
+            {"id": "personal-2", "source": "personal-images"},
+        ]
+
+        type_patch, db_patch = create_mock_ormar_models([mock_plugin_type], mock_db_plugins)
+        with type_patch, db_patch:
+            with patch("app.services.plugin_image_service.plugin_manager") as mock_manager:
+                mock_manager.get_plugins.return_value = [
+                    MockImagePlugin("family-images", family_images),
+                    MockImagePlugin("personal-images", personal_images),
+                ]
+
+                await service.get_images()
+                service._current_image_id = "personal-2"
+
+                result = await service.next_image(source_ids=["personal-images"])
+
+                assert result["id"] == "personal-2"
+                assert service._current_image_ids_by_source_key["personal-images"] == "personal-2"
+
     async def test_get_current_image_returns_current(self):
         """Test get_current_image returns current image when set."""
         service = PluginImageService()

--- a/backend/tests/unit/test_plugin_image_service.py
+++ b/backend/tests/unit/test_plugin_image_service.py
@@ -196,6 +196,40 @@ class TestPluginImageService:
 
                 assert result == personal_images
 
+    async def test_filtered_randomized_images_do_not_pollute_all_sources_order(self):
+        """Test source-specific randomization does not replace all-sources random order."""
+        service = PluginImageService()
+
+        mock_plugin_type = MagicMock(
+            type_id="local", enabled=True, common_config_schema={"display_order": "0"}
+        )
+        mock_db_plugins = [
+            MagicMock(id="family-images", type_id="local", display_order=0),
+            MagicMock(id="personal-images", type_id="local", display_order=1),
+        ]
+
+        family_images = [{"id": "family-img", "source": "family-images"}]
+        personal_images = [{"id": "personal-img", "source": "personal-images"}]
+
+        type_patch, db_patch = create_mock_ormar_models([mock_plugin_type], mock_db_plugins)
+        with type_patch, db_patch:
+            with patch("app.services.plugin_image_service.plugin_manager") as mock_manager:
+                mock_manager.get_plugins.return_value = [
+                    MockImagePlugin("family-images", family_images),
+                    MockImagePlugin("personal-images", personal_images),
+                ]
+
+                filtered = await service.get_images(randomize=True, source_ids=["personal-images"])
+                assert {image["id"] for image in filtered} == {"personal-img"}
+                assert service._randomized_order == []
+
+                await service.get_current_image(randomize=True)
+
+                assert {image["id"] for image in service._randomized_order} == {
+                    "family-img",
+                    "personal-img",
+                }
+
     async def test_get_current_image_returns_current(self):
         """Test get_current_image returns current image when set."""
         service = PluginImageService()

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2265,7 +2265,10 @@ export interface operations {
   };
   get_current_image_api_images_current_get: {
     parameters: {
-      query?: never;
+      query?: {
+        /** @description Comma-separated source IDs */
+        source_ids?: string | null;
+      };
       header?: never;
       path?: never;
       cookie?: never;
@@ -2279,13 +2282,25 @@ export interface operations {
         };
         content: {
           "application/json": unknown;
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
     };
   };
   list_images_api_images_list_get: {
     parameters: {
-      query?: never;
+      query?: {
+        /** @description Comma-separated source IDs */
+        source_ids?: string | null;
+      };
       header?: never;
       path?: never;
       cookie?: never;
@@ -2299,13 +2314,25 @@ export interface operations {
         };
         content: {
           "application/json": unknown;
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
     };
   };
   next_image_api_images_next_post: {
     parameters: {
-      query?: never;
+      query?: {
+        /** @description Comma-separated source IDs */
+        source_ids?: string | null;
+      };
       header?: never;
       path?: never;
       cookie?: never;
@@ -2321,11 +2348,23 @@ export interface operations {
           "application/json": unknown;
         };
       };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
     };
   };
   previous_image_api_images_previous_post: {
     parameters: {
-      query?: never;
+      query?: {
+        /** @description Comma-separated source IDs */
+        source_ids?: string | null;
+      };
       header?: never;
       path?: never;
       cookie?: never;
@@ -2339,6 +2378,15 @@ export interface operations {
         };
         content: {
           "application/json": unknown;
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
     };

--- a/frontend/src/components/CalendarView.vue
+++ b/frontend/src/components/CalendarView.vue
@@ -129,6 +129,13 @@ import EventDetailPanel from "./EventDetailPanel.vue";
 import CalendarEventItem from "./CalendarEventItem.vue";
 import DashboardPanel from "./DashboardPanel.vue";
 
+const props = defineProps({
+  sourceIds: {
+    type: Array,
+    default: () => [],
+  },
+});
+
 const configStore = useConfigStore();
 const viewMode = computed(() => configStore.calendarViewMode);
 const showWeekNumbers = computed(() => configStore.showWeekNumbers);
@@ -221,7 +228,7 @@ watch(calendarRefreshIntervalMinutes, () => {
 });
 
 const currentDate = computed(() => calendarStore.currentDate);
-const events = computed(() => calendarStore.events);
+const events = computed(() => calendarStore.getEventsForSource(props.sourceIds));
 const loading = computed(() => calendarStore.loading);
 const selectedEvent = computed(() => calendarStore.selectedEvent);
 
@@ -716,7 +723,7 @@ const focusEvent = (dayIndex, eventIndex) => {
 };
 
 const selectEvent = (event, dayDate) => {
-  calendarStore.selectEvent(event, dayDate);
+  calendarStore.selectEvent(event, dayDate, props.sourceIds);
 };
 
 const closeEventDetail = () => {
@@ -904,7 +911,7 @@ const loadEvents = async (background = false) => {
     // The cache TTL (5 minutes) and periodic refresh (15 minutes) will keep data fresh
     const refresh = false;
 
-    await calendarStore.fetchEvents(startDate, endDate, refresh, background);
+    await calendarStore.fetchEvents(startDate, endDate, refresh, background, props.sourceIds);
     console.log(
       `Loaded ${calendarStore.events.length} events for ${year}-${month + 1} (range: ${startDate.toISOString().split("T")[0]} to ${endDate.toISOString().split("T")[0]})`
     );
@@ -916,6 +923,14 @@ const loadEvents = async (background = false) => {
 watch(currentDate, () => {
   loadEvents();
 });
+
+watch(
+  () => props.sourceIds,
+  () => {
+    loadEvents();
+  },
+  { deep: true }
+);
 
 // Watch for route changes to reload events when navigating back to dashboard
 watch(

--- a/frontend/src/components/CalendarView.vue
+++ b/frontend/src/components/CalendarView.vue
@@ -137,6 +137,15 @@ const props = defineProps({
 });
 
 const configStore = useConfigStore();
+const sourceKey = computed(() =>
+  [
+    ...new Set(
+      props.sourceIds.filter(id => typeof id === "string" && id.trim()).map(id => id.trim())
+    ),
+  ]
+    .sort()
+    .join(",")
+);
 const viewMode = computed(() => configStore.calendarViewMode);
 const showWeekNumbers = computed(() => configStore.showWeekNumbers);
 const weekStartDay = computed(() => configStore.weekStartDay ?? 1);
@@ -924,13 +933,9 @@ watch(currentDate, () => {
   loadEvents();
 });
 
-watch(
-  () => props.sourceIds,
-  () => {
-    loadEvents();
-  },
-  { deep: true }
-);
+watch(sourceKey, () => {
+  loadEvents();
+});
 
 // Watch for route changes to reload events when navigating back to dashboard
 watch(

--- a/frontend/src/components/DashboardRegion.vue
+++ b/frontend/src/components/DashboardRegion.vue
@@ -8,32 +8,34 @@
         :class="{ 'dashboard-subregion-active': sub.id === activeRegionId }"
         :style="getSubStyle(sub)"
       >
-        <CalendarView v-if="sub.kind === 'calendar'" />
+        <CalendarView v-if="sub.kind === 'calendar'" :source-ids="sub.instanceIds || []" />
         <PhotoSlideshow
           v-else-if="sub.kind === 'photos'"
           :is-fullscreen="false"
           :auto-rotate="true"
           :rotation-interval="photoRotationInterval * 1000"
+          :source-ids="sub.instanceIds || []"
         />
         <WebServiceViewer
           v-else-if="sub.kind === 'service'"
           :is-fullscreen="false"
-          :service-id="sub.serviceId"
+          :service-id="sub.instanceIds?.[0] || sub.serviceId"
         />
       </div>
     </template>
     <template v-else>
-      <CalendarView v-if="region.kind === 'calendar'" />
+      <CalendarView v-if="region.kind === 'calendar'" :source-ids="region.instanceIds || []" />
       <PhotoSlideshow
         v-else-if="region.kind === 'photos'"
         :is-fullscreen="false"
         :auto-rotate="true"
         :rotation-interval="photoRotationInterval * 1000"
+        :source-ids="region.instanceIds || []"
       />
       <WebServiceViewer
         v-else-if="region.kind === 'service'"
         :is-fullscreen="false"
-        :service-id="region.serviceId"
+        :service-id="region.instanceIds?.[0] || region.serviceId"
       />
     </template>
   </div>

--- a/frontend/src/components/PhotoSlideshow.vue
+++ b/frontend/src/components/PhotoSlideshow.vue
@@ -79,6 +79,15 @@ const props = defineProps({
 
 const imagesStore = useImagesStore();
 
+const sourceKey = computed(() =>
+  [
+    ...new Set(
+      props.sourceIds.filter(id => typeof id === "string" && id.trim()).map(id => id.trim())
+    ),
+  ]
+    .sort()
+    .join(",")
+);
 const currentImage = computed(() => imagesStore.getCurrentImageForSource(props.sourceIds));
 const sourceImages = computed(() => imagesStore.getImagesForSource(props.sourceIds));
 const currentImageUrl = computed(() => imagesStore.getCurrentImageUrlForSource(props.sourceIds));
@@ -194,15 +203,11 @@ watch(
   }
 );
 
-watch(
-  () => props.sourceIds,
-  async () => {
-    stopAutoRotation();
-    await imagesStore.fetchImages(props.sourceIds);
-    if (props.autoRotate) startAutoRotation();
-  },
-  { deep: true }
-);
+watch(sourceKey, async () => {
+  stopAutoRotation();
+  await imagesStore.fetchImages(props.sourceIds);
+  if (props.autoRotate) startAutoRotation();
+});
 </script>
 
 <style scoped>

--- a/frontend/src/components/PhotoSlideshow.vue
+++ b/frontend/src/components/PhotoSlideshow.vue
@@ -7,18 +7,18 @@
             {{ imagesStore.error }}
           </div>
           <button
-            v-if="imagesStore.images.length > 1"
+            v-if="sourceImages.length > 1"
             class="dashboard-panel__icon-button"
             title="Previous image"
-            @click="imagesStore.previousImage"
+            @click="imagesStore.previousImage(sourceIds)"
           >
             ‹
           </button>
           <button
-            v-if="imagesStore.images.length > 1"
+            v-if="sourceImages.length > 1"
             class="dashboard-panel__icon-button"
             title="Next image"
-            @click="imagesStore.nextImage"
+            @click="imagesStore.nextImage(sourceIds)"
           >
             ›
           </button>
@@ -36,7 +36,7 @@
         <div v-else class="photo-container">
           <img
             :src="currentImageUrl"
-            :alt="imagesStore.currentImage?.filename || 'Photo'"
+            :alt="currentImage?.filename || 'Photo'"
             :class="['photo-image', `photo-image-${displayMode}`]"
             :style="imageStyle"
             decoding="async"
@@ -71,11 +71,17 @@ const props = defineProps({
     type: Number,
     default: 30000, // 30 seconds
   },
+  sourceIds: {
+    type: Array,
+    default: () => [],
+  },
 });
 
 const imagesStore = useImagesStore();
 
-const currentImageUrl = computed(() => imagesStore.getCurrentImageUrl);
+const currentImage = computed(() => imagesStore.getCurrentImageForSource(props.sourceIds));
+const sourceImages = computed(() => imagesStore.getImagesForSource(props.sourceIds));
+const currentImageUrl = computed(() => imagesStore.getCurrentImageUrlForSource(props.sourceIds));
 
 // Get display mode from config
 const displayMode = computed(() => {
@@ -85,7 +91,7 @@ const displayMode = computed(() => {
 // Calculate smart display mode based on image and container dimensions
 const imageStyle = computed(() => {
   const mode = displayMode.value;
-  const image = imagesStore.currentImage;
+  const image = currentImage.value;
 
   if (!image || mode !== "smart") {
     return {};
@@ -142,9 +148,9 @@ const onImageError = () => {
 };
 
 const startAutoRotation = () => {
-  if (props.autoRotate && imagesStore.images.length > 1) {
+  if (props.autoRotate && sourceImages.value.length > 1) {
     rotationTimer = setInterval(() => {
-      imagesStore.nextImage();
+      imagesStore.nextImage(props.sourceIds);
     }, props.rotationInterval);
   }
 };
@@ -159,9 +165,9 @@ const stopAutoRotation = () => {
 onMounted(async () => {
   // Fetch images and current image
   try {
-    await imagesStore.fetchImages();
-    if (imagesStore.images.length > 0 && !imagesStore.currentImage) {
-      await imagesStore.fetchCurrentImage();
+    await imagesStore.fetchImages(props.sourceIds);
+    if (sourceImages.value.length > 0 && !currentImage.value) {
+      await imagesStore.fetchCurrentImage(props.sourceIds);
     }
   } catch (error) {
     console.error("Failed to load images:", error);
@@ -186,6 +192,16 @@ watch(
       stopAutoRotation();
     }
   }
+);
+
+watch(
+  () => props.sourceIds,
+  async () => {
+    stopAutoRotation();
+    await imagesStore.fetchImages(props.sourceIds);
+    if (props.autoRotate) startAutoRotation();
+  },
+  { deep: true }
 );
 </script>
 

--- a/frontend/src/components/settings/tabs/dashboard/DashboardLayoutTab.vue
+++ b/frontend/src/components/settings/tabs/dashboard/DashboardLayoutTab.vue
@@ -728,7 +728,7 @@ const sourceSelectionLabel = region => {
 const toggleRegionSource = (screenIndex, regionIndex, sourceId, checked) => {
   const layout = cloneLayout(screenIndex);
   const region = layout.regions[regionIndex];
-  if (!region) return;
+  if (!region || region.kind === "service") return;
   const current = new Set(region.instanceIds || []);
   if (checked) current.add(sourceId);
   else current.delete(sourceId);
@@ -740,7 +740,7 @@ const toggleRegionSource = (screenIndex, regionIndex, sourceId, checked) => {
 const toggleSubRegionSource = (screenIndex, regionIndex, subIndex, sourceId, checked) => {
   const layout = cloneLayout(screenIndex);
   const sub = layout.regions[regionIndex]?.split?.regions?.[subIndex];
-  if (!sub) return;
+  if (!sub || sub.kind === "service") return;
   const current = new Set(sub.instanceIds || []);
   if (checked) current.add(sourceId);
   else current.delete(sourceId);
@@ -752,7 +752,7 @@ const toggleSubRegionSource = (screenIndex, regionIndex, subIndex, sourceId, che
 const clearRegionSources = (screenIndex, regionIndex) => {
   const layout = cloneLayout(screenIndex);
   const region = layout.regions[regionIndex];
-  if (!region) return;
+  if (!region || region.kind === "service") return;
   region.instanceIds = [];
   region.serviceId = null;
   updateScreen(screenIndex, { layout });
@@ -761,7 +761,7 @@ const clearRegionSources = (screenIndex, regionIndex) => {
 const clearSubRegionSources = (screenIndex, regionIndex, subIndex) => {
   const layout = cloneLayout(screenIndex);
   const sub = layout.regions[regionIndex]?.split?.regions?.[subIndex];
-  if (!sub) return;
+  if (!sub || sub.kind === "service") return;
   sub.instanceIds = [];
   sub.serviceId = null;
   updateScreen(screenIndex, { layout });

--- a/frontend/src/components/settings/tabs/dashboard/DashboardLayoutTab.vue
+++ b/frontend/src/components/settings/tabs/dashboard/DashboardLayoutTab.vue
@@ -252,6 +252,38 @@
                               {{ option.label }}
                             </button>
                             <div
+                              v-if="sourceOptionsFor(sub.kind).length > 0"
+                              class="source-options"
+                            >
+                              <button
+                                type="button"
+                                class="component-option"
+                                @click="clearSubRegionSources(screenIndex, previewIndex, subIndex)"
+                              >
+                                {{ sourceSelectionLabel({ ...sub, instanceIds: [] }) }}
+                              </button>
+                              <label
+                                v-for="source in sourceOptionsFor(sub.kind)"
+                                :key="source.id"
+                                class="source-option"
+                              >
+                                <input
+                                  type="checkbox"
+                                  :checked="(sub.instanceIds || []).includes(source.id)"
+                                  @change="
+                                    toggleSubRegionSource(
+                                      screenIndex,
+                                      previewIndex,
+                                      subIndex,
+                                      source.id,
+                                      $event.target.checked
+                                    )
+                                  "
+                                />
+                                {{ source.name }}
+                              </label>
+                            </div>
+                            <div
                               v-if="filteredComponentOptions.length === 0"
                               class="component-empty"
                             >
@@ -328,6 +360,34 @@
                       >
                         {{ option.label }}
                       </button>
+                      <div v-if="sourceOptionsFor(region.kind).length > 0" class="source-options">
+                        <button
+                          type="button"
+                          class="component-option"
+                          @click="clearRegionSources(screenIndex, previewIndex)"
+                        >
+                          {{ sourceSelectionLabel({ ...region, instanceIds: [] }) }}
+                        </button>
+                        <label
+                          v-for="source in sourceOptionsFor(region.kind)"
+                          :key="source.id"
+                          class="source-option"
+                        >
+                          <input
+                            type="checkbox"
+                            :checked="(region.instanceIds || []).includes(source.id)"
+                            @change="
+                              toggleRegionSource(
+                                screenIndex,
+                                previewIndex,
+                                source.id,
+                                $event.target.checked
+                              )
+                            "
+                          />
+                          {{ source.name }}
+                        </label>
+                      </div>
                       <div v-if="filteredComponentOptions.length === 0" class="component-empty">
                         No matches
                       </div>
@@ -378,6 +438,8 @@
 <script setup>
 import { computed, onMounted, onUnmounted, reactive, ref } from "vue";
 import { useWebServicesStore } from "@/stores/webServices";
+import { useCalendarStore } from "@/stores/calendar";
+import { usePlugins } from "@/composables";
 import {
   MAX_TOP_REGIONS,
   addSubRegion,
@@ -410,6 +472,8 @@ const props = defineProps({
 
 const emit = defineEmits(["update:config"]);
 const webServicesStore = useWebServicesStore();
+const calendarStore = useCalendarStore();
+const { plugins, pluginInstances, loadingPlugins, loadPlugins } = usePlugins();
 const previewRefs = new Map();
 const subPreviewRefs = new Map();
 const dragState = ref(null);
@@ -490,14 +554,21 @@ const previewStyleFor = layout => {
 };
 
 const services = computed(() => webServicesStore.services);
+const calendarSources = computed(() => calendarStore.sources || []);
+const imageInstances = computed(() =>
+  plugins.value
+    .filter(plugin => plugin.type === "image" && plugin.enabled)
+    .flatMap(plugin => pluginInstances.value[plugin.id] || [])
+    .sort((a, b) => (a.display_order ?? 0) - (b.display_order ?? 0))
+);
 const componentOptions = computed(() => [
-  { value: "calendar", label: "Calendar", kind: "calendar", serviceId: null },
-  { value: "photos", label: "Photos", kind: "photos", serviceId: null },
+  { value: "calendar", label: "Calendar", kind: "calendar", instanceIds: [] },
+  { value: "photos", label: "Photos", kind: "photos", instanceIds: [] },
   ...services.value.map(service => ({
     value: `service:${service.id}`,
     label: service.name,
     kind: "service",
-    serviceId: service.id,
+    instanceIds: [service.id],
   })),
 ]);
 const filteredComponentOptions = computed(() => {
@@ -578,7 +649,8 @@ const selectRegionComponent = (screenIndex, regionIndex, option) => {
   layout.regions[regionIndex] = {
     ...layout.regions[regionIndex],
     kind: option.kind,
-    serviceId: option.kind === "service" ? option.serviceId : null,
+    serviceId: option.kind === "service" ? option.instanceIds?.[0] || null : null,
+    instanceIds: option.instanceIds || [],
   };
   openComponentPickerKey.value = null;
   componentSearch.value = "";
@@ -588,7 +660,8 @@ const selectRegionComponent = (screenIndex, regionIndex, option) => {
 const selectSubRegionComponent = (screenIndex, regionIndex, subIndex, option) => {
   const layout = setSubRegionContent(cloneLayout(screenIndex), regionIndex, subIndex, {
     kind: option.kind,
-    serviceId: option.serviceId,
+    serviceId: option.instanceIds?.[0] || null,
+    instanceIds: option.instanceIds || [],
   });
   openComponentPickerKey.value = null;
   componentSearch.value = "";
@@ -628,16 +701,83 @@ const toggleComponentPicker = (screenId, regionId) => {
   componentSearch.value = "";
 };
 
+const sourceOptionsFor = kind => {
+  if (kind === "calendar") {
+    return calendarSources.value.map(source => ({ id: source.id, name: source.name }));
+  }
+  if (kind === "photos") {
+    return imageInstances.value.map(instance => ({ id: instance.id, name: instance.name }));
+  }
+  return [];
+};
+
+const sourceSelectionLabel = region => {
+  const ids = region.instanceIds || [];
+  if (region.kind !== "calendar" && region.kind !== "photos") return "";
+  if (ids.length === 0) return "All sources";
+  if (ids.length === 1) {
+    const source = sourceOptionsFor(region.kind).find(option => option.id === ids[0]);
+    return source?.name || "1 source";
+  }
+  return `${ids.length} sources`;
+};
+
+const toggleRegionSource = (screenIndex, regionIndex, sourceId, checked) => {
+  const layout = cloneLayout(screenIndex);
+  const region = layout.regions[regionIndex];
+  if (!region) return;
+  const current = new Set(region.instanceIds || []);
+  if (checked) current.add(sourceId);
+  else current.delete(sourceId);
+  region.instanceIds = [...current];
+  region.serviceId = null;
+  updateScreen(screenIndex, { layout });
+};
+
+const toggleSubRegionSource = (screenIndex, regionIndex, subIndex, sourceId, checked) => {
+  const layout = cloneLayout(screenIndex);
+  const sub = layout.regions[regionIndex]?.split?.regions?.[subIndex];
+  if (!sub) return;
+  const current = new Set(sub.instanceIds || []);
+  if (checked) current.add(sourceId);
+  else current.delete(sourceId);
+  sub.instanceIds = [...current];
+  sub.serviceId = null;
+  updateScreen(screenIndex, { layout });
+};
+
+const clearRegionSources = (screenIndex, regionIndex) => {
+  const layout = cloneLayout(screenIndex);
+  const region = layout.regions[regionIndex];
+  if (!region) return;
+  region.instanceIds = [];
+  region.serviceId = null;
+  updateScreen(screenIndex, { layout });
+};
+
+const clearSubRegionSources = (screenIndex, regionIndex, subIndex) => {
+  const layout = cloneLayout(screenIndex);
+  const sub = layout.regions[regionIndex]?.split?.regions?.[subIndex];
+  if (!sub) return;
+  sub.instanceIds = [];
+  sub.serviceId = null;
+  updateScreen(screenIndex, { layout });
+};
+
 const cloneLayout = screenIndex => {
   const screen = dashboardScreens.value.screens[screenIndex];
   return {
     ...screen.layout,
     regions: screen.layout.regions.map(region => ({
       ...region,
+      instanceIds: [...(region.instanceIds || [])],
       split: region.split
         ? {
             ...region.split,
-            regions: region.split.regions.map(sub => ({ ...sub })),
+            regions: region.split.regions.map(sub => ({
+              ...sub,
+              instanceIds: [...(sub.instanceIds || [])],
+            })),
           }
         : null,
     })),
@@ -777,10 +917,12 @@ const deleteScreen = screenIndex => {
 const regionLabel = previewIndex => `Region ${previewIndex + 1}`;
 
 const regionKindLabel = region => {
-  if (region.kind === "calendar") return "Calendar";
-  if (region.kind === "photos") return "Photos";
+  if (region.kind === "calendar") return `Calendar - ${sourceSelectionLabel(region)}`;
+  if (region.kind === "photos") return `Photos - ${sourceSelectionLabel(region)}`;
   if (region.kind === "service") {
-    const service = services.value.find(item => item.id === region.serviceId);
+    const service = services.value.find(
+      item => item.id === (region.instanceIds?.[0] || region.serviceId)
+    );
     return service?.name || "Service";
   }
   return "Region";
@@ -807,6 +949,12 @@ const resizeRegionAtIndex = (regions, index, size) => {
 onMounted(async () => {
   if (webServicesStore.services.length === 0 && !webServicesStore.loading) {
     await webServicesStore.fetchServices();
+  }
+  if (calendarStore.sources.length === 0 && !calendarStore.loading) {
+    await calendarStore.fetchSources();
+  }
+  if (plugins.value.length === 0 && !loadingPlugins.value) {
+    await loadPlugins();
   }
 });
 
@@ -1106,6 +1254,25 @@ onUnmounted(() => {
 .component-option:focus {
   background: var(--bg-secondary);
   outline: none;
+}
+
+.source-options {
+  border-top: 1px solid var(--border-color);
+  padding: 0.35rem 0;
+}
+
+.source-option {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.45rem 0.65rem;
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.source-option:hover {
+  background: var(--bg-secondary);
 }
 
 .component-empty {

--- a/frontend/src/components/settings/tabs/dashboard/DashboardLayoutTab.vue
+++ b/frontend/src/components/settings/tabs/dashboard/DashboardLayoutTab.vue
@@ -554,11 +554,14 @@ const previewStyleFor = layout => {
 };
 
 const services = computed(() => webServicesStore.services);
-const calendarSources = computed(() => calendarStore.sources || []);
+const calendarSources = computed(() =>
+  (calendarStore.sources || []).filter(source => source.enabled !== false)
+);
 const imageInstances = computed(() =>
   plugins.value
     .filter(plugin => plugin.type === "image" && plugin.enabled)
     .flatMap(plugin => pluginInstances.value[plugin.id] || [])
+    .filter(instance => instance.enabled !== false)
     .sort((a, b) => (a.display_order ?? 0) - (b.display_order ?? 0))
 );
 const componentOptions = computed(() => [

--- a/frontend/src/stores/calendar.js
+++ b/frontend/src/stores/calendar.js
@@ -14,6 +14,7 @@ import { logDebug, logError, logInfo } from "../utils/logger";
 
 export const useCalendarStore = defineStore("calendar", () => {
   const events = ref([]);
+  const eventsBySourceKey = ref({});
   const sources = ref([]); // Calendar sources with colors and show_time settings
   const loading = ref(false);
   const backgroundRefreshing = ref(false);
@@ -105,7 +106,29 @@ export const useCalendarStore = defineStore("calendar", () => {
     return source?.show_time !== false; // Default to true
   };
 
-  const fetchEvents = async (startDate, endDate, refreshParam = "", background = false) => {
+  const normalizeSourceIds = sourceIds =>
+    Array.isArray(sourceIds)
+      ? [
+          ...new Set(
+            sourceIds.filter(id => typeof id === "string" && id.trim()).map(id => id.trim())
+          ),
+        ].sort()
+      : [];
+
+  const getSourceKey = sourceIds => {
+    const ids = normalizeSourceIds(sourceIds);
+    return ids.length ? ids.join(",") : "__all__";
+  };
+
+  const getEventsForSource = sourceIds => eventsBySourceKey.value[getSourceKey(sourceIds)] || [];
+
+  const fetchEvents = async (
+    startDate,
+    endDate,
+    refreshParam = "",
+    background = false,
+    sourceIds = []
+  ) => {
     if (background) {
       backgroundRefreshing.value = true;
     } else {
@@ -114,7 +137,9 @@ export const useCalendarStore = defineStore("calendar", () => {
     error.value = null;
 
     const connectionStore = useConnectionStore();
-    const cacheKey = `calendar_events_${startDate?.toISOString()}_${endDate?.toISOString()}`;
+    const normalizedSourceIds = normalizeSourceIds(sourceIds);
+    const sourceKey = getSourceKey(normalizedSourceIds);
+    const cacheKey = `calendar_events_${sourceKey}_${startDate?.toISOString()}_${endDate?.toISOString()}`;
     const cacheTTL = 30 * 60 * 1000; // 30 minutes
 
     // Try to load from cache first if offline
@@ -122,7 +147,8 @@ export const useCalendarStore = defineStore("calendar", () => {
       const cachedEvents = getCachedData(cacheKey, cacheTTL);
       if (cachedEvents) {
         logInfo("[Calendar]", `Using cached events (${cachedEvents.events?.length || 0} events)`);
-        events.value = cachedEvents.events || [];
+        eventsBySourceKey.value[sourceKey] = cachedEvents.events || [];
+        if (sourceKey === "__all__") events.value = cachedEvents.events || [];
         loading.value = false;
         return cachedEvents;
       }
@@ -133,6 +159,9 @@ export const useCalendarStore = defineStore("calendar", () => {
         start_date: startDate?.toISOString(),
         end_date: endDate?.toISOString(),
       };
+      if (normalizedSourceIds.length > 0) {
+        params.source_ids = normalizedSourceIds.join(",");
+      }
 
       // Add refresh parameter if provided (for cache busting)
       if (refreshParam) {
@@ -151,14 +180,17 @@ export const useCalendarStore = defineStore("calendar", () => {
       const response = await axios.get("/api/calendar/events", { params });
       /** @type {CalendarEventsResponse} */
       const responseData = response.data;
-      events.value = responseData.events || [];
+      eventsBySourceKey.value[sourceKey] = responseData.events || [];
+      if (sourceKey === "__all__") {
+        events.value = responseData.events || [];
+      }
 
       // Cache the response
       setCachedData(cacheKey, responseData);
 
-      logDebug("[Calendar]", `Fetched ${events.value.length} events from API`);
-      if (events.value.length > 0) {
-        logDebug("[Calendar]", "Sample event:", events.value[0]);
+      logDebug("[Calendar]", `Fetched ${responseData.events?.length || 0} events from API`);
+      if (responseData.events?.length > 0) {
+        logDebug("[Calendar]", "Sample event:", responseData.events[0]);
       }
       return responseData;
     } catch (err) {
@@ -170,7 +202,8 @@ export const useCalendarStore = defineStore("calendar", () => {
             "[Calendar]",
             `Request failed, using cached events (${cachedEvents.events?.length || 0} events)`
           );
-          events.value = cachedEvents.events || [];
+          eventsBySourceKey.value[sourceKey] = cachedEvents.events || [];
+          if (sourceKey === "__all__") events.value = cachedEvents.events || [];
           loading.value = false;
           return cachedEvents;
         }
@@ -223,10 +256,15 @@ export const useCalendarStore = defineStore("calendar", () => {
     return date1.day - date2.day;
   };
 
-  const selectEvent = (event, selectedDayDate = null) => {
+  const selectEvent = (event, selectedDayDate = null, sourceIds = []) => {
+    const sourceEvents = getEventsForSource(sourceIds);
+    const eventPool =
+      sourceEvents.length > 0 || getSourceKey(sourceIds) !== "__all__"
+        ? sourceEvents
+        : events.value;
     // Find the event in the main events array to ensure we're using the same object reference
     // This helps with reactivity and ensures consistent comparisons
-    const eventFromMainArray = events.value.find(e => {
+    const eventFromMainArray = eventPool.find(e => {
       // Compare IDs as strings to ensure consistent comparison
       return String(e.id) === String(event.id);
     });
@@ -271,7 +309,7 @@ export const useCalendarStore = defineStore("calendar", () => {
       const gridDateComponents = getDateComponents(dateToUse, false);
 
       // Filter events using the exact same logic as CalendarView.getEventsForDate
-      dayEvents.value = events.value
+      dayEvents.value = eventPool
         .filter(e => {
           const eStart = new Date(e.start);
           const eEnd = new Date(e.end);
@@ -399,6 +437,7 @@ export const useCalendarStore = defineStore("calendar", () => {
 
   return {
     events,
+    eventsBySourceKey,
     sources,
     loading,
     backgroundRefreshing,
@@ -409,6 +448,7 @@ export const useCalendarStore = defineStore("calendar", () => {
     dayEvents,
     showAllDayEvents,
     fetchEvents,
+    getEventsForSource,
     fetchSources,
     updateSource,
     getSourceColor,

--- a/frontend/src/stores/images.js
+++ b/frontend/src/stores/images.js
@@ -4,19 +4,54 @@ import axios from "axios";
 
 export const useImagesStore = defineStore("images", () => {
   const images = ref([]);
+  const imagesBySourceKey = ref({});
   const currentImage = ref(null);
+  const currentImagesBySourceKey = ref({});
   const loading = ref(false);
   const error = ref(null);
 
-  const fetchImages = async () => {
+  const normalizeSourceIds = sourceIds =>
+    Array.isArray(sourceIds)
+      ? [
+          ...new Set(
+            sourceIds.filter(id => typeof id === "string" && id.trim()).map(id => id.trim())
+          ),
+        ].sort()
+      : [];
+
+  const getSourceKey = sourceIds => {
+    const ids = normalizeSourceIds(sourceIds);
+    return ids.length ? ids.join(",") : "__all__";
+  };
+
+  const sourceParams = sourceIds => {
+    const ids = normalizeSourceIds(sourceIds);
+    return ids.length ? { params: { source_ids: ids.join(",") } } : undefined;
+  };
+
+  const getWithSources = (url, sourceIds) => {
+    const config = sourceParams(sourceIds);
+    return config ? axios.get(url, config) : axios.get(url);
+  };
+
+  const postWithSources = (url, sourceIds) => {
+    const config = sourceParams(sourceIds);
+    return config ? axios.post(url, null, config) : axios.post(url);
+  };
+
+  const fetchImages = async (sourceIds = []) => {
     loading.value = true;
     error.value = null;
+    const sourceKey = getSourceKey(sourceIds);
     try {
-      const response = await axios.get("/api/images/list");
-      images.value = response.data.images || [];
+      const response = await getWithSources("/api/images/list", sourceIds);
+      imagesBySourceKey.value[sourceKey] = response.data.images || [];
+      if (sourceKey === "__all__") images.value = response.data.images || [];
       // If we have images but no current image, fetch current
-      if (images.value.length > 0 && !currentImage.value) {
-        await fetchCurrentImage();
+      const existingCurrent =
+        sourceKey === "__all__" ? currentImage.value : currentImagesBySourceKey.value[sourceKey];
+      if (imagesBySourceKey.value[sourceKey].length > 0 && !existingCurrent) {
+        await fetchCurrentImage(sourceIds);
       }
       return response.data;
     } catch (err) {
@@ -28,10 +63,12 @@ export const useImagesStore = defineStore("images", () => {
     }
   };
 
-  const fetchCurrentImage = async () => {
+  const fetchCurrentImage = async (sourceIds = []) => {
+    const sourceKey = getSourceKey(sourceIds);
     try {
-      const response = await axios.get("/api/images/current");
-      currentImage.value = response.data.image;
+      const response = await getWithSources("/api/images/current", sourceIds);
+      currentImagesBySourceKey.value[sourceKey] = response.data.image;
+      if (sourceKey === "__all__") currentImage.value = response.data.image;
       return response.data;
     } catch (err) {
       console.error("Failed to fetch current image:", err);
@@ -39,10 +76,12 @@ export const useImagesStore = defineStore("images", () => {
     }
   };
 
-  const nextImage = async () => {
+  const nextImage = async (sourceIds = []) => {
+    const sourceKey = getSourceKey(sourceIds);
     try {
-      const response = await axios.post("/api/images/next");
-      currentImage.value = response.data.image;
+      const response = await postWithSources("/api/images/next", sourceIds);
+      currentImagesBySourceKey.value[sourceKey] = response.data.image;
+      if (sourceKey === "__all__") currentImage.value = response.data.image;
       return response.data;
     } catch (err) {
       console.error("Failed to go to next image:", err);
@@ -50,10 +89,12 @@ export const useImagesStore = defineStore("images", () => {
     }
   };
 
-  const previousImage = async () => {
+  const previousImage = async (sourceIds = []) => {
+    const sourceKey = getSourceKey(sourceIds);
     try {
-      const response = await axios.post("/api/images/previous");
-      currentImage.value = response.data.image;
+      const response = await postWithSources("/api/images/previous", sourceIds);
+      currentImagesBySourceKey.value[sourceKey] = response.data.image;
+      if (sourceKey === "__all__") currentImage.value = response.data.image;
       return response.data;
     } catch (err) {
       console.error("Failed to go to previous image:", err);
@@ -62,18 +103,37 @@ export const useImagesStore = defineStore("images", () => {
   };
 
   const getCurrentImageUrl = computed(() => {
-    if (!currentImage.value) return null;
+    return getImageUrl(currentImage.value);
+  });
 
+  const getCurrentImageForSource = sourceIds => {
+    const sourceKey = getSourceKey(sourceIds);
+    return sourceKey === "__all__"
+      ? currentImagesBySourceKey.value[sourceKey] || currentImage.value
+      : currentImagesBySourceKey.value[sourceKey] || null;
+  };
+
+  const getImagesForSource = sourceIds => {
+    const sourceKey = getSourceKey(sourceIds);
+    return sourceKey === "__all__"
+      ? imagesBySourceKey.value[sourceKey] || images.value
+      : imagesBySourceKey.value[sourceKey] || [];
+  };
+
+  const getCurrentImageUrlForSource = sourceIds => getImageUrl(getCurrentImageForSource(sourceIds));
+
+  const getImageUrl = image => {
+    if (!image) return null;
     // For remote images (like Picsum, Unsplash), use the URL directly
     // This avoids unnecessary backend redirects and improves performance
-    const imageUrl = currentImage.value.url || currentImage.value.raw_url;
+    const imageUrl = image.url || image.raw_url;
     if (imageUrl && (imageUrl.startsWith("http://") || imageUrl.startsWith("https://"))) {
       return imageUrl;
     }
 
     // For local images, use the API endpoint
-    return `/api/images/${currentImage.value.id}`;
-  });
+    return `/api/images/${image.id}`;
+  };
 
   const uploadImage = async file => {
     loading.value = true;
@@ -118,7 +178,9 @@ export const useImagesStore = defineStore("images", () => {
 
   return {
     images,
+    imagesBySourceKey,
     currentImage,
+    currentImagesBySourceKey,
     loading,
     error,
     fetchImages,
@@ -126,6 +188,9 @@ export const useImagesStore = defineStore("images", () => {
     nextImage,
     previousImage,
     getCurrentImageUrl,
+    getCurrentImageForSource,
+    getImagesForSource,
+    getCurrentImageUrlForSource,
     uploadImage,
     deleteImage,
   };

--- a/frontend/src/utils/layout.js
+++ b/frontend/src/utils/layout.js
@@ -86,30 +86,30 @@ export const MAX_TOP_REGIONS = 8;
 export const DASHBOARD_LAYOUT_PRESETS = {
   single: {
     label: "Single Region",
-    regions: [{ id: "region-1", kind: "calendar", size: 100 }],
+    regions: [{ id: "region-1", kind: "calendar", instanceIds: [], size: 100 }],
   },
   split_two: {
     label: "Two Regions",
     regions: [
-      { id: "region-1", kind: "calendar", size: 70 },
-      { id: "region-2", kind: "photos", size: 30 },
+      { id: "region-1", kind: "calendar", instanceIds: [], size: 70 },
+      { id: "region-2", kind: "photos", instanceIds: [], size: 30 },
     ],
   },
   split_three: {
     label: "Three Regions",
     regions: [
-      { id: "region-1", kind: "calendar", size: 50 },
-      { id: "region-2", kind: "photos", size: 25 },
-      { id: "region-3", kind: "service", size: 25 },
+      { id: "region-1", kind: "calendar", instanceIds: [], size: 50 },
+      { id: "region-2", kind: "photos", instanceIds: [], size: 25 },
+      { id: "region-3", kind: "service", instanceIds: [], size: 25 },
     ],
   },
   split_four: {
     label: "Four Regions",
     regions: [
-      { id: "region-1", kind: "calendar", size: 25 },
-      { id: "region-2", kind: "photos", size: 25 },
-      { id: "region-3", kind: "service", size: 25 },
-      { id: "region-4", kind: "service", size: 25 },
+      { id: "region-1", kind: "calendar", instanceIds: [], size: 25 },
+      { id: "region-2", kind: "photos", instanceIds: [], size: 25 },
+      { id: "region-3", kind: "service", instanceIds: [], size: 25 },
+      { id: "region-4", kind: "service", instanceIds: [], size: 25 },
     ],
   },
 };
@@ -275,6 +275,7 @@ export function createLegacyDashboardLayout(config = {}) {
         id: "region-2",
         kind: secondaryKind,
         serviceId: null,
+        instanceIds: [],
         size: 100 - calendarSize,
       },
     ],
@@ -297,10 +298,12 @@ export function normalizeDashboardLayout(layout, legacyConfig = {}) {
       };
     const kind = DASHBOARD_REGION_KINDS.includes(region.kind) ? region.kind : presetRegion.kind;
     const id = region.id || presetRegion.id || `region-${index + 1}`;
+    const instanceIds = normalizeRegionInstanceIds(region, kind);
     return {
       id,
       kind,
-      serviceId: kind === "service" ? region.serviceId || null : null,
+      serviceId: kind === "service" ? instanceIds[0] || null : null,
+      instanceIds,
       size: clampRegionSize(region.size ?? presetRegion.size ?? 100 / sourceRegions.length),
       split: normalizeRegionSplit(region.split, id),
     };
@@ -342,10 +345,12 @@ export function createDashboardLayoutFromPreset(preset, existingLayout = null) {
     regions: presetConfig.regions.map((region, index) => {
       const existing = existingRegions[index] || {};
       const kind = DASHBOARD_REGION_KINDS.includes(existing.kind) ? existing.kind : region.kind;
+      const instanceIds = normalizeRegionInstanceIds(existing, kind);
       return {
         ...region,
         kind,
-        serviceId: kind === "service" ? existing.serviceId || region.serviceId || null : null,
+        serviceId: kind === "service" ? instanceIds[0] || region.serviceId || null : null,
+        instanceIds: instanceIds.length ? instanceIds : normalizeRegionInstanceIds(region, kind),
         size: existing.size ?? region.size,
       };
     }),
@@ -400,10 +405,12 @@ function normalizeRegionSplit(split, parentId) {
   if (subs.length < 2) return null;
   const normalized = subs.map((sub, index) => {
     const kind = DASHBOARD_REGION_KINDS.includes(sub.kind) ? sub.kind : "photos";
+    const instanceIds = normalizeRegionInstanceIds(sub, kind);
     return {
       id: sub.id || `${parentId}-${String.fromCharCode(97 + index)}`,
       kind,
-      serviceId: kind === "service" ? sub.serviceId || null : null,
+      serviceId: kind === "service" ? instanceIds[0] || null : null,
+      instanceIds,
       size: clampRegionSize(Number(sub.size) || 100 / subs.length),
     };
   });
@@ -450,6 +457,7 @@ export function addTopRegion(layout, opts = {}) {
     id: opts.id || nextRegionId(layout.regions),
     kind: opts.kind || "service",
     serviceId: null,
+    instanceIds: normalizeRegionInstanceIds(opts, opts.kind || "service"),
     size: newRegionSize,
     split: null,
   };
@@ -484,13 +492,16 @@ export function splitTopRegion(layout, topIndex) {
       {
         id: `${parentId}-a`,
         kind: target.kind,
-        serviceId: target.kind === "service" ? target.serviceId || null : null,
+        serviceId:
+          target.kind === "service" ? target.instanceIds?.[0] || target.serviceId || null : null,
+        instanceIds: normalizeRegionInstanceIds(target, target.kind),
         size: 50,
       },
       {
         id: `${parentId}-b`,
         kind: secondaryKind,
         serviceId: null,
+        instanceIds: [],
         size: 50,
       },
     ],
@@ -511,7 +522,9 @@ export function unsplitTopRegion(layout, topIndex) {
       ? {
           id: region.id,
           kind: subA.kind,
-          serviceId: subA.kind === "service" ? subA.serviceId || null : null,
+          serviceId:
+            subA.kind === "service" ? subA.instanceIds?.[0] || subA.serviceId || null : null,
+          instanceIds: normalizeRegionInstanceIds(subA, subA.kind),
           size: region.size,
           split: null,
         }
@@ -520,7 +533,7 @@ export function unsplitTopRegion(layout, topIndex) {
   return { ...layout, regions };
 }
 
-export function setSubRegionContent(layout, topIndex, subIndex, { kind, serviceId }) {
+export function setSubRegionContent(layout, topIndex, subIndex, { kind, serviceId, instanceIds }) {
   const region = layout?.regions?.[topIndex];
   if (!region?.split) return layout;
   const subs = region.split.regions.map((sub, index) =>
@@ -528,7 +541,8 @@ export function setSubRegionContent(layout, topIndex, subIndex, { kind, serviceI
       ? {
           ...sub,
           kind,
-          serviceId: kind === "service" ? serviceId || null : null,
+          serviceId: kind === "service" ? instanceIds?.[0] || serviceId || null : null,
+          instanceIds: normalizeRegionInstanceIds({ serviceId, instanceIds }, kind),
         }
       : sub
   );
@@ -596,7 +610,11 @@ export function removeSubRegion(layout, topIndex, subIndex) {
         ? {
             id: candidate.id,
             kind: surviving.kind,
-            serviceId: surviving.kind === "service" ? surviving.serviceId || null : null,
+            serviceId:
+              surviving.kind === "service"
+                ? surviving.instanceIds?.[0] || surviving.serviceId || null
+                : null,
+            instanceIds: normalizeRegionInstanceIds(surviving, surviving.kind),
             size: candidate.size,
             split: null,
           }
@@ -616,6 +634,21 @@ function updateLayoutSplit(layout, topIndex, subs) {
       : candidate
   );
   return { ...layout, regions };
+}
+
+function normalizeRegionInstanceIds(region, kind) {
+  if (!region || (kind !== "calendar" && kind !== "photos" && kind !== "service")) return [];
+  const rawIds = Array.isArray(region.instanceIds)
+    ? region.instanceIds
+    : region.instanceId
+      ? [region.instanceId]
+      : region.serviceId
+        ? [region.serviceId]
+        : [];
+  const ids = [
+    ...new Set(rawIds.filter(id => typeof id === "string" && id.trim()).map(id => id.trim())),
+  ];
+  return kind === "service" ? ids.slice(0, 1) : ids;
 }
 
 function nextSubId(parentId, subs) {

--- a/frontend/tests/unit/components/DashboardDisplayTabs.spec.js
+++ b/frontend/tests/unit/components/DashboardDisplayTabs.spec.js
@@ -51,8 +51,8 @@ describe("dashboard display settings tabs", () => {
     const emitted = wrapper.emitted("update:config").at(-1)[0];
     const screen = emitted.dashboardScreens.screens[0];
     expect(screen.layout.regions).toEqual([
-      { id: "region-1", kind: "calendar", serviceId: null, size: 90, split: null },
-      { id: "region-2", kind: "photos", serviceId: null, size: 10, split: null },
+      { id: "region-1", kind: "calendar", serviceId: null, instanceIds: [], size: 90, split: null },
+      { id: "region-2", kind: "photos", serviceId: null, instanceIds: [], size: 10, split: null },
     ]);
   });
 
@@ -66,7 +66,14 @@ describe("dashboard display settings tabs", () => {
     const emitted = wrapper.emitted("update:config").at(-1)[0];
     const screen = emitted.dashboardScreens.screens[0];
     expect(screen.layout.regions).toEqual([
-      { id: "region-1", kind: "calendar", serviceId: null, size: 100, split: null },
+      {
+        id: "region-1",
+        kind: "calendar",
+        serviceId: null,
+        instanceIds: [],
+        size: 100,
+        split: null,
+      },
     ]);
   });
 

--- a/frontend/tests/unit/stores/calendar.spec.js
+++ b/frontend/tests/unit/stores/calendar.spec.js
@@ -256,6 +256,27 @@ describe("Calendar Store", () => {
       });
     });
 
+    it("should add source_ids parameter when source IDs are provided", async () => {
+      const startDate = new Date("2024-01-01");
+      const endDate = new Date("2024-01-31");
+      const mockEvents = { events: [] };
+
+      axios.get.mockResolvedValue({ data: mockEvents });
+      mockConnectionStore.isFullyOnline.mockReturnValue(true);
+
+      const store = useCalendarStore();
+      await store.fetchEvents(startDate, endDate, false, false, ["family", "personal"]);
+
+      expect(axios.get).toHaveBeenCalledWith("/api/calendar/events", {
+        params: {
+          start_date: startDate.toISOString(),
+          end_date: endDate.toISOString(),
+          source_ids: "family,personal",
+        },
+      });
+      expect(store.getEventsForSource(["personal", "family"])).toEqual([]);
+    });
+
     it("should use cached events when offline", async () => {
       const startDate = new Date("2024-01-01");
       const endDate = new Date("2024-01-31");

--- a/frontend/tests/unit/stores/config.spec.js
+++ b/frontend/tests/unit/stores/config.spec.js
@@ -127,8 +127,22 @@ describe("Config Store", () => {
     await store.fetchConfig();
 
     expect(store.dashboardLayout.regions).toEqual([
-      { id: "region-1", kind: "calendar", serviceId: null, size: 60, split: null },
-      { id: "region-2", kind: "service", serviceId: null, size: 40, split: null },
+      {
+        id: "region-1",
+        kind: "calendar",
+        serviceId: null,
+        instanceIds: [],
+        size: 60,
+        split: null,
+      },
+      {
+        id: "region-2",
+        kind: "service",
+        serviceId: null,
+        instanceIds: [],
+        size: 40,
+        split: null,
+      },
     ]);
     expect(store.dashboardScreens.activeScreenId).toBe("services");
     expect(store.dashboardScreens.screens[0].activeRegionId).toBe("region-2");

--- a/frontend/tests/unit/stores/images.spec.js
+++ b/frontend/tests/unit/stores/images.spec.js
@@ -50,6 +50,25 @@ describe("Images Store", () => {
       expect(store.error).toBe(null);
     });
 
+    it("should fetch images for selected source IDs", async () => {
+      const mockImages = {
+        images: [{ id: "1", filename: "image1.jpg", source: "family" }],
+      };
+
+      axios.get.mockResolvedValueOnce({ data: mockImages });
+      axios.get.mockResolvedValueOnce({
+        data: { image: mockImages.images[0] },
+      });
+
+      const store = useImagesStore();
+      await store.fetchImages(["family", "personal"]);
+
+      expect(axios.get).toHaveBeenCalledWith("/api/images/list", {
+        params: { source_ids: "family,personal" },
+      });
+      expect(store.getImagesForSource(["personal", "family"])).toEqual(mockImages.images);
+    });
+
     it("should fetch current image when images are available", async () => {
       const mockImages = {
         images: [{ id: "1", filename: "image1.jpg" }],

--- a/frontend/tests/unit/utils/layout.spec.js
+++ b/frontend/tests/unit/utils/layout.spec.js
@@ -129,8 +129,22 @@ describe("Layout Utilities", () => {
         preset: "split_two",
         direction: null,
         regions: [
-          { id: "region-1", kind: "calendar", serviceId: null, size: 65, split: null },
-          { id: "region-2", kind: "photos", serviceId: null, size: 35, split: null },
+          {
+            id: "region-1",
+            kind: "calendar",
+            serviceId: null,
+            instanceIds: [],
+            size: 65,
+            split: null,
+          },
+          {
+            id: "region-2",
+            kind: "photos",
+            serviceId: null,
+            instanceIds: [],
+            size: 35,
+            split: null,
+          },
         ],
       });
     });
@@ -155,8 +169,22 @@ describe("Layout Utilities", () => {
       });
 
       expect(layout.regions).toEqual([
-        { id: "region-1", kind: "service", serviceId: "weather", size: 70, split: null },
-        { id: "region-2", kind: "service", serviceId: "meals", size: 30, split: null },
+        {
+          id: "region-1",
+          kind: "service",
+          serviceId: "weather",
+          instanceIds: ["weather"],
+          size: 70,
+          split: null,
+        },
+        {
+          id: "region-2",
+          kind: "service",
+          serviceId: "meals",
+          instanceIds: ["meals"],
+          size: 30,
+          split: null,
+        },
       ]);
     });
 
@@ -200,7 +228,14 @@ describe("Layout Utilities", () => {
       const layout = createDashboardLayoutFromPreset("single");
 
       expect(layout.regions).toEqual([
-        { id: "region-1", kind: "calendar", serviceId: null, size: 100, split: null },
+        {
+          id: "region-1",
+          kind: "calendar",
+          serviceId: null,
+          instanceIds: [],
+          size: 100,
+          split: null,
+        },
       ]);
       expect(getRegionAxisStyle(layout.regions[0], "landscape")).toEqual({
         width: "100%",


### PR DESCRIPTION
## Summary
- Add per-region `instanceIds` selection so calendar and photo regions can show all, one, or multiple plugin instances.
- Keep service regions on a selected single instance while preserving legacy `serviceId` migration.
- Support calendar `source_ids` requests and source-keyed event state.
- Support image `source_ids` requests with independent cursor state per selected source set.
- Update dashboard layout settings, OpenAPI snapshot, generated API types, and focused tests.

## Validation
- `npm test -- --run tests/unit/utils/layout.spec.js tests/unit/stores/calendar.spec.js tests/unit/stores/images.spec.js tests/unit/components/DashboardDisplayTabs.spec.js tests/unit/components/PhotoSlideshow.spec.js tests/unit/components/DashboardRegionSurfaces.spec.js`
- `uv run pytest tests/unit/test_plugin_image_service.py tests/integration/test_api_images.py tests/contract/test_openapi_snapshot.py -q`
- `npm run build`