### PR TITLE
[codex] Fix logging and clock bar test coverage

### DIFF
--- a/backend/app/api/routes/calendar.py
+++ b/backend/app/api/routes/calendar.py
@@ -416,9 +416,6 @@ async def update_calendar_source(source_id: str, source: CalendarSource):
                 # Then unregister it
                 await plugin_manager.unregister(source_id)
             except Exception:
-                import logging
-
-                logger = logging.getLogger(__name__)
                 logger.exception("Error cleaning up disabled plugin {}", source_id)
 
     return source

--- a/backend/app/api/routes/config.py
+++ b/backend/app/api/routes/config.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
+from loguru import logger
 from pydantic import BaseModel, ConfigDict
 
 from app.config import settings
@@ -82,9 +83,6 @@ def get_frontend_version() -> str | None:
         return None
     except Exception as e:
         # File not found or error reading - log in debug mode
-        import logging
-
-        logger = logging.getLogger(__name__)
         logger.debug(f"Could not read frontend version: {e}")
         return None
 

--- a/backend/app/api/routes/health.py
+++ b/backend/app/api/routes/health.py
@@ -1,10 +1,7 @@
 """Health check endpoints."""
 
-import logging
-
 from fastapi import APIRouter
-
-logger = logging.getLogger(__name__)
+from loguru import logger
 
 router = APIRouter()
 
@@ -15,8 +12,8 @@ async def health_check():
     try:
         logger.info("Health check endpoint called")
         return {"status": "healthy"}
-    except Exception as e:
-        logger.exception(f"Error in health check: {e}")
+    except Exception:
+        logger.exception("Error in health check")
         raise
 
 
@@ -49,8 +46,8 @@ async def test_db_health_check():
             "database_connected": db_connected,
             "config_items_count": count,
         }
-    except Exception as e:
+    except Exception:
         import traceback
 
-        logger.exception(f"Database health check failed: {e}\n{traceback.format_exc()}")
+        logger.exception("Database health check failed\n{}", traceback.format_exc())
         raise

--- a/backend/app/api/routes/images.py
+++ b/backend/app/api/routes/images.py
@@ -1,15 +1,13 @@
 """Image endpoints."""
 
-import logging
 from pathlib import Path
 
 from fastapi import APIRouter, File, Query, UploadFile
 from fastapi.responses import FileResponse
+from loguru import logger
 
 from app.services import plugin_image_service
 from app.utils.errors import ErrorResponse
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter()
 

--- a/backend/app/api/routes/plugins/config.py
+++ b/backend/app/api/routes/plugins/config.py
@@ -1,16 +1,14 @@
 """Plugin configuration endpoints and utilities."""
 
 import json
-import logging
 from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, HTTPException
+from loguru import logger
 
 from app.plugins.loader import plugin_loader
 from app.services.config_service import config_service
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter()
 

--- a/backend/app/api/routes/plugins/github.py
+++ b/backend/app/api/routes/plugins/github.py
@@ -1,6 +1,5 @@
 """GitHub and local plugin installation endpoints."""
 
-import logging
 import re
 import shutil
 import tempfile
@@ -10,6 +9,7 @@ from typing import Any
 
 import httpx
 from fastapi import APIRouter, Body, HTTPException
+from loguru import logger
 
 from app.api.routes.plugins.management import _validate_just_installed_plugin
 from app.api.routes.plugins.themes import _register_theme_in_db
@@ -17,8 +17,6 @@ from app.config import settings
 from app.plugins.loader import plugin_loader
 from app.services.plugin_installer import plugin_installer
 from app.services.theme_installer import theme_installer
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -139,7 +137,7 @@ async def enumerate_plugins_from_github(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to enumerate plugins from GitHub: {e}", exc_info=True)
+        logger.exception("Failed to enumerate plugins from GitHub")
         error_detail = str(e) if str(e) else "Unknown error occurred"
         raise HTTPException(status_code=500, detail=f"Failed to enumerate plugins: {error_detail}")
     finally:
@@ -287,11 +285,11 @@ async def install_plugin_from_github(request: dict[str, Any] = Body(...)):
                 # Wrap in try-except to handle loading errors gracefully
                 try:
                     plugin_loader.load_installed_plugins()
-                except Exception as load_error:
-                    logger.warning(
-                        f"Plugin {manifest['id']} installed but failed to load: {load_error}. "
+                except Exception:
+                    logger.opt(exception=True).warning(
+                        "Plugin {} installed but failed to load. "
                         "It will be available after server restart.",
-                        exc_info=True,
+                        manifest["id"],
                     )
                     # Don't fail the installation - the plugin files are installed correctly
                     # It just needs a restart to be loaded
@@ -337,7 +335,7 @@ async def install_plugin_from_github(request: dict[str, Any] = Body(...)):
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to install plugin from GitHub: {e}", exc_info=True)
+        logger.exception("Failed to install plugin from GitHub")
         raise HTTPException(status_code=500, detail=f"Failed to install plugin: {str(e)}")
     finally:
         # Clean up temp files
@@ -525,5 +523,5 @@ async def install_plugin_from_local(request: dict[str, Any] = Body(...)):
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Failed to install plugin from local path: {e}", exc_info=True)
+        logger.exception("Failed to install plugin from local path")
         raise HTTPException(status_code=500, detail=f"Failed to install: {str(e)}")

--- a/backend/app/api/routes/plugins/instances.py
+++ b/backend/app/api/routes/plugins/instances.py
@@ -1,12 +1,12 @@
 """Plugin instance management endpoints."""
 
 import asyncio
-import logging
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Body, HTTPException
+from loguru import logger
 from pydantic import BaseModel
 
 from app.api.routes.plugins.config import mask_sensitive_config
@@ -15,8 +15,6 @@ from app.plugins.hooks import plugin_manager as hook_manager
 from app.plugins.loader import plugin_loader
 from app.plugins.manager import plugin_manager
 from app.services.event_system import event_system
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -483,10 +481,8 @@ async def update_plugin_instance(instance_id: str, instance_data: dict[str, Any]
                         f"Failed to emit plugin_instance_created event "
                         f"for instance {instance_id}: {e}"
                     )
-            except Exception as e:
-                logger.error(
-                    f"Error creating and starting plugin {instance_id}: {e}", exc_info=True
-                )
+            except Exception:
+                logger.exception("Error creating and starting plugin {}", instance_id)
                 plugin = None
 
     if plugin:
@@ -506,8 +502,8 @@ async def update_plugin_instance(instance_id: str, instance_data: dict[str, Any]
 
                         if isinstance(plugin, BackendPlugin):
                             await backend_plugin_scheduler.register_plugin_tasks(plugin)
-                    except Exception as e:
-                        logger.error(f"Error starting plugin {instance_id}: {e}", exc_info=True)
+                    except Exception:
+                        logger.exception("Error starting plugin {}", instance_id)
             else:
                 plugin.disable()
                 # Stop the plugin if it's running
@@ -521,15 +517,15 @@ async def update_plugin_instance(instance_id: str, instance_data: dict[str, Any]
                         if isinstance(plugin, BackendPlugin):
                             await backend_plugin_scheduler.unregister_plugin_tasks(instance_id)
                         await plugin.cleanup()
-                    except Exception as e:
-                        logger.warning(f"Error stopping plugin {instance_id}: {e}", exc_info=True)
+                    except Exception:
+                        logger.opt(exception=True).warning("Error stopping plugin {}", instance_id)
 
         # Update config if provided
         if updated_config is not None:
             try:
                 await plugin.configure(updated_config)
-            except Exception as e:
-                logger.warning(f"Error updating plugin {instance_id} config: {e}", exc_info=True)
+            except Exception:
+                logger.opt(exception=True).warning("Error updating plugin {} config", instance_id)
 
     # Emit plugin_instance_updated event if instance was updated (but not newly created)
     if (

--- a/backend/app/api/routes/plugins/management.py
+++ b/backend/app/api/routes/plugins/management.py
@@ -153,11 +153,10 @@ async def get_plugins(
     try:
         db_types_list = await PluginTypeDB.objects.all()
         db_types = {db_type.type_id: db_type for db_type in db_types_list}
-    except Exception as e:
-        logger.error(
-            f"[get_plugins] Failed to load plugin types from database: {e}. "
-            "This may indicate missing tables. Check database initialization.",
-            exc_info=True,
+    except Exception:
+        logger.exception(
+            "[get_plugins] Failed to load plugin types from database. "
+            "This may indicate missing tables. Check database initialization."
         )
         # Continue with empty dict - app won't crash but plugins won't load
         db_types = {}
@@ -264,8 +263,8 @@ async def get_plugins(
                     "version": theme_manifest.get("version", "1.0.0"),
                 }
                 result.append(theme_entry)
-        except Exception as e:
-            logger.error(f"[get_plugins] Error including themes: {e}", exc_info=True)
+        except Exception:
+            logger.exception("[get_plugins] Error including themes")
 
     return {"plugins": result, "total": len(result)}
 
@@ -972,7 +971,7 @@ async def get_plugin_data(
             await plugin_instance.initialize()
             plugin_instance.start()
         except Exception as e:
-            logger.error(f"Error initializing plugin {plugin_id}: {e}", exc_info=True)
+            logger.exception("Error initializing plugin {}", plugin_id)
             raise HTTPException(status_code=500, detail=f"Failed to initialize plugin: {str(e)}")
 
     try:
@@ -980,7 +979,7 @@ async def get_plugin_data(
         if data is not None:
             return data
     except Exception as e:
-        logger.error(f"Error calling fetch_service_data for {plugin_id}: {e}", exc_info=True)
+        logger.exception("Error calling fetch_service_data for {}", plugin_id)
         raise HTTPException(status_code=500, detail=f"Failed to fetch plugin data: {str(e)}")
 
     # If plugin returned None, it doesn't support data fetching
@@ -1248,7 +1247,7 @@ async def run_backend_plugin_task(plugin_id: str):
             "message": f"Plugin '{plugin_id}' does not support scheduled tasks",
         }
     except Exception as e:
-        logger.exception(f"Error running task for backend plugin {plugin_id}")
+        logger.exception("Error running task for backend plugin {}", plugin_id)
         return {
             "success": False,
             "message": f"Error running task: {str(e)}",

--- a/backend/app/api/routes/plugins/themes.py
+++ b/backend/app/api/routes/plugins/themes.py
@@ -1,14 +1,13 @@
 """Theme helper functions for plugin management."""
 
 import json
-import logging
 from pathlib import Path
 from typing import Any
 
+from loguru import logger
+
 from app.models.db_models import PluginTypeDB
 from app.plugins.base import PluginType
-
-logger = logging.getLogger(__name__)
 
 
 def _load_builtin_themes() -> dict[str, Any]:

--- a/backend/app/api/routes/system.py
+++ b/backend/app/api/routes/system.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import json
-import logging
 import os
 import re
 import shutil
@@ -14,11 +13,10 @@ from typing import Any
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import StreamingResponse
+from loguru import logger
 
 from app.config import settings
 from app.services.display_power_service import display_power_service
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -54,17 +52,17 @@ def _attempt_restart_calvin_service(service: str) -> bool:
                 text=True,
             )
             if result.returncode == 0:
-                logger.info("%s restart initiated via helper script", service)
+                logger.info("{} restart initiated via helper script", service)
                 return True
             error_msg = result.stderr or result.stdout or "Unknown error"
-            logger.warning("Helper script failed: %s", error_msg)
+            logger.warning("Helper script failed: {}", error_msg)
         except FileNotFoundError:
             logger.warning("sudo not found")
         except subprocess.TimeoutExpired:
             logger.info("Helper script timed out (but may have initiated)")
             return True
-        except Exception as e:
-            logger.error("Helper script error: %s", e, exc_info=True)
+        except Exception:
+            logger.exception("Helper script error")
 
     try:
         result = subprocess.run(
@@ -74,16 +72,16 @@ def _attempt_restart_calvin_service(service: str) -> bool:
             text=True,
         )
         if result.returncode == 0:
-            logger.info("%s restart initiated via systemctl restart", service)
+            logger.info("{} restart initiated via systemctl restart", service)
             return True
-        logger.warning("systemctl restart failed: %s", result.stderr or "Unknown error")
+        logger.warning("systemctl restart failed: {}", result.stderr or "Unknown error")
     except FileNotFoundError:
         logger.warning("systemctl not found")
     except subprocess.TimeoutExpired:
         logger.info("systemctl restart timed out (but may have initiated)")
         return True
-    except Exception as e:
-        logger.error("systemctl restart error: %s", e, exc_info=True)
+    except Exception:
+        logger.exception("systemctl restart error")
 
     return False
 
@@ -148,7 +146,7 @@ def _read_update_state(state_file: Path) -> dict[str, Any] | None:
             state = json.load(f)
         return state if isinstance(state, dict) else None
     except (OSError, json.JSONDecodeError):
-        logger.warning("Failed to read update state file: %s", state_file, exc_info=True)
+        logger.opt(exception=True).warning("Failed to read update state file: {}", state_file)
         return None
 
 
@@ -703,7 +701,7 @@ async def restart_frontend():
     except HTTPException:
         raise
     except Exception as e:
-        logger.error("Frontend restart error: %s", e, exc_info=True)
+        logger.exception("Frontend restart error")
         raise HTTPException(status_code=500, detail=f"Failed to restart frontend service: {str(e)}")
 
 
@@ -746,7 +744,7 @@ async def restart_backend():
     except HTTPException:
         raise
     except Exception as e:
-        logger.error("Backend restart error: %s", e, exc_info=True)
+        logger.exception("Backend restart error")
         raise HTTPException(status_code=500, detail=f"Failed to restart backend service: {str(e)}")
 
 
@@ -776,8 +774,8 @@ async def reboot_system():
         except subprocess.TimeoutExpired:
             logger.info("systemctl reboot timed out (but may have initiated)")
             reboot_attempted = True
-        except Exception as e:
-            logger.error(f"systemctl reboot error: {e}", exc_info=True)
+        except Exception:
+            logger.exception("systemctl reboot error")
 
         # Method 2: Use dbus to call systemd-logind (alternative to systemctl)
         # This might work if polkit rules are configured
@@ -807,8 +805,8 @@ async def reboot_system():
             except subprocess.TimeoutExpired:
                 logger.info("dbus reboot timed out (but may have initiated)")
                 reboot_attempted = True
-            except Exception as e:
-                logger.error(f"dbus reboot error: {e}", exc_info=True)
+            except Exception:
+                logger.exception("dbus reboot error")
 
         if reboot_attempted:
             return {"status": "success", "message": "System reboot initiated"}
@@ -825,5 +823,5 @@ async def reboot_system():
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Reboot error: {e}", exc_info=True)
+        logger.exception("Reboot error")
         raise HTTPException(status_code=500, detail=f"Failed to reboot system: {str(e)}")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,11 +1,9 @@
 """Configuration management."""
 
-import logging
 from pathlib import Path
 
+from loguru import logger
 from pydantic_settings import BaseSettings, SettingsConfigDict
-
-logger = logging.getLogger(__name__)
 
 
 class Settings(BaseSettings):
@@ -140,8 +138,8 @@ class Settings(BaseSettings):
                         shutil.copy2(wrong_path, db_path)
                         logger.info(f"Database migrated successfully to {db_path}")
                         # Old file is kept for safety - user can remove manually if needed
-                    except Exception as e:
-                        logger.warning(f"Failed to migrate database: {e}", exc_info=True)
+                    except Exception:
+                        logger.opt(exception=True).warning("Failed to migrate database")
                     break
 
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -4,6 +4,7 @@ import logging
 import os
 
 import databases
+from loguru import logger
 from sqlalchemy import MetaData
 
 from app.config import settings
@@ -51,7 +52,6 @@ async def connect_db():
     except Exception as e:
         # If PRAGMA commands fail, log but don't fail connection
         # (might happen if database is read-only or other issues)
-        logger = logging.getLogger(__name__)
         logger.warning(f"Failed to configure SQLite PRAGMA settings: {e}")
 
 

--- a/backend/app/plugins/calendar/google.py
+++ b/backend/app/plugins/calendar/google.py
@@ -198,11 +198,8 @@ class GoogleCalendarPlugin(CalendarPlugin):
                 f"{self.plugin_id}: {e}"
             )
             raise
-        except Exception as e:
-            logger.error(
-                f"[GOOGLE PLUGIN] Error fetching events from {self.plugin_id}: {e}",
-                exc_info=True,
-            )
+        except Exception:
+            logger.exception("[GOOGLE PLUGIN] Error fetching events from {}", self.plugin_id)
             raise
 
     async def validate_config(self, config: dict) -> bool:

--- a/backend/app/plugins/calendar/ical.py
+++ b/backend/app/plugins/calendar/ical.py
@@ -133,11 +133,8 @@ class ICalCalendarPlugin(CalendarPlugin):
                 e,
             )
             raise
-        except Exception as e:
-            logger.error(
-                f"[ICAL PLUGIN] Error fetching events from {self.plugin_id}: {e}",
-                exc_info=True,
-            )
+        except Exception:
+            logger.exception("[ICAL PLUGIN] Error fetching events from {}", self.plugin_id)
             raise
 
     async def validate_config(self, config: dict) -> bool:

--- a/backend/app/plugins/image/local.py
+++ b/backend/app/plugins/image/local.py
@@ -191,10 +191,6 @@ class LocalImagePlugin(ImagePlugin):
         Returns:
             List of image metadata dictionaries
         """
-        import logging
-
-        logger = logging.getLogger(__name__)
-
         logger.debug(f"[Local Images] scan_images() called for plugin {self.plugin_id}")
         logger.debug(f"[Local Images] image_dir: {self.image_dir}")
         logger.debug(f"[Local Images] image_dir exists: {self.image_dir.exists()}")

--- a/backend/app/plugins/loader.py
+++ b/backend/app/plugins/loader.py
@@ -159,11 +159,7 @@ class PluginLoader:
                     try:
                         plugin_types.append(PluginDefinition.from_raw(raw_definition))
                     except Exception as e:
-                        logger.error(
-                            "Error normalizing plugin type from hook result: {}",
-                            e,
-                            exc_info=True,
-                        )
+                        logger.exception("Error normalizing plugin type from hook result: {}", e)
         return plugin_types
 
     def create_plugin_instance(

--- a/backend/app/plugins/manager.py
+++ b/backend/app/plugins/manager.py
@@ -59,10 +59,9 @@ class PluginManager:
 
                     # Subscribe to events
                     event_system.subscribe(plugin.plugin_id, subscribed_events, event_handler)
-            except Exception as e:
-                logger.warning(
-                    f"Error subscribing backend plugin {plugin.plugin_id} to events: {e}",
-                    exc_info=True,
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Error subscribing backend plugin {} to events", plugin.plugin_id
                 )
 
     async def unregister(self, plugin_id: str) -> bool:
@@ -101,10 +100,9 @@ class PluginManager:
                 else:
                     # Unsubscribe from all if no specific events
                     event_system.unsubscribe(plugin.plugin_id)
-            except Exception as e:
-                logger.warning(
-                    f"Error unsubscribing backend plugin {plugin_id} from events: {e}",
-                    exc_info=True,
+            except Exception:
+                logger.opt(exception=True).warning(
+                    "Error unsubscribing backend plugin {} from events", plugin_id
                 )
 
         return True
@@ -160,10 +158,9 @@ class PluginManager:
                         except NotImplementedError:
                             # Plugin doesn't implement start_worker, that's fine
                             pass
-                        except Exception as e:
-                            logger.warning(
-                                f"Error starting worker for backend plugin {plugin.plugin_id}: {e}",
-                                exc_info=True,
+                        except Exception:
+                            logger.opt(exception=True).warning(
+                                "Error starting worker for backend plugin {}", plugin.plugin_id
                             )
 
                     # Mark as running after successful initialization
@@ -173,11 +170,10 @@ class PluginManager:
                     if isinstance(plugin, BackendPlugin):
                         try:
                             await backend_plugin_scheduler.register_plugin_tasks(plugin)
-                        except Exception as e:
-                            logger.error(
-                                f"Error registering scheduled tasks for backend plugin "
-                                f"{plugin.plugin_id}: {e}",
-                                exc_info=True,
+                        except Exception:
+                            logger.exception(
+                                "Error registering scheduled tasks for backend plugin {}",
+                                plugin.plugin_id,
                             )
                 except Exception:
                     logger.exception("Error initializing plugin {}", plugin.plugin_id)
@@ -194,11 +190,10 @@ class PluginManager:
                 if isinstance(plugin, BackendPlugin):
                     try:
                         await backend_plugin_scheduler.unregister_plugin_tasks(plugin.plugin_id)
-                    except Exception as e:
-                        logger.warning(
-                            f"Error unregistering scheduled tasks for backend plugin "
-                            f"{plugin.plugin_id}: {e}",
-                            exc_info=True,
+                    except Exception:
+                        logger.opt(exception=True).warning(
+                            "Error unregistering scheduled tasks for backend plugin {}",
+                            plugin.plugin_id,
                         )
 
                 # Stop plugin before cleanup
@@ -211,10 +206,9 @@ class PluginManager:
                     except NotImplementedError:
                         # Plugin doesn't implement stop_worker, that's fine
                         pass
-                    except Exception as e:
-                        logger.warning(
-                            f"Error stopping worker for backend plugin {plugin.plugin_id}: {e}",
-                            exc_info=True,
+                    except Exception:
+                        logger.opt(exception=True).warning(
+                            "Error stopping worker for backend plugin {}", plugin.plugin_id
                         )
 
                 await plugin.cleanup()
@@ -248,10 +242,9 @@ class PluginManager:
                     except NotImplementedError:
                         # Plugin doesn't implement start_worker, that's fine
                         pass
-                    except Exception as e:
-                        logger.warning(
-                            f"Error starting worker for backend plugin {plugin_id}: {e}",
-                            exc_info=True,
+                    except Exception:
+                        logger.opt(exception=True).warning(
+                            "Error starting worker for backend plugin {}", plugin_id
                         )
 
                 plugin.start()
@@ -260,11 +253,9 @@ class PluginManager:
                 if isinstance(plugin, BackendPlugin):
                     try:
                         await backend_plugin_scheduler.register_plugin_tasks(plugin)
-                    except Exception as e:
-                        logger.error(
-                            f"Error registering scheduled tasks for backend plugin "
-                            f"{plugin_id}: {e}",
-                            exc_info=True,
+                    except Exception:
+                        logger.exception(
+                            "Error registering scheduled tasks for backend plugin {}", plugin_id
                         )
 
                     # Subscribe to events if not already subscribed
@@ -291,10 +282,9 @@ class PluginManager:
 
                                 # Subscribe to events
                                 event_system.subscribe(plugin_id, subscribed_events, event_handler)
-                    except Exception as e:
-                        logger.warning(
-                            f"Error subscribing backend plugin {plugin_id} to events: {e}",
-                            exc_info=True,
+                    except Exception:
+                        logger.opt(exception=True).warning(
+                            "Error subscribing backend plugin {} to events", plugin_id
                         )
 
             return True
@@ -325,11 +315,9 @@ class PluginManager:
                 if isinstance(plugin, BackendPlugin):
                     try:
                         await backend_plugin_scheduler.unregister_plugin_tasks(plugin_id)
-                    except Exception as e:
-                        logger.warning(
-                            f"Error unregistering scheduled tasks for backend plugin "
-                            f"{plugin_id}: {e}",
-                            exc_info=True,
+                    except Exception:
+                        logger.opt(exception=True).warning(
+                            "Error unregistering scheduled tasks for backend plugin {}", plugin_id
                         )
 
                 plugin.stop()
@@ -341,10 +329,9 @@ class PluginManager:
                     except NotImplementedError:
                         # Plugin doesn't implement stop_worker, that's fine
                         pass
-                    except Exception as e:
-                        logger.warning(
-                            f"Error stopping worker for backend plugin {plugin_id}: {e}",
-                            exc_info=True,
+                    except Exception:
+                        logger.opt(exception=True).warning(
+                            "Error stopping worker for backend plugin {}", plugin_id
                         )
 
                 await plugin.cleanup()

--- a/backend/app/plugins/registry/loader.py
+++ b/backend/app/plugins/registry/loader.py
@@ -1,13 +1,11 @@
 """Plugin loading logic - loading plugin types and instances from database."""
 
-import logging
+from loguru import logger
 
 from app.models.db_models import PluginDB, PluginTypeDB
 from app.plugins.definitions import PluginDefinition
 from app.plugins.loader import plugin_loader
 from app.plugins.manager import plugin_manager as instance_manager
-
-logger = logging.getLogger(__name__)
 
 
 async def load_plugin_types() -> None:
@@ -86,9 +84,8 @@ async def load_plugin_types() -> None:
         except Exception as e:
             # Log the error and mark plugin as broken
             error_message = str(e)
-            logger.error(
-                f"Error loading plugin type {type_id or 'unknown'}: {error_message}",
-                exc_info=True,
+            logger.exception(
+                "Error loading plugin type {}: {}", type_id or "unknown", error_message
             )
 
             if type_id:
@@ -120,11 +117,8 @@ async def load_plugin_types() -> None:
 
                 try:
                     await _save_error_status()
-                except Exception as db_error:
-                    logger.error(
-                        f"Error updating database for broken plugin {type_id}: {db_error}",
-                        exc_info=True,
-                    )
+                except Exception:
+                    logger.exception("Error updating database for broken plugin {}", type_id)
 
 
 async def load_plugin_instances() -> None:
@@ -141,10 +135,9 @@ async def load_plugin_instances() -> None:
                 try:
                     await existing.cleanup()
                     await instance_manager.unregister(db_plugin.id)
-                except Exception as e:
-                    logger.warning(
-                        f"Error cleaning up disabled plugin {db_plugin.id}: {e}",
-                        exc_info=True,
+                except Exception:
+                    logger.opt(exception=True).warning(
+                        "Error cleaning up disabled plugin {}", db_plugin.id
                     )
             continue
 
@@ -159,10 +152,8 @@ async def load_plugin_instances() -> None:
                     # Plugin should already be enabled (we only process enabled plugins)
                     if not existing.enabled:
                         existing.enable()
-                except Exception as e:
-                    logger.error(
-                        f"Error updating existing plugin {db_plugin.id}: {e}", exc_info=True
-                    )
+                except Exception:
+                    logger.exception("Error updating existing plugin {}", db_plugin.id)
                     # Disable plugin on error
                     existing.disable()
                     db_plugin.enabled = False
@@ -182,11 +173,11 @@ async def load_plugin_instances() -> None:
                     name=db_plugin.name,
                     config=plugin_config_with_enabled,
                 )
-            except Exception as e:
-                logger.error(
-                    f"Error creating plugin instance {db_plugin.id} "
-                    f"(type: {db_plugin.type_id}): {e}",
-                    exc_info=True,
+            except Exception:
+                logger.exception(
+                    "Error creating plugin instance {} (type: {})",
+                    db_plugin.id,
+                    db_plugin.type_id,
                 )
                 # Mark plugin as disabled in database on error
                 db_plugin.enabled = False
@@ -220,23 +211,17 @@ async def load_plugin_instances() -> None:
                     try:
                         await plugin.initialize()
                         plugin.start()
-                    except Exception as init_error:
-                        logger.error(
-                            f"Error initializing plugin {db_plugin.id}: {init_error}",
-                            exc_info=True,
-                        )
+                    except Exception:
+                        logger.exception("Error initializing plugin {}", db_plugin.id)
                         plugin.stop()
-                except Exception as e:
-                    logger.error(f"Error configuring plugin {db_plugin.id}: {e}", exc_info=True)
+                except Exception:
+                    logger.exception("Error configuring plugin {}", db_plugin.id)
                     # Only disable this specific plugin on error
                     try:
                         db_plugin.enabled = False
                         await db_plugin.save_with_timestamp()
-                    except Exception as db_error:
-                        logger.error(
-                            f"Error updating database for plugin {db_plugin.id}: {db_error}",
-                            exc_info=True,
-                        )
+                    except Exception:
+                        logger.exception("Error updating database for plugin {}", db_plugin.id)
             else:
                 # Plugin creation returned None - this could be normal
                 # if plugin type isn't registered
@@ -250,12 +235,9 @@ async def load_plugin_instances() -> None:
                 # Don't disable - the plugin might work later
                 # when the plugin type is registered
 
-        except Exception as e:
+        except Exception:
             # Catch-all for any unexpected errors
-            logger.error(
-                f"Unexpected error loading plugin instance {db_plugin.id}: {e}",
-                exc_info=True,
-            )
+            logger.exception("Unexpected error loading plugin instance {}", db_plugin.id)
             # Disable plugin on error
             try:
                 db_plugin.enabled = False

--- a/backend/app/plugins/registry/manager.py
+++ b/backend/app/plugins/registry/manager.py
@@ -1,13 +1,12 @@
 """Plugin registration and unregistration logic."""
 
-import logging
 from typing import Any
+
+from loguru import logger
 
 from app.models.db_models import PluginDB, PluginTypeDB
 from app.plugins.loader import plugin_loader
 from app.plugins.manager import plugin_manager as instance_manager
-
-logger = logging.getLogger(__name__)
 
 
 async def register_plugin(
@@ -105,10 +104,9 @@ async def unregister_plugin(plugin_id: str) -> bool:
     if plugin:
         try:
             await plugin.cleanup()
-        except Exception as e:
-            logger.warning(
-                f"Error cleaning up plugin {plugin_id} during unregister: {e}",
-                exc_info=True,
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Error cleaning up plugin {} during unregister", plugin_id
             )
             # Continue with deletion even if cleanup fails
 
@@ -137,20 +135,14 @@ async def unregister_plugin(plugin_id: str) -> bool:
                     deleted_from_db = False
                 else:
                     logger.info(f"Verified: Plugin {plugin_id} successfully removed from database")
-            except Exception as e:
-                logger.error(
-                    f"Error deleting plugin {plugin_id} from database: {e}",
-                    exc_info=True,
-                )
+            except Exception:
+                logger.exception("Error deleting plugin {} from database", plugin_id)
                 deleted_from_db = False
                 raise
         else:
             logger.warning(f"Plugin {plugin_id} not found in database during unregister")
-    except Exception as e:
-        logger.error(
-            f"Unexpected error during database deletion of {plugin_id}: {e}",
-            exc_info=True,
-        )
+    except Exception:
+        logger.exception("Unexpected error during database deletion of {}", plugin_id)
         # Don't re-raise here - we want to continue and unregister from manager
         # But mark as not deleted
         deleted_from_db = False

--- a/backend/app/plugins/utils/instance_manager.py
+++ b/backend/app/plugins/utils/instance_manager.py
@@ -5,15 +5,14 @@ that eliminates the need for plugins to implement hundreds of lines of
 boilerplate instance management code.
 """
 
-import logging
 from collections.abc import Callable
 from typing import Any
+
+from loguru import logger
 
 from app.models.db_models import PluginDB
 from app.plugins.manager import plugin_manager
 from app.plugins.registry import plugin_registry
-
-logger = logging.getLogger(__name__)
 
 
 class InstanceManagerConfig:
@@ -183,8 +182,8 @@ async def handle_plugin_config_update_generic(
                 if not existing_plugin:
                     await db_instance.delete()
                     db_instance = None
-    except Exception as e:
-        logger.warning(f"[{type_id}] Error querying database: {e}", exc_info=True)
+    except Exception:
+        logger.opt(exception=True).warning("[{}] Error querying database", type_id)
         db_instance = None
 
     # Determine enabled status
@@ -266,7 +265,7 @@ async def handle_plugin_config_update_generic(
                 }
             raise
         except Exception as e:
-            logger.error(f"[{type_id}] Failed to create instance: {e}", exc_info=True)
+            logger.exception("[{}] Failed to create instance", type_id)
             return {"instance_created": False, "error": str(e)}
     else:
         # Update existing instance
@@ -301,16 +300,16 @@ async def handle_plugin_config_update_generic(
                     try:
                         await plugin.initialize()
                         plugin.start()
-                    except Exception as e:
-                        logger.error(f"[{type_id}] Error starting plugin: {e}", exc_info=True)
+                    except Exception:
+                        logger.exception("[{}] Error starting plugin", type_id)
             else:
                 plugin.disable()
                 if plugin.is_running():
                     try:
                         plugin.stop()
                         await plugin.cleanup()
-                    except Exception as e:
-                        logger.warning(f"[{type_id}] Error stopping plugin: {e}", exc_info=True)
+                    except Exception:
+                        logger.opt(exception=True).warning("[{}] Error stopping plugin", type_id)
 
             result = {
                 "instance_updated": True,
@@ -366,9 +365,7 @@ async def handle_plugin_config_update_generic(
                         "warning": "Plugin instance updated in DB but not registered in manager",
                     }
             except Exception as e:
-                logger.error(
-                    f"[{type_id}] Failed to register existing instance: {e}", exc_info=True
-                )
+                logger.exception("[{}] Failed to register existing instance", type_id)
                 # Still update the DB entry even if registration fails
                 result = {
                     "instance_updated": True,

--- a/backend/app/services/backend_scheduler.py
+++ b/backend/app/services/backend_scheduler.py
@@ -71,10 +71,8 @@ class BackendPluginScheduler:
                         "Expected format: 'minute hour day month day_of_week'"
                     )
                     return
-            except Exception as e:
-                logger.error(
-                    f"Error parsing cron expression for plugin {plugin_id}: {e}", exc_info=True
-                )
+            except Exception:
+                logger.exception("Error parsing cron expression for plugin {}", plugin_id)
                 return
         elif "interval" in schedule_config:
             # Interval-based scheduling (seconds)
@@ -88,8 +86,8 @@ class BackendPluginScheduler:
                         f"Invalid interval for plugin {plugin_id}: {interval}. Must be > 0"
                     )
                     return
-            except (ValueError, TypeError) as e:
-                logger.error(f"Error parsing interval for plugin {plugin_id}: {e}", exc_info=True)
+            except (ValueError, TypeError):
+                logger.exception("Error parsing interval for plugin {}", plugin_id)
                 return
         else:
             logger.warning(
@@ -126,10 +124,8 @@ class BackendPluginScheduler:
                             f"Scheduled task for plugin {plugin_id} failed: "
                             f"{result.get('message', 'Unknown error')}"
                         )
-            except Exception as e:
-                logger.error(
-                    f"Error executing scheduled task for plugin {plugin_id}: {e}", exc_info=True
-                )
+            except Exception:
+                logger.exception("Error executing scheduled task for plugin {}", plugin_id)
 
         # Register task with scheduler
         job_id = f"backend_plugin_{plugin_id}"
@@ -152,10 +148,8 @@ class BackendPluginScheduler:
                 f"Registered scheduled task for plugin {plugin_id}: {trigger_description} "
                 f"(max_concurrent: {max_concurrent})"
             )
-        except Exception as e:
-            logger.error(
-                f"Error registering scheduled task for plugin {plugin_id}: {e}", exc_info=True
-            )
+        except Exception:
+            logger.exception("Error registering scheduled task for plugin {}", plugin_id)
 
     async def unregister_plugin_tasks(self, plugin_id: str) -> None:
         """Unregister scheduled tasks for a plugin.
@@ -172,9 +166,9 @@ class BackendPluginScheduler:
                 self.scheduler.remove_job(job_id)
             del self._registered_tasks[plugin_id]
             logger.info(f"Unregistered scheduled task for plugin {plugin_id}")
-        except Exception as e:
-            logger.warning(
-                f"Error unregistering scheduled task for plugin {plugin_id}: {e}", exc_info=True
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Error unregistering scheduled task for plugin {}", plugin_id
             )
             # Clean up entry even if removal failed
             self._registered_tasks.pop(plugin_id, None)

--- a/backend/app/services/event_system.py
+++ b/backend/app/services/event_system.py
@@ -88,10 +88,7 @@ class EventSystem:
                 result = await handler(event_type, event_data)
                 return {"plugin_id": plugin_id, "success": True, "result": result}
             except Exception as e:
-                logger.error(
-                    f"Error in event handler {plugin_id} for event {event_type}: {e}",
-                    exc_info=True,
-                )
+                logger.exception("Error in event handler {} for event {}", plugin_id, event_type)
                 return {"plugin_id": plugin_id, "success": False, "error": str(e)}
 
         return asyncio.create_task(safe_handler())
@@ -105,10 +102,7 @@ class EventSystem:
         results = await asyncio.gather(*tasks, return_exceptions=True)
         for result, (plugin_id, _) in zip(results, handlers):
             if isinstance(result, Exception):
-                logger.error(
-                    f"Exception in event handler {plugin_id}: {result}",
-                    exc_info=True,
-                )
+                logger.opt(exception=result).error("Exception in event handler {}", plugin_id)
             elif result and not result.get("success", False):
                 logger.warning(f"Event handler {plugin_id} returned error: {result.get('error')}")
 

--- a/backend/app/services/plugin_installer.py
+++ b/backend/app/services/plugin_installer.py
@@ -1,13 +1,14 @@
 """Plugin installation service for managing installed plugins."""
 
 import json
-import logging
 import shutil
 import subprocess
 import sys
 import zipfile
 from pathlib import Path
 from typing import Any
+
+from loguru import logger
 
 from app.config import settings
 from app.plugins.definitions import CURRENT_PLUGIN_PROTOCOL_VERSION
@@ -20,8 +21,6 @@ from app.services.validation import (
     validate_plugin_type,
     validate_zip_structure,
 )
-
-logger = logging.getLogger(__name__)
 
 
 class PluginInstaller:

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -1,15 +1,13 @@
 """Scheduler service for periodic calendar updates."""
 
-import logging
 from datetime import datetime
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
+from loguru import logger
 
 from app.services import plugin_calendar_service
 from app.services.config_service import config_service
-
-logger = logging.getLogger(__name__)
 
 
 class CalendarScheduler:
@@ -64,8 +62,8 @@ class CalendarScheduler:
             await plugin_calendar_service.clear_cache()
             await plugin_calendar_service.preload_months(months_to_preload=1)
             logger.info(f"Calendar cache refreshed at {datetime.now()}")
-        except Exception as e:
-            logger.error(f"Error refreshing calendar cache: {e}", exc_info=True)
+        except Exception:
+            logger.exception("Error refreshing calendar cache")
 
     async def set_refresh_interval(self, minutes: int):
         """Set the refresh interval in minutes."""

--- a/backend/app/services/theme_installer.py
+++ b/backend/app/services/theme_installer.py
@@ -1,11 +1,12 @@
 """Theme installation service for managing installed themes (file operations only)."""
 
 import json
-import logging
 import shutil
 import zipfile
 from pathlib import Path
 from typing import Any
+
+from loguru import logger
 
 from app.services.validation import (
     validate_directory_structure,
@@ -14,8 +15,6 @@ from app.services.validation import (
     validate_theme_variables,
     validate_zip_structure,
 )
-
-logger = logging.getLogger(__name__)
 
 # Constants
 REQUIRED_THEME_FIELDS = ["id", "name", "version", "variables"]

--- a/backend/app/utils/db_init.py
+++ b/backend/app/utils/db_init.py
@@ -5,14 +5,12 @@ It ensures all tables are created and migrations are run properly.
 """
 
 import asyncio
-import logging
 from pathlib import Path
 
 import databases
+from loguru import logger
 
 from app.database import metadata
-
-logger = logging.getLogger(__name__)
 
 
 async def initialize_database(

--- a/backend/app/utils/db_retry.py
+++ b/backend/app/utils/db_retry.py
@@ -1,14 +1,12 @@
 """Database retry utilities for handling SQLite concurrency issues."""
 
 import asyncio
-import logging
 from collections.abc import Callable
 from functools import wraps
 from typing import Any, TypeVar
 
+from loguru import logger
 from sqlalchemy.exc import OperationalError
-
-logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 

--- a/frontend/tests/unit/components/ClockBarHorizontal.spec.js
+++ b/frontend/tests/unit/components/ClockBarHorizontal.spec.js
@@ -26,6 +26,12 @@ describe("ClockBarHorizontal", () => {
     setActivePinia(createPinia());
   });
 
+  const globalMountOptions = {
+    stubs: {
+      BarActionCluster: true,
+    },
+  };
+
   it("should render when enabled and showInNonKiosk is true and UI is visible", () => {
     const store = useConfigStore();
     store.showUI = true;
@@ -38,7 +44,7 @@ describe("ClockBarHorizontal", () => {
         enabled: true,
       },
       global: {
-        plugins: [],
+        ...globalMountOptions,
       },
     });
 
@@ -57,7 +63,7 @@ describe("ClockBarHorizontal", () => {
         enabled: true,
       },
       global: {
-        plugins: [],
+        ...globalMountOptions,
       },
     });
 
@@ -76,7 +82,7 @@ describe("ClockBarHorizontal", () => {
         enabled: true,
       },
       global: {
-        plugins: [],
+        ...globalMountOptions,
       },
     });
 
@@ -92,7 +98,7 @@ describe("ClockBarHorizontal", () => {
         enabled: false,
       },
       global: {
-        plugins: [],
+        ...globalMountOptions,
       },
     });
 
@@ -111,7 +117,7 @@ describe("ClockBarHorizontal", () => {
         enabled: true,
       },
       global: {
-        plugins: [],
+        ...globalMountOptions,
       },
     });
 
@@ -130,7 +136,7 @@ describe("ClockBarHorizontal", () => {
         enabled: true,
       },
       global: {
-        plugins: [],
+        ...globalMountOptions,
       },
     });
 
@@ -151,7 +157,7 @@ describe("ClockBarHorizontal", () => {
         enabled: true,
       },
       global: {
-        plugins: [],
+        ...globalMountOptions,
       },
     });
 
@@ -171,7 +177,7 @@ describe("ClockBarHorizontal", () => {
         enabled: true,
       },
       global: {
-        plugins: [],
+        ...globalMountOptions,
       },
     });
 
@@ -191,7 +197,7 @@ describe("ClockBarHorizontal", () => {
         enabled: true,
       },
       global: {
-        plugins: [],
+        ...globalMountOptions,
       },
     });
 

--- a/frontend/tests/unit/components/ClockBarVertical.spec.js
+++ b/frontend/tests/unit/components/ClockBarVertical.spec.js
@@ -2,6 +2,7 @@
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { mount } from "@vue/test-utils";
+import { nextTick } from "vue";
 import { setActivePinia, createPinia } from "pinia";
 import ClockBarVertical from "@/components/ClockBarVertical.vue";
 import { useConfigStore } from "@/stores/config";
@@ -26,6 +27,17 @@ describe("ClockBarVertical", () => {
     setActivePinia(createPinia());
   });
 
+  const globalMountOptions = {
+    stubs: {
+      BarActionCluster: true,
+      PluginStatusbarItems: {
+        props: ["orientation"],
+        template:
+          '<div class="plugin-statusbar-stub" :data-orientation="orientation || \'horizontal\'" />',
+      },
+    },
+  };
+
   it("should render when enabled and showInNonKiosk is true and UI is visible", () => {
     const store = useConfigStore();
     store.showUI = true;
@@ -38,7 +50,7 @@ describe("ClockBarVertical", () => {
         enabled: true,
       },
       global: {
-        plugins: [],
+        ...globalMountOptions,
       },
     });
 
@@ -57,7 +69,7 @@ describe("ClockBarVertical", () => {
         enabled: true,
       },
       global: {
-        plugins: [],
+        ...globalMountOptions,
       },
     });
 
@@ -76,7 +88,7 @@ describe("ClockBarVertical", () => {
         enabled: true,
       },
       global: {
-        plugins: [],
+        ...globalMountOptions,
       },
     });
 
@@ -92,7 +104,7 @@ describe("ClockBarVertical", () => {
         enabled: false,
       },
       global: {
-        plugins: [],
+        ...globalMountOptions,
       },
     });
 
@@ -111,7 +123,7 @@ describe("ClockBarVertical", () => {
         enabled: true,
       },
       global: {
-        plugins: [],
+        ...globalMountOptions,
       },
     });
 
@@ -132,7 +144,7 @@ describe("ClockBarVertical", () => {
         enabled: true,
       },
       global: {
-        plugins: [],
+        ...globalMountOptions,
       },
     });
 
@@ -156,7 +168,7 @@ describe("ClockBarVertical", () => {
         enabled: true,
       },
       global: {
-        plugins: [],
+        ...globalMountOptions,
       },
     });
 
@@ -177,7 +189,7 @@ describe("ClockBarVertical", () => {
         enabled: true,
       },
       global: {
-        plugins: [],
+        ...globalMountOptions,
       },
     });
 
@@ -197,7 +209,7 @@ describe("ClockBarVertical", () => {
         enabled: true,
       },
       global: {
-        plugins: [],
+        ...globalMountOptions,
       },
     });
 
@@ -217,12 +229,39 @@ describe("ClockBarVertical", () => {
         enabled: true,
       },
       global: {
-        plugins: [],
+        ...globalMountOptions,
       },
     });
 
     const timeElement = wrapper.find(".clock-time");
     expect(timeElement.exists()).toBe(true);
     expect(timeElement.attributes("style")).toContain("font-size: 18px");
+  });
+
+  it("should render statusbar items vertically when weather is enabled", async () => {
+    const store = useConfigStore();
+    store.showUI = true;
+    store.clockBarShowWeather = false;
+
+    const wrapper = mount(ClockBarVertical, {
+      props: {
+        position: "left",
+        showInNonKiosk: true,
+        showInKiosk: false,
+        enabled: true,
+      },
+      global: {
+        ...globalMountOptions,
+      },
+    });
+
+    expect(wrapper.find(".plugin-statusbar-stub").exists()).toBe(false);
+
+    store.clockBarShowWeather = true;
+    await nextTick();
+
+    const statusbar = wrapper.find(".plugin-statusbar-stub");
+    expect(statusbar.exists()).toBe(true);
+    expect(statusbar.attributes("data-orientation")).toBe("vertical");
   });
 });

--- a/frontend/tests/unit/components/ClockSettingsTab.spec.js
+++ b/frontend/tests/unit/components/ClockSettingsTab.spec.js
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import ClockSettingsTab from "@/components/settings/tabs/dashboard/ClockSettingsTab.vue";
+
+const baseConfig = {
+  orientation: "landscape",
+  clockBarMode: "vertical",
+  clockBarPosition: "left",
+  clockBarLayout: "single-line",
+  clockBarFontSize: 16,
+  clockBarDateFontSize: 14,
+  clockBarPadding: 8,
+  clockShowDate: true,
+  clockShowSeconds: false,
+  clockBarShowInKiosk: true,
+  clockBarShowLogo: true,
+  clockBarShowWeather: true,
+};
+
+describe("ClockSettingsTab", () => {
+  function mountTab(configOverrides = {}) {
+    return mount(ClockSettingsTab, {
+      props: {
+        config: { ...baseConfig, ...configOverrides },
+      },
+      global: {
+        stubs: {
+          CollapsibleSection: { template: "<section><slot /></section>" },
+          SettingItem: { template: "<div><slot /></div>" },
+          ClockBarFontSizePicker: true,
+        },
+      },
+    });
+  }
+
+  it("shows the weather toggle for vertical clock bars", () => {
+    const wrapper = mountTab();
+
+    const weatherToggle = wrapper.find('input[name="clockBarShowWeather"]');
+    expect(weatherToggle.exists()).toBe(true);
+    expect(weatherToggle.element.checked).toBe(true);
+  });
+
+  it("keeps the weather toggle available for horizontal clock bars", () => {
+    const wrapper = mountTab({
+      clockBarMode: "horizontal",
+      clockBarPosition: "top",
+    });
+
+    const weatherToggle = wrapper.find('input[name="clockBarShowWeather"]');
+    expect(weatherToggle.exists()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Migrate app-owned stdlib logging usage to loguru while preserving stdlib logging only for interception and third-party logger configuration.
- Convert loguru call sites using exc_info=True to logger.exception(...).
- Stub BarActionCluster in ClockBar specs to remove router injection warning noise.
- Add regression coverage for vertical clock bar statusbar/weather behavior and the vertical-mode weather setting.

## Why

This addresses the quick-win issue sweep around unified backend logging and noisy ClockBar tests, and locks down the existing vertical weather parity wiring for the clock bar.

## Validation

- npm test -- ClockBarHorizontal.spec.js ClockBarVertical.spec.js --run
- npm test -- ClockBarVertical.spec.js ClockSettingsTab.spec.js --run
- npm run lint
- backend\.venv\Scripts\ruff.exe check backend\app
- backend\.venv\Scripts\python.exe -m compileall backend\app
- backend\.venv\Scripts\pytest.exe tests\unit -q