### PR TITLE
Per-screen clock bar + clock bar settings UX rework

### DIFF
--- a/frontend/src/components/settings/tabs/clock-bar/ClockBarItemsTab.vue
+++ b/frontend/src/components/settings/tabs/clock-bar/ClockBarItemsTab.vue
@@ -2,41 +2,61 @@
   <div class="clock-bar-items-tab">
     <CollapsibleSection title="Bar Items" icon="🧩" :expanded="true">
       <p class="section-description">
-        Pick which plugin tiles appear in the clock bar. Toggling here flips each instance's
-        <code>show_in_statusbar</code> flag, so plugins continue to control their own preview and
-        data &mdash; this menu just chooses which ones to show.
+        Choose which plugin tiles appear in the clock bar. Each tile keeps its own preview and live
+        data — toggling here just controls whether it's shown.
       </p>
 
       <div v-if="loading" class="state-message">Loading installed plugins&hellip;</div>
 
       <div v-else-if="barCapableServices.length === 0" class="state-message empty-state">
-        <p>No installed plugins expose a status bar item.</p>
+        <p>No installed plugins expose a clock bar tile.</p>
         <p>
-          Install a plugin that ships a <code>statusbar_schema</code> to add tiles here. Manage
-          installs in the <strong>Plugins</strong> category.
+          Install a plugin that ships a status bar item to add tiles here. Manage installs in the
+          <strong>Plugins</strong> category.
         </p>
       </div>
 
-      <ul v-else class="items-list">
-        <li v-for="service in barCapableServices" :key="service.id" class="item-row">
-          <div class="preview" :title="`Live preview of ${service.name}`">
-            <SchemaStatusbarItem :service-id="service.id" :schema="service.statusbar_schema" />
-          </div>
-          <div class="meta">
-            <div class="title">{{ service.name }}</div>
-            <div class="subtitle">{{ service.plugin_name || service.plugin_id }}</div>
-          </div>
-          <label class="toggle" :class="{ saving: pendingId === service.id }">
-            <input
-              type="checkbox"
-              :checked="isVisible(service)"
-              :disabled="pendingId === service.id"
-              @change="toggle(service, $event.target.checked)"
-            />
-            <span>{{ isVisible(service) ? "Shown" : "Hidden" }}</span>
-          </label>
-        </li>
-      </ul>
+      <template v-else>
+        <p class="items-summary">
+          <strong>{{ visibleCount }}</strong> of {{ barCapableServices.length }} tile{{
+            barCapableServices.length === 1 ? "" : "s"
+          }}
+          shown
+        </p>
+
+        <ul class="items-list">
+          <li
+            v-for="service in barCapableServices"
+            :key="service.id"
+            class="item-row"
+            :class="{ 'item-row-hidden': !isVisible(service) }"
+          >
+            <div class="preview" :title="`Live preview of ${service.name}`">
+              <SchemaStatusbarItem :service-id="service.id" :schema="service.statusbar_schema" />
+            </div>
+            <div class="meta">
+              <div class="title">{{ service.name }}</div>
+              <div class="subtitle">{{ service.plugin_name || service.plugin_id }}</div>
+            </div>
+            <label
+              class="switch"
+              :class="{ 'switch-on': isVisible(service), saving: pendingId === service.id }"
+              :title="isVisible(service) ? 'Click to hide' : 'Click to show'"
+            >
+              <input
+                type="checkbox"
+                :checked="isVisible(service)"
+                :disabled="pendingId === service.id"
+                @change="toggle(service, $event.target.checked)"
+              />
+              <span class="switch-track" aria-hidden="true">
+                <span class="switch-thumb" />
+              </span>
+              <span class="switch-label">{{ isVisible(service) ? "Shown" : "Hidden" }}</span>
+            </label>
+          </li>
+        </ul>
+      </template>
 
       <div v-if="errorMessage" class="error-message" role="alert">{{ errorMessage }}</div>
     </CollapsibleSection>
@@ -60,6 +80,8 @@ const errorMessage = ref("");
 const barCapableServices = computed(() =>
   webServicesStore.services.filter(s => s.statusbar_schema?.kind)
 );
+
+const visibleCount = computed(() => barCapableServices.value.filter(isVisible).length);
 
 function asBoolean(value) {
   if (typeof value === "string") {
@@ -175,23 +197,80 @@ onMounted(async () => {
   color: var(--text-secondary);
 }
 
-.toggle {
+.items-summary {
+  margin: 0 0 0.6rem;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.items-summary strong {
+  color: var(--text-primary);
+}
+
+.item-row-hidden {
+  opacity: 0.55;
+}
+
+.switch {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.55rem;
   cursor: pointer;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   color: var(--text-primary);
   user-select: none;
 }
 
-.toggle.saving {
+.switch input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  width: 0;
+  height: 0;
+}
+
+.switch-track {
+  position: relative;
+  width: 2.2rem;
+  height: 1.2rem;
+  border-radius: 999px;
+  background: var(--border-color);
+  transition: background 0.15s ease;
+  flex-shrink: 0;
+}
+
+.switch-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: var(--bg-primary);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  transition: transform 0.15s ease;
+}
+
+.switch-on .switch-track {
+  background: var(--accent-primary);
+}
+
+.switch-on .switch-thumb {
+  transform: translateX(1rem);
+}
+
+.switch-label {
+  min-width: 3.2rem;
+}
+
+.switch.saving {
   opacity: 0.6;
   cursor: progress;
 }
 
-.toggle input {
-  cursor: inherit;
+.switch input:focus-visible + .switch-track {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
 }
 
 .error-message {

--- a/frontend/src/components/settings/tabs/dashboard/ClockSettingsTab.vue
+++ b/frontend/src/components/settings/tabs/dashboard/ClockSettingsTab.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="clock-settings-tab">
-    <CollapsibleSection title="Status Bar" icon="🕐" :expanded="true">
-      <SettingItem label="Show Date" help="Display the date alongside the time">
+    <CollapsibleSection title="Clock display" icon="🕐" :expanded="true">
+      <SettingItem label="Show date" help="Display the date alongside the time">
         <label>
           <input
             name="clockShowDate"
@@ -9,11 +9,11 @@
             type="checkbox"
             @change="handleClockSettingsChange"
           />
-          Show Date
+          Show date
         </label>
       </SettingItem>
 
-      <SettingItem label="Show Seconds" help="Display seconds in the time (updates every second)">
+      <SettingItem label="Show seconds" help="Updates the time every second">
         <label>
           <input
             name="clockShowSeconds"
@@ -21,69 +21,63 @@
             type="checkbox"
             @change="handleClockSettingsChange"
           />
-          Show Seconds
+          Show seconds
         </label>
       </SettingItem>
+    </CollapsibleSection>
 
-      <SettingItem label="Show Bar in Kiosk Mode" help="Display bar when UI is hidden">
-        <label>
-          <input
-            name="clockBarShowInKiosk"
-            :checked="config.clockBarShowInKiosk"
-            type="checkbox"
-            @change="handleClockSettingsChange"
-          />
-          Show in Kiosk Mode
-        </label>
-      </SettingItem>
+    <CollapsibleSection title="Default position" icon="📍" :expanded="true">
+      <p class="section-hint">
+        These are the defaults used when a screen doesn't specify its own clock bar position. To
+        override on a specific screen — including dropping the bar into a gap between regions — open
+        <strong>Screens</strong> in the Dashboard settings.
+      </p>
 
-      <SettingItem label="Bar Mode" help="Horizontal or vertical clock bar">
+      <SettingItem label="Bar mode" help="Horizontal bar (top/bottom) or vertical bar (left/right)">
         <select
           name="clockBarMode"
           :value="config.clockBarMode"
           @change="handleClockSettingsChange"
         >
-          <option value="horizontal">Horizontal Bar</option>
-          <option value="vertical">Vertical Bar</option>
+          <option value="horizontal">Horizontal</option>
+          <option value="vertical">Vertical</option>
         </select>
       </SettingItem>
 
-      <SettingItem label="Bar Position" :help="getBarPositionHelp()">
+      <SettingItem label="Bar position" :help="getBarPositionHelp()">
         <select
           name="clockBarPosition"
           :value="config.clockBarPosition"
           @change="handleClockSettingsChange"
         >
           <template v-if="config.clockBarMode === 'horizontal'">
-            <option value="top">Top Header</option>
-            <option value="bottom">Bottom Bar</option>
-            <option value="between" :disabled="config.orientation !== 'portrait'">
-              Between Calendar/Side View (Portrait Only)
-            </option>
+            <option value="top">Top</option>
+            <option value="bottom">Bottom</option>
+            <option value="between">Between regions (first gap)</option>
           </template>
           <template v-else>
-            <option value="left">Far Left</option>
-            <option value="right">Far Right</option>
-            <option value="between" :disabled="config.orientation !== 'landscape'">
-              Between Calendar/Side View (Landscape Only)
-            </option>
+            <option value="left">Left</option>
+            <option value="right">Right</option>
+            <option value="between">Between regions (first gap)</option>
           </template>
         </select>
       </SettingItem>
+    </CollapsibleSection>
 
-      <SettingItem label="Bar Layout" help="Display clock and date on one line or two lines">
+    <CollapsibleSection title="Appearance" icon="🎨" :expanded="true">
+      <SettingItem label="Layout" help="Display clock and date on one line or two">
         <select
           name="clockBarLayout"
           :value="config.clockBarLayout || 'single-line'"
           @change="handleClockSettingsChange"
         >
-          <option value="single-line">Single Line</option>
-          <option value="two-lines">Two Lines</option>
+          <option value="single-line">Single line</option>
+          <option value="two-lines">Two lines</option>
         </select>
       </SettingItem>
 
       <SettingItem
-        label="Font Sizes"
+        label="Font sizes"
         help="Adjust font sizes for time and date. Preview shows how the bar will look."
       >
         <ClockBarFontSizePicker
@@ -100,8 +94,8 @@
       </SettingItem>
 
       <SettingItem
-        label="Show Calvin Logo"
-        help="Display a small Calvin glyph at the leading edge of the bar."
+        label="Show Calvin logo"
+        help="Display a small Calvin glyph at the leading edge of the bar"
       >
         <label>
           <input
@@ -110,13 +104,13 @@
             type="checkbox"
             @change="handleClockSettingsChange"
           />
-          Show Logo
+          Show logo
         </label>
       </SettingItem>
 
       <SettingItem
-        label="Show Weather in Bar"
-        help="Display current temperature and weather icon (requires a weather service to be configured)"
+        label="Show weather"
+        help="Display current temperature and icon (requires a weather service)"
       >
         <label>
           <input
@@ -125,7 +119,24 @@
             type="checkbox"
             @change="handleClockSettingsChange"
           />
-          Show Weather in Bar
+          Show weather in bar
+        </label>
+      </SettingItem>
+    </CollapsibleSection>
+
+    <CollapsibleSection title="Visibility" icon="👁️" :expanded="true">
+      <SettingItem
+        label="Show in kiosk mode"
+        help="Keep the bar visible when the rest of the UI is hidden"
+      >
+        <label>
+          <input
+            name="clockBarShowInKiosk"
+            :checked="config.clockBarShowInKiosk"
+            type="checkbox"
+            @change="handleClockSettingsChange"
+          />
+          Show in kiosk mode
         </label>
       </SettingItem>
     </CollapsibleSection>
@@ -164,9 +175,9 @@ const handleClockSettingsChange = event => {
 
 const getBarPositionHelp = () => {
   if (props.config.clockBarMode === "horizontal") {
-    return "Position for horizontal bar. 'Between' only works in portrait mode.";
+    return "Top/bottom always render. 'Between' shows when the screen layout stacks regions vertically.";
   }
-  return "Position for vertical bar. 'Between' only works in landscape mode.";
+  return "Left/right always render. 'Between' shows when the screen layout places regions side by side.";
 };
 
 const handleBarFontSizeChange = px => {
@@ -185,5 +196,23 @@ const handleBarPaddingChange = px => {
 <style scoped>
 .clock-settings-tab {
   width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.section-hint {
+  margin: 0 0 0.75rem;
+  padding: 0.6rem 0.75rem;
+  border-left: 3px solid var(--accent-primary);
+  background: var(--bg-secondary);
+  border-radius: 0 4px 4px 0;
+  color: var(--text-secondary);
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+.section-hint strong {
+  color: var(--text-primary);
 }
 </style>

--- a/frontend/src/components/settings/tabs/dashboard/DashboardLayoutTab.vue
+++ b/frontend/src/components/settings/tabs/dashboard/DashboardLayoutTab.vue
@@ -127,14 +127,27 @@
                 {{ opt.label }}
               </option>
             </select>
-            <label class="clock-bar-show-toggle">
+            <label
+              class="clock-bar-switch"
+              :class="{ 'clock-bar-switch-on': effectiveClockBarFor(screen).enabled }"
+              :title="
+                effectiveClockBarFor(screen).enabled
+                  ? 'Hide bar on this screen'
+                  : 'Show bar on this screen'
+              "
+            >
               <input
                 type="checkbox"
                 :checked="effectiveClockBarFor(screen).enabled"
                 :aria-label="`Show clock bar on screen ${screenIndex + 1}`"
                 @change="setScreenClockBarEnabled(screenIndex, $event.target.checked)"
               />
-              Show
+              <span class="clock-bar-switch-track" aria-hidden="true">
+                <span class="clock-bar-switch-thumb" />
+              </span>
+              <span class="clock-bar-switch-label">{{
+                effectiveClockBarFor(screen).enabled ? "Shown" : "Hidden"
+              }}</span>
             </label>
             <button
               v-if="screenHasClockBarOverride(screen)"
@@ -156,6 +169,11 @@
                 effectiveClockBarFor(screen).position !== 'top'
               "
               class="clock-bar-drop-zone clock-bar-drop-zone-horizontal"
+              :class="{
+                'clock-bar-drop-zone-mode-switch':
+                  effectiveClockBarFor(screen).mode !== 'horizontal',
+              }"
+              :title="dropZoneTooltip(screen, 'top')"
               @dragover.prevent
               @drop="handleClockBarDrop(screenIndex, 'top', $event)"
             >
@@ -187,6 +205,11 @@
                   effectiveClockBarFor(screen).position !== 'left'
                 "
                 class="clock-bar-drop-zone clock-bar-drop-zone-vertical"
+                :class="{
+                  'clock-bar-drop-zone-mode-switch':
+                    effectiveClockBarFor(screen).mode !== 'vertical',
+                }"
+                :title="dropZoneTooltip(screen, 'left')"
                 @dragover.prevent
                 @drop="handleClockBarDrop(screenIndex, 'left', $event)"
               >
@@ -522,6 +545,7 @@
                     "
                     class="clock-bar-drop-zone"
                     :class="`clock-bar-drop-zone-between-${layoutDirectionFor(screen.layout) === 'row' ? 'vertical' : 'horizontal'}`"
+                    title="Drop here to place the bar between these regions"
                     @dragover.prevent
                     @drop="
                       handleClockBarDrop(
@@ -531,7 +555,7 @@
                       )
                     "
                   >
-                    Gap {{ previewIndex + 1 }}
+                    Between region {{ previewIndex + 1 }} & {{ previewIndex + 2 }}
                   </div>
                   <div
                     v-if="
@@ -578,6 +602,11 @@
                   effectiveClockBarFor(screen).position !== 'right'
                 "
                 class="clock-bar-drop-zone clock-bar-drop-zone-vertical"
+                :class="{
+                  'clock-bar-drop-zone-mode-switch':
+                    effectiveClockBarFor(screen).mode !== 'vertical',
+                }"
+                :title="dropZoneTooltip(screen, 'right')"
                 @dragover.prevent
                 @drop="handleClockBarDrop(screenIndex, 'right', $event)"
               >
@@ -604,6 +633,11 @@
                 effectiveClockBarFor(screen).position !== 'bottom'
               "
               class="clock-bar-drop-zone clock-bar-drop-zone-horizontal"
+              :class="{
+                'clock-bar-drop-zone-mode-switch':
+                  effectiveClockBarFor(screen).mode !== 'horizontal',
+              }"
+              :title="dropZoneTooltip(screen, 'bottom')"
               @dragover.prevent
               @drop="handleClockBarDrop(screenIndex, 'bottom', $event)"
             >
@@ -627,16 +661,16 @@ import { useWebServicesStore } from "@/stores/webServices";
 import { useCalendarStore } from "@/stores/calendar";
 import { usePlugins } from "@/composables";
 import {
-  CLOCK_BAR_PERIMETER_POSITIONS,
   MAX_TOP_REGIONS,
   addSubRegion,
   addTopRegion,
+  computeClockBarModeUpdate,
+  computeClockBarPositionUpdate,
   createDashboardScreenFromPreset,
   getClockBarBetweenIndex,
+  getGlobalClockBarSettings,
   getLayoutDirection,
   getSplitDirection,
-  isClockBarBetweenPosition,
-  normalizeClockBarPosition,
   normalizeDashboardScreens,
   removeSubRegion,
   removeTopRegion,
@@ -716,13 +750,18 @@ const configValue = computed(() => {
   };
 });
 
-const globalClockBarSettings = computed(() => ({
-  enabled: true,
-  mode: configValue.value.clockBarMode,
-  position: configValue.value.clockBarPosition,
-}));
+const globalClockBarSettings = computed(() => getGlobalClockBarSettings(configValue.value));
+
+const effectiveClockBars = computed(() => {
+  const map = new Map();
+  for (const screen of configValue.value.dashboardScreens.screens) {
+    map.set(screen.id, resolveClockBarForScreen(screen, globalClockBarSettings.value));
+  }
+  return map;
+});
 
 const effectiveClockBarFor = screen =>
+  effectiveClockBars.value.get(screen.id) ||
   resolveClockBarForScreen(screen, globalClockBarSettings.value);
 
 const screenHasClockBarOverride = screen => Boolean(screen?.clockBar);
@@ -746,7 +785,7 @@ const clockBarPositionLabel = (position, screen) => {
     const before = regions[index];
     const after = regions[index + 1];
     if (before && after) {
-      return `Between R${index + 1} & R${index + 2}`;
+      return `Between region ${index + 1} & ${index + 2}`;
     }
     return "Between regions";
   }
@@ -772,6 +811,20 @@ const clockBarPositionOptions = (screen, mode) => {
   return options;
 };
 
+const dropZoneTooltip = (screen, position) => {
+  const resolved = effectiveClockBarFor(screen);
+  const targetMode =
+    position === "top" || position === "bottom"
+      ? "horizontal"
+      : position === "left" || position === "right"
+        ? "vertical"
+        : resolved.mode;
+  if (targetMode !== resolved.mode) {
+    return `Drop here to move the bar — switches to ${targetMode} orientation`;
+  }
+  return "Drop here to move the bar";
+};
+
 const updateScreenClockBar = (screenIndex, patch) => {
   const screens = cloneScreens();
   const target = screens.screens[screenIndex];
@@ -792,45 +845,20 @@ const clearScreenClockBar = screenIndex => {
 
 const setScreenClockBarMode = (screenIndex, mode) => {
   const screen = dashboardScreens.value.screens[screenIndex];
-  const resolved = effectiveClockBarFor(screen);
-  // Switching mode invalidates the current perimeter side; re-coerce position.
-  const patch = { mode };
-  if (
-    (mode === "horizontal" && resolved.position !== "top" && resolved.position !== "bottom") ||
-    (mode === "vertical" && resolved.position !== "left" && resolved.position !== "right")
-  ) {
-    if (!isClockBarBetweenPosition(resolved.position)) {
-      patch.position = mode === "horizontal" ? "top" : "left";
-    }
-  }
-  updateScreenClockBar(screenIndex, patch);
+  const update = computeClockBarModeUpdate(screen, mode, globalClockBarSettings.value);
+  if (!update) return;
+  updateScreenClockBar(screenIndex, update.patch);
 };
 
 const setScreenClockBarPosition = (screenIndex, position) => {
   const screen = dashboardScreens.value.screens[screenIndex];
-  const regionsCount = screen.layout.regions.length;
-  const normalized = normalizeClockBarPosition(position, regionsCount);
-  if (!normalized) return;
-  // If the override has no other fields and the new position matches the
-  // global already, leave the screen inheriting.
-  const wouldMatchGlobal =
-    normalized === globalClockBarSettings.value.position &&
-    !screen.clockBar?.mode &&
-    typeof screen.clockBar?.enabled !== "boolean";
-  if (wouldMatchGlobal) {
+  const update = computeClockBarPositionUpdate(screen, position, globalClockBarSettings.value);
+  if (!update) return;
+  if (update.clear) {
     clearScreenClockBar(screenIndex);
     return;
   }
-  // Set position; also pin the mode so the position remains valid even if the
-  // global mode flips later.
-  const patch = { position: normalized };
-  const sideMode = CLOCK_BAR_PERIMETER_POSITIONS.includes(normalized)
-    ? normalized === "top" || normalized === "bottom"
-      ? "horizontal"
-      : "vertical"
-    : null;
-  if (sideMode) patch.mode = sideMode;
-  updateScreenClockBar(screenIndex, patch);
+  updateScreenClockBar(screenIndex, update.patch);
 };
 
 const setScreenClockBarEnabled = (screenIndex, enabled) => {
@@ -1754,11 +1782,61 @@ onUnmounted(() => {
   color: var(--text-primary);
 }
 
-.clock-bar-show-toggle {
+.clock-bar-switch {
   display: inline-flex;
   align-items: center;
-  gap: 0.3rem;
+  gap: 0.4rem;
   cursor: pointer;
+  user-select: none;
+  font-size: 0.8rem;
+  color: var(--text-primary);
+}
+
+.clock-bar-switch input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  width: 0;
+  height: 0;
+}
+
+.clock-bar-switch-track {
+  position: relative;
+  width: 1.9rem;
+  height: 1rem;
+  border-radius: 999px;
+  background: var(--border-color);
+  transition: background 0.15s ease;
+  flex-shrink: 0;
+}
+
+.clock-bar-switch-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  background: var(--bg-primary);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  transition: transform 0.15s ease;
+}
+
+.clock-bar-switch-on .clock-bar-switch-track {
+  background: var(--accent-primary);
+}
+
+.clock-bar-switch-on .clock-bar-switch-thumb {
+  transform: translateX(0.9rem);
+}
+
+.clock-bar-switch input:focus-visible + .clock-bar-switch-track {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 2px;
+}
+
+.clock-bar-switch-label {
+  min-width: 3rem;
 }
 
 .clock-bar-inherit {
@@ -1862,6 +1940,12 @@ onUnmounted(() => {
   width: 1.4rem;
   align-self: stretch;
   writing-mode: vertical-rl;
+}
+
+.clock-bar-drop-zone-mode-switch {
+  border-style: dotted;
+  border-color: var(--accent-secondary, var(--accent-primary));
+  background: rgba(255, 165, 0, 0.08);
 }
 
 .screen-add {

--- a/frontend/src/components/settings/tabs/dashboard/DashboardLayoutTab.vue
+++ b/frontend/src/components/settings/tabs/dashboard/DashboardLayoutTab.vue
@@ -102,327 +102,513 @@
             </button>
           </header>
 
-          <div
-            v-if="expandedScreens.has(screen.id)"
-            :ref="el => setPreviewRef(screen.id, el)"
-            class="screen-preview"
-            :class="`screen-preview-${layoutDirectionFor(screen.layout)}`"
-            :style="previewStyleFor(screen.layout)"
-          >
-            <template v-for="(region, previewIndex) in screen.layout.regions" :key="region.id">
-              <div
-                :class="[
-                  'preview-region',
-                  region.split ? 'preview-region-split' : `preview-region-${region.kind}`,
-                  { 'preview-region-active': region.id === screen.activeRegionId },
-                ]"
-                :style="getPreviewRegionStyle(region)"
+          <div v-if="expandedScreens.has(screen.id)" class="screen-clock-bar-controls">
+            <span class="clock-bar-row-label">Clock bar</span>
+            <select
+              class="clock-bar-control"
+              :value="effectiveClockBarFor(screen).mode"
+              :aria-label="`Screen ${screenIndex + 1} clock bar mode`"
+              @change="setScreenClockBarMode(screenIndex, $event.target.value)"
+            >
+              <option value="horizontal">Horizontal</option>
+              <option value="vertical">Vertical</option>
+            </select>
+            <select
+              class="clock-bar-control"
+              :value="effectiveClockBarFor(screen).position"
+              :aria-label="`Screen ${screenIndex + 1} clock bar position`"
+              @change="setScreenClockBarPosition(screenIndex, $event.target.value)"
+            >
+              <option
+                v-for="opt in clockBarPositionOptions(screen, effectiveClockBarFor(screen).mode)"
+                :key="opt.value"
+                :value="opt.value"
               >
-                <div class="preview-region-header">
-                  <label v-if="!region.split" class="preview-primary-control" @click.stop>
-                    <input
-                      :id="`region-primary-${region.id}`"
-                      type="radio"
-                      :name="`dashboard-active-region-${screen.id}`"
-                      :checked="region.id === screen.activeRegionId"
-                      :aria-label="`Make ${regionLabel(previewIndex)} primary`"
-                      @change="setActiveRegion(screenIndex, region.id)"
-                    />
-                    Primary
-                  </label>
-                  <div class="preview-region-label">{{ regionLabel(previewIndex) }}</div>
-                  <button
-                    v-if="region.split"
-                    type="button"
-                    class="split-toggle"
-                    :aria-label="`Toggle ${regionLabel(previewIndex)} split direction`"
-                    :title="`Sub direction: ${directionLabel(splitDirectionFor(screen.layout, region))}`"
-                    @click.stop="toggleSubDirection(screenIndex, previewIndex)"
-                  >
-                    {{ splitDirectionFor(screen.layout, region) === "column" ? "▭▭" : "▯|▯" }}
-                  </button>
-                  <button
-                    v-if="region.split && region.split.regions.length < MAX_TOP_REGIONS"
-                    type="button"
-                    class="add-region-button add-region-button-small"
-                    :aria-label="`Add sub-region to ${regionLabel(previewIndex)}`"
-                    @click.stop="addSub(screenIndex, previewIndex)"
-                  >
-                    + Sub
-                  </button>
-                  <button
-                    type="button"
-                    class="split-toggle"
-                    :aria-label="
-                      region.split
-                        ? `Unsplit ${regionLabel(previewIndex)}`
-                        : `Split ${regionLabel(previewIndex)}`
-                    "
-                    @click.stop="toggleSplit(screenIndex, previewIndex)"
-                  >
-                    {{ region.split ? "Unsplit" : "Split" }}
-                  </button>
-                  <button
-                    v-if="screen.layout.regions.length > 1"
-                    type="button"
-                    class="region-delete"
-                    :aria-label="`Delete ${regionLabel(previewIndex)}`"
-                    @click.stop="removeRegion(screenIndex, previewIndex)"
-                  >
-                    ×
-                  </button>
-                </div>
+                {{ opt.label }}
+              </option>
+            </select>
+            <label class="clock-bar-show-toggle">
+              <input
+                type="checkbox"
+                :checked="effectiveClockBarFor(screen).enabled"
+                :aria-label="`Show clock bar on screen ${screenIndex + 1}`"
+                @change="setScreenClockBarEnabled(screenIndex, $event.target.checked)"
+              />
+              Show
+            </label>
+            <button
+              v-if="screenHasClockBarOverride(screen)"
+              type="button"
+              class="clock-bar-inherit"
+              :aria-label="`Inherit global clock bar settings on screen ${screenIndex + 1}`"
+              @click="clearScreenClockBar(screenIndex)"
+            >
+              Inherit global
+            </button>
+            <span v-else class="clock-bar-inherit-hint">Inherits global</span>
+            <span class="clock-bar-summary">{{ clockBarSummary(screen) }}</span>
+          </div>
 
-                <template v-if="region.split">
-                  <div
-                    :ref="el => setSubPreviewRef(screen.id, region.id, el)"
-                    class="preview-split-container"
-                    :class="`preview-split-${splitDirectionFor(screen.layout, region)}`"
-                  >
-                    <template v-for="(sub, subIndex) in region.split.regions" :key="sub.id">
-                      <div
-                        :class="[
-                          'preview-subregion',
-                          `preview-region-${sub.kind}`,
-                          { 'preview-region-active': sub.id === screen.activeRegionId },
-                        ]"
-                        :style="getSubRegionStyle(sub)"
-                      >
-                        <div class="preview-region-header">
-                          <label class="preview-primary-control" @click.stop>
-                            <input
-                              :id="`region-primary-${sub.id}`"
-                              type="radio"
-                              :name="`dashboard-active-region-${screen.id}`"
-                              :checked="sub.id === screen.activeRegionId"
-                              :aria-label="`Make ${regionLabel(previewIndex)} sub ${subIndex + 1} primary`"
-                              @change="setActiveRegion(screenIndex, sub.id)"
-                            />
-                            Primary
-                          </label>
-                          <div class="preview-region-label">
-                            {{ regionLabel(previewIndex) }}.{{ subIndex + 1 }}
-                          </div>
-                          <button
-                            v-if="region.split.regions.length > 1"
-                            type="button"
-                            class="region-delete"
-                            :aria-label="`Delete ${regionLabel(previewIndex)} sub ${subIndex + 1}`"
-                            @click.stop="removeSub(screenIndex, previewIndex, subIndex)"
-                          >
-                            ×
-                          </button>
-                        </div>
-                        <div class="preview-component-picker" @click.stop>
-                          <button
-                            :id="`region-component-${sub.id}`"
-                            type="button"
-                            class="preview-component-select"
-                            :aria-expanded="openComponentPickerKey === `${screen.id}:${sub.id}`"
-                            :aria-label="`${regionLabel(previewIndex)} sub ${subIndex + 1} component`"
-                            @click="toggleComponentPicker(screen.id, sub.id)"
-                          >
-                            {{ regionKindLabel(sub) }}
-                          </button>
-                          <div
-                            v-if="openComponentPickerKey === `${screen.id}:${sub.id}`"
-                            class="component-menu"
-                          >
-                            <input
-                              v-model="componentSearch"
-                              class="component-search"
-                              type="search"
-                              placeholder="Filter components"
-                              autocomplete="off"
-                            />
+          <div v-if="expandedScreens.has(screen.id)" class="screen-preview-frame">
+            <div
+              v-if="
+                clockBarDragScreenId === screen.id &&
+                effectiveClockBarFor(screen).position !== 'top'
+              "
+              class="clock-bar-drop-zone clock-bar-drop-zone-horizontal"
+              @dragover.prevent
+              @drop="handleClockBarDrop(screenIndex, 'top', $event)"
+            >
+              Top
+            </div>
+            <div
+              v-if="
+                effectiveClockBarFor(screen).enabled &&
+                effectiveClockBarFor(screen).position === 'top'
+              "
+              class="clock-bar-token clock-bar-token-horizontal"
+              draggable="true"
+              :aria-label="`Clock bar on screen ${screenIndex + 1} — drag to reposition`"
+              @dragstart="beginClockBarDrag(screen.id, $event)"
+              @dragend="endClockBarDrag()"
+            >
+              <span class="clock-bar-token-label">⠿ Clock bar</span>
+            </div>
+
+            <div
+              :ref="el => setPreviewRef(screen.id, el)"
+              class="screen-preview"
+              :class="`screen-preview-${layoutDirectionFor(screen.layout)}`"
+              :style="previewStyleFor(screen.layout)"
+            >
+              <div
+                v-if="
+                  clockBarDragScreenId === screen.id &&
+                  effectiveClockBarFor(screen).position !== 'left'
+                "
+                class="clock-bar-drop-zone clock-bar-drop-zone-vertical"
+                @dragover.prevent
+                @drop="handleClockBarDrop(screenIndex, 'left', $event)"
+              >
+                Left
+              </div>
+              <div
+                v-if="
+                  effectiveClockBarFor(screen).enabled &&
+                  effectiveClockBarFor(screen).position === 'left'
+                "
+                class="clock-bar-token clock-bar-token-vertical"
+                draggable="true"
+                :aria-label="`Clock bar on screen ${screenIndex + 1} — drag to reposition`"
+                @dragstart="beginClockBarDrag(screen.id, $event)"
+                @dragend="endClockBarDrag()"
+              >
+                <span class="clock-bar-token-label">⠿</span>
+              </div>
+              <template v-for="(region, previewIndex) in screen.layout.regions" :key="region.id">
+                <div
+                  :class="[
+                    'preview-region',
+                    region.split ? 'preview-region-split' : `preview-region-${region.kind}`,
+                    { 'preview-region-active': region.id === screen.activeRegionId },
+                  ]"
+                  :style="getPreviewRegionStyle(region)"
+                >
+                  <div class="preview-region-header">
+                    <label v-if="!region.split" class="preview-primary-control" @click.stop>
+                      <input
+                        :id="`region-primary-${region.id}`"
+                        type="radio"
+                        :name="`dashboard-active-region-${screen.id}`"
+                        :checked="region.id === screen.activeRegionId"
+                        :aria-label="`Make ${regionLabel(previewIndex)} primary`"
+                        @change="setActiveRegion(screenIndex, region.id)"
+                      />
+                      Primary
+                    </label>
+                    <div class="preview-region-label">{{ regionLabel(previewIndex) }}</div>
+                    <button
+                      v-if="region.split"
+                      type="button"
+                      class="split-toggle"
+                      :aria-label="`Toggle ${regionLabel(previewIndex)} split direction`"
+                      :title="`Sub direction: ${directionLabel(splitDirectionFor(screen.layout, region))}`"
+                      @click.stop="toggleSubDirection(screenIndex, previewIndex)"
+                    >
+                      {{ splitDirectionFor(screen.layout, region) === "column" ? "▭▭" : "▯|▯" }}
+                    </button>
+                    <button
+                      v-if="region.split && region.split.regions.length < MAX_TOP_REGIONS"
+                      type="button"
+                      class="add-region-button add-region-button-small"
+                      :aria-label="`Add sub-region to ${regionLabel(previewIndex)}`"
+                      @click.stop="addSub(screenIndex, previewIndex)"
+                    >
+                      + Sub
+                    </button>
+                    <button
+                      type="button"
+                      class="split-toggle"
+                      :aria-label="
+                        region.split
+                          ? `Unsplit ${regionLabel(previewIndex)}`
+                          : `Split ${regionLabel(previewIndex)}`
+                      "
+                      @click.stop="toggleSplit(screenIndex, previewIndex)"
+                    >
+                      {{ region.split ? "Unsplit" : "Split" }}
+                    </button>
+                    <button
+                      v-if="screen.layout.regions.length > 1"
+                      type="button"
+                      class="region-delete"
+                      :aria-label="`Delete ${regionLabel(previewIndex)}`"
+                      @click.stop="removeRegion(screenIndex, previewIndex)"
+                    >
+                      ×
+                    </button>
+                  </div>
+
+                  <template v-if="region.split">
+                    <div
+                      :ref="el => setSubPreviewRef(screen.id, region.id, el)"
+                      class="preview-split-container"
+                      :class="`preview-split-${splitDirectionFor(screen.layout, region)}`"
+                    >
+                      <template v-for="(sub, subIndex) in region.split.regions" :key="sub.id">
+                        <div
+                          :class="[
+                            'preview-subregion',
+                            `preview-region-${sub.kind}`,
+                            { 'preview-region-active': sub.id === screen.activeRegionId },
+                          ]"
+                          :style="getSubRegionStyle(sub)"
+                        >
+                          <div class="preview-region-header">
+                            <label class="preview-primary-control" @click.stop>
+                              <input
+                                :id="`region-primary-${sub.id}`"
+                                type="radio"
+                                :name="`dashboard-active-region-${screen.id}`"
+                                :checked="sub.id === screen.activeRegionId"
+                                :aria-label="`Make ${regionLabel(previewIndex)} sub ${subIndex + 1} primary`"
+                                @change="setActiveRegion(screenIndex, sub.id)"
+                              />
+                              Primary
+                            </label>
+                            <div class="preview-region-label">
+                              {{ regionLabel(previewIndex) }}.{{ subIndex + 1 }}
+                            </div>
                             <button
-                              v-for="option in filteredComponentOptions"
-                              :key="option.value"
+                              v-if="region.split.regions.length > 1"
                               type="button"
-                              class="component-option"
-                              @click="
-                                selectSubRegionComponent(
+                              class="region-delete"
+                              :aria-label="`Delete ${regionLabel(previewIndex)} sub ${subIndex + 1}`"
+                              @click.stop="removeSub(screenIndex, previewIndex, subIndex)"
+                            >
+                              ×
+                            </button>
+                          </div>
+                          <div class="preview-component-picker" @click.stop>
+                            <button
+                              :id="`region-component-${sub.id}`"
+                              type="button"
+                              class="preview-component-select"
+                              :aria-expanded="openComponentPickerKey === `${screen.id}:${sub.id}`"
+                              :aria-label="`${regionLabel(previewIndex)} sub ${subIndex + 1} component`"
+                              @click="toggleComponentPicker(screen.id, sub.id)"
+                            >
+                              {{ regionKindLabel(sub) }}
+                            </button>
+                            <div
+                              v-if="openComponentPickerKey === `${screen.id}:${sub.id}`"
+                              class="component-menu"
+                            >
+                              <input
+                                v-model="componentSearch"
+                                class="component-search"
+                                type="search"
+                                placeholder="Filter components"
+                                autocomplete="off"
+                              />
+                              <button
+                                v-for="option in filteredComponentOptions"
+                                :key="option.value"
+                                type="button"
+                                class="component-option"
+                                @click="
+                                  selectSubRegionComponent(
+                                    screenIndex,
+                                    previewIndex,
+                                    subIndex,
+                                    option
+                                  )
+                                "
+                              >
+                                {{ option.label }}
+                              </button>
+                              <div
+                                v-if="sourceOptionsFor(sub.kind).length > 0"
+                                class="source-options"
+                              >
+                                <button
+                                  type="button"
+                                  class="component-option"
+                                  @click="
+                                    clearSubRegionSources(screenIndex, previewIndex, subIndex)
+                                  "
+                                >
+                                  {{ sourceSelectionLabel({ ...sub, instanceIds: [] }) }}
+                                </button>
+                                <label
+                                  v-for="source in sourceOptionsFor(sub.kind)"
+                                  :key="source.id"
+                                  class="source-option"
+                                >
+                                  <input
+                                    type="checkbox"
+                                    :checked="(sub.instanceIds || []).includes(source.id)"
+                                    @change="
+                                      toggleSubRegionSource(
+                                        screenIndex,
+                                        previewIndex,
+                                        subIndex,
+                                        source.id,
+                                        $event.target.checked
+                                      )
+                                    "
+                                  />
+                                  {{ source.name }}
+                                </label>
+                              </div>
+                              <div
+                                v-if="filteredComponentOptions.length === 0"
+                                class="component-empty"
+                              >
+                                No matches
+                              </div>
+                            </div>
+                          </div>
+                          <label class="preview-size-control">
+                            Size
+                            <input
+                              :id="`region-size-${sub.id}`"
+                              :value="sub.size"
+                              type="number"
+                              min="10"
+                              max="90"
+                              step="1"
+                              :aria-label="`Sub ${subIndex + 1} size percentage`"
+                              @change="
+                                handleSubRegionSizeChange(
                                   screenIndex,
                                   previewIndex,
                                   subIndex,
-                                  option
+                                  $event.target.value
                                 )
                               "
-                            >
-                              {{ option.label }}
-                            </button>
-                            <div
-                              v-if="sourceOptionsFor(sub.kind).length > 0"
-                              class="source-options"
-                            >
-                              <button
-                                type="button"
-                                class="component-option"
-                                @click="clearSubRegionSources(screenIndex, previewIndex, subIndex)"
-                              >
-                                {{ sourceSelectionLabel({ ...sub, instanceIds: [] }) }}
-                              </button>
-                              <label
-                                v-for="source in sourceOptionsFor(sub.kind)"
-                                :key="source.id"
-                                class="source-option"
-                              >
-                                <input
-                                  type="checkbox"
-                                  :checked="(sub.instanceIds || []).includes(source.id)"
-                                  @change="
-                                    toggleSubRegionSource(
-                                      screenIndex,
-                                      previewIndex,
-                                      subIndex,
-                                      source.id,
-                                      $event.target.checked
-                                    )
-                                  "
-                                />
-                                {{ source.name }}
-                              </label>
-                            </div>
-                            <div
-                              v-if="filteredComponentOptions.length === 0"
-                              class="component-empty"
-                            >
-                              No matches
-                            </div>
-                          </div>
+                            />
+                            %
+                          </label>
                         </div>
-                        <label class="preview-size-control">
-                          Size
-                          <input
-                            :id="`region-size-${sub.id}`"
-                            :value="sub.size"
-                            type="number"
-                            min="10"
-                            max="90"
-                            step="1"
-                            :aria-label="`Sub ${subIndex + 1} size percentage`"
-                            @change="
-                              handleSubRegionSizeChange(
-                                screenIndex,
-                                previewIndex,
-                                subIndex,
-                                $event.target.value
-                              )
-                            "
-                          />
-                          %
-                        </label>
-                      </div>
-                      <button
-                        v-if="subIndex < region.split.regions.length - 1"
-                        type="button"
-                        :class="[
-                          'preview-resizer',
-                          `preview-resizer-${splitDirectionFor(screen.layout, region)}`,
-                        ]"
-                        :aria-label="`Resize ${regionLabel(previewIndex)} sub-regions`"
-                        @pointerdown.stop="
-                          startSubResize(screenIndex, previewIndex, subIndex, $event)
-                        "
-                      />
-                    </template>
-                  </div>
-                </template>
-                <template v-else>
-                  <div class="preview-component-picker" @click.stop>
-                    <button
-                      :id="`region-component-${region.id}`"
-                      type="button"
-                      class="preview-component-select"
-                      :aria-expanded="openComponentPickerKey === `${screen.id}:${region.id}`"
-                      :aria-label="`${regionLabel(previewIndex)} component`"
-                      @click="toggleComponentPicker(screen.id, region.id)"
-                    >
-                      {{ regionKindLabel(region) }}
-                    </button>
-                    <div
-                      v-if="openComponentPickerKey === `${screen.id}:${region.id}`"
-                      class="component-menu"
-                    >
-                      <input
-                        v-model="componentSearch"
-                        class="component-search"
-                        type="search"
-                        placeholder="Filter components"
-                        autocomplete="off"
-                      />
-                      <button
-                        v-for="option in filteredComponentOptions"
-                        :key="option.value"
-                        type="button"
-                        class="component-option"
-                        @click="selectRegionComponent(screenIndex, previewIndex, option)"
-                      >
-                        {{ option.label }}
-                      </button>
-                      <div v-if="sourceOptionsFor(region.kind).length > 0" class="source-options">
                         <button
+                          v-if="subIndex < region.split.regions.length - 1"
+                          type="button"
+                          :class="[
+                            'preview-resizer',
+                            `preview-resizer-${splitDirectionFor(screen.layout, region)}`,
+                          ]"
+                          :aria-label="`Resize ${regionLabel(previewIndex)} sub-regions`"
+                          @pointerdown.stop="
+                            startSubResize(screenIndex, previewIndex, subIndex, $event)
+                          "
+                        />
+                      </template>
+                    </div>
+                  </template>
+                  <template v-else>
+                    <div class="preview-component-picker" @click.stop>
+                      <button
+                        :id="`region-component-${region.id}`"
+                        type="button"
+                        class="preview-component-select"
+                        :aria-expanded="openComponentPickerKey === `${screen.id}:${region.id}`"
+                        :aria-label="`${regionLabel(previewIndex)} component`"
+                        @click="toggleComponentPicker(screen.id, region.id)"
+                      >
+                        {{ regionKindLabel(region) }}
+                      </button>
+                      <div
+                        v-if="openComponentPickerKey === `${screen.id}:${region.id}`"
+                        class="component-menu"
+                      >
+                        <input
+                          v-model="componentSearch"
+                          class="component-search"
+                          type="search"
+                          placeholder="Filter components"
+                          autocomplete="off"
+                        />
+                        <button
+                          v-for="option in filteredComponentOptions"
+                          :key="option.value"
                           type="button"
                           class="component-option"
-                          @click="clearRegionSources(screenIndex, previewIndex)"
+                          @click="selectRegionComponent(screenIndex, previewIndex, option)"
                         >
-                          {{ sourceSelectionLabel({ ...region, instanceIds: [] }) }}
+                          {{ option.label }}
                         </button>
-                        <label
-                          v-for="source in sourceOptionsFor(region.kind)"
-                          :key="source.id"
-                          class="source-option"
-                        >
-                          <input
-                            type="checkbox"
-                            :checked="(region.instanceIds || []).includes(source.id)"
-                            @change="
-                              toggleRegionSource(
-                                screenIndex,
-                                previewIndex,
-                                source.id,
-                                $event.target.checked
-                              )
-                            "
-                          />
-                          {{ source.name }}
-                        </label>
-                      </div>
-                      <div v-if="filteredComponentOptions.length === 0" class="component-empty">
-                        No matches
+                        <div v-if="sourceOptionsFor(region.kind).length > 0" class="source-options">
+                          <button
+                            type="button"
+                            class="component-option"
+                            @click="clearRegionSources(screenIndex, previewIndex)"
+                          >
+                            {{ sourceSelectionLabel({ ...region, instanceIds: [] }) }}
+                          </button>
+                          <label
+                            v-for="source in sourceOptionsFor(region.kind)"
+                            :key="source.id"
+                            class="source-option"
+                          >
+                            <input
+                              type="checkbox"
+                              :checked="(region.instanceIds || []).includes(source.id)"
+                              @change="
+                                toggleRegionSource(
+                                  screenIndex,
+                                  previewIndex,
+                                  source.id,
+                                  $event.target.checked
+                                )
+                              "
+                            />
+                            {{ source.name }}
+                          </label>
+                        </div>
+                        <div v-if="filteredComponentOptions.length === 0" class="component-empty">
+                          No matches
+                        </div>
                       </div>
                     </div>
-                  </div>
-                  <label
-                    v-if="screen.layout.regions.length > 1"
-                    class="preview-size-control"
-                    @click.stop
+                    <label
+                      v-if="screen.layout.regions.length > 1"
+                      class="preview-size-control"
+                      @click.stop
+                    >
+                      Size
+                      <input
+                        :id="`region-size-${region.id}`"
+                        :value="region.size"
+                        type="number"
+                        min="10"
+                        max="90"
+                        step="1"
+                        :aria-label="`${regionLabel(previewIndex)} size percentage`"
+                        @change="
+                          handleRegionSizeChange(screenIndex, previewIndex, $event.target.value)
+                        "
+                      />
+                      %
+                    </label>
+                  </template>
+                </div>
+                <template v-if="previewIndex < screen.layout.regions.length - 1">
+                  <div
+                    v-if="
+                      clockBarDragScreenId === screen.id &&
+                      getClockBarBetweenIndex(effectiveClockBarFor(screen).position) !==
+                        previewIndex
+                    "
+                    class="clock-bar-drop-zone"
+                    :class="`clock-bar-drop-zone-between-${layoutDirectionFor(screen.layout) === 'row' ? 'vertical' : 'horizontal'}`"
+                    @dragover.prevent
+                    @drop="
+                      handleClockBarDrop(
+                        screenIndex,
+                        previewIndex === 0 ? 'between' : `between:${previewIndex}`,
+                        $event
+                      )
+                    "
                   >
-                    Size
-                    <input
-                      :id="`region-size-${region.id}`"
-                      :value="region.size"
-                      type="number"
-                      min="10"
-                      max="90"
-                      step="1"
-                      :aria-label="`${regionLabel(previewIndex)} size percentage`"
-                      @change="
-                        handleRegionSizeChange(screenIndex, previewIndex, $event.target.value)
-                      "
-                    />
-                    %
-                  </label>
+                    Gap {{ previewIndex + 1 }}
+                  </div>
+                  <div
+                    v-if="
+                      effectiveClockBarFor(screen).enabled &&
+                      getClockBarBetweenIndex(effectiveClockBarFor(screen).position) ===
+                        previewIndex
+                    "
+                    class="clock-bar-token"
+                    :class="`clock-bar-token-${layoutDirectionFor(screen.layout) === 'row' ? 'vertical' : 'horizontal'}`"
+                    draggable="true"
+                    :aria-label="`Clock bar on screen ${screenIndex + 1} — drag to reposition`"
+                    @dragstart="beginClockBarDrag(screen.id, $event)"
+                    @dragend="endClockBarDrag()"
+                  >
+                    <span class="clock-bar-token-label">⠿</span>
+                  </div>
+                  <button
+                    type="button"
+                    :class="[
+                      'preview-resizer',
+                      `preview-resizer-${layoutDirectionFor(screen.layout)}`,
+                    ]"
+                    :aria-label="`Resize ${regionLabel(previewIndex)}`"
+                    @pointerdown="startResize(screenIndex, previewIndex, $event)"
+                  />
                 </template>
+              </template>
+              <div
+                v-if="
+                  effectiveClockBarFor(screen).enabled &&
+                  effectiveClockBarFor(screen).position === 'right'
+                "
+                class="clock-bar-token clock-bar-token-vertical"
+                draggable="true"
+                :aria-label="`Clock bar on screen ${screenIndex + 1} — drag to reposition`"
+                @dragstart="beginClockBarDrag(screen.id, $event)"
+                @dragend="endClockBarDrag()"
+              >
+                <span class="clock-bar-token-label">⠿</span>
               </div>
-              <button
-                v-if="previewIndex < screen.layout.regions.length - 1"
-                type="button"
-                :class="['preview-resizer', `preview-resizer-${layoutDirectionFor(screen.layout)}`]"
-                :aria-label="`Resize ${regionLabel(previewIndex)}`"
-                @pointerdown="startResize(screenIndex, previewIndex, $event)"
-              />
-            </template>
+              <div
+                v-if="
+                  clockBarDragScreenId === screen.id &&
+                  effectiveClockBarFor(screen).position !== 'right'
+                "
+                class="clock-bar-drop-zone clock-bar-drop-zone-vertical"
+                @dragover.prevent
+                @drop="handleClockBarDrop(screenIndex, 'right', $event)"
+              >
+                Right
+              </div>
+            </div>
+
+            <div
+              v-if="
+                effectiveClockBarFor(screen).enabled &&
+                effectiveClockBarFor(screen).position === 'bottom'
+              "
+              class="clock-bar-token clock-bar-token-horizontal"
+              draggable="true"
+              :aria-label="`Clock bar on screen ${screenIndex + 1} — drag to reposition`"
+              @dragstart="beginClockBarDrag(screen.id, $event)"
+              @dragend="endClockBarDrag()"
+            >
+              <span class="clock-bar-token-label">⠿ Clock bar</span>
+            </div>
+            <div
+              v-if="
+                clockBarDragScreenId === screen.id &&
+                effectiveClockBarFor(screen).position !== 'bottom'
+              "
+              class="clock-bar-drop-zone clock-bar-drop-zone-horizontal"
+              @dragover.prevent
+              @drop="handleClockBarDrop(screenIndex, 'bottom', $event)"
+            >
+              Bottom
+            </div>
           </div>
         </section>
 
@@ -441,18 +627,23 @@ import { useWebServicesStore } from "@/stores/webServices";
 import { useCalendarStore } from "@/stores/calendar";
 import { usePlugins } from "@/composables";
 import {
+  CLOCK_BAR_PERIMETER_POSITIONS,
   MAX_TOP_REGIONS,
   addSubRegion,
   addTopRegion,
   createDashboardScreenFromPreset,
+  getClockBarBetweenIndex,
   getLayoutDirection,
   getSplitDirection,
+  isClockBarBetweenPosition,
+  normalizeClockBarPosition,
   normalizeDashboardScreens,
   removeSubRegion,
   removeTopRegion,
   resizeAdjacentRegions,
   resizeSubRegion,
   resizeSubRegionPair,
+  resolveClockBarForScreen,
   setLayoutDirection,
   setSplitDirection,
   setSubRegionContent,
@@ -477,8 +668,29 @@ const { plugins, pluginInstances, loadingPlugins, loadPlugins } = usePlugins();
 const previewRefs = new Map();
 const subPreviewRefs = new Map();
 const dragState = ref(null);
+const clockBarDragScreenId = ref(null);
 const openComponentPickerKey = ref(null);
 const componentSearch = ref("");
+
+const beginClockBarDrag = (screenId, event) => {
+  clockBarDragScreenId.value = screenId;
+  if (event?.dataTransfer) {
+    event.dataTransfer.effectAllowed = "move";
+    // Some browsers require setData for drag to start.
+    event.dataTransfer.setData("text/plain", `clock-bar:${screenId}`);
+  }
+};
+
+const endClockBarDrag = () => {
+  clockBarDragScreenId.value = null;
+};
+
+const handleClockBarDrop = (screenIndex, position, event) => {
+  event?.preventDefault?.();
+  if (clockBarDragScreenId.value === null) return;
+  setScreenClockBarPosition(screenIndex, position);
+  endClockBarDrag();
+};
 
 const setPreviewRef = (screenId, el) => {
   if (el) previewRefs.set(screenId, el);
@@ -498,9 +710,132 @@ const configValue = computed(() => {
     orientationFlipped: config.orientationFlipped ?? false,
     applyDisplayRotation: config.applyDisplayRotation ?? true,
     calendarSplit: config.calendarSplit ?? 70,
+    clockBarMode: config.clockBarMode ?? "horizontal",
+    clockBarPosition: config.clockBarPosition ?? "top",
     dashboardScreens: normalizeDashboardScreens(config.dashboardScreens),
   };
 });
+
+const globalClockBarSettings = computed(() => ({
+  enabled: true,
+  mode: configValue.value.clockBarMode,
+  position: configValue.value.clockBarPosition,
+}));
+
+const effectiveClockBarFor = screen =>
+  resolveClockBarForScreen(screen, globalClockBarSettings.value);
+
+const screenHasClockBarOverride = screen => Boolean(screen?.clockBar);
+
+const clockBarSummary = screen => {
+  const resolved = effectiveClockBarFor(screen);
+  const positionLabel = clockBarPositionLabel(resolved.position, screen);
+  const modeLabel = resolved.mode === "vertical" ? "Vertical" : "Horizontal";
+  const enabledLabel = resolved.enabled ? "" : " · Hidden";
+  return `${modeLabel} · ${positionLabel}${enabledLabel}`;
+};
+
+const clockBarPositionLabel = (position, screen) => {
+  if (position === "top") return "Top";
+  if (position === "bottom") return "Bottom";
+  if (position === "left") return "Left";
+  if (position === "right") return "Right";
+  const index = getClockBarBetweenIndex(position);
+  if (index !== null) {
+    const regions = screen?.layout?.regions || [];
+    const before = regions[index];
+    const after = regions[index + 1];
+    if (before && after) {
+      return `Between R${index + 1} & R${index + 2}`;
+    }
+    return "Between regions";
+  }
+  return "—";
+};
+
+const clockBarPositionOptions = (screen, mode) => {
+  const options =
+    mode === "vertical"
+      ? [
+          { value: "left", label: "Left edge" },
+          { value: "right", label: "Right edge" },
+        ]
+      : [
+          { value: "top", label: "Top edge" },
+          { value: "bottom", label: "Bottom edge" },
+        ];
+  const regions = screen?.layout?.regions || [];
+  for (let i = 0; i < regions.length - 1; i += 1) {
+    const value = i === 0 ? "between" : `between:${i}`;
+    options.push({ value, label: `Between region ${i + 1} & ${i + 2}` });
+  }
+  return options;
+};
+
+const updateScreenClockBar = (screenIndex, patch) => {
+  const screens = cloneScreens();
+  const target = screens.screens[screenIndex];
+  const next = { ...(target.clockBar || {}), ...patch };
+  // Drop fields explicitly set to undefined or null so override stays minimal.
+  Object.keys(next).forEach(key => {
+    if (next[key] === undefined || next[key] === null) delete next[key];
+  });
+  target.clockBar = Object.keys(next).length ? next : null;
+  emitScreensUpdate(screens);
+};
+
+const clearScreenClockBar = screenIndex => {
+  const screens = cloneScreens();
+  screens.screens[screenIndex].clockBar = null;
+  emitScreensUpdate(screens);
+};
+
+const setScreenClockBarMode = (screenIndex, mode) => {
+  const screen = dashboardScreens.value.screens[screenIndex];
+  const resolved = effectiveClockBarFor(screen);
+  // Switching mode invalidates the current perimeter side; re-coerce position.
+  const patch = { mode };
+  if (
+    (mode === "horizontal" && resolved.position !== "top" && resolved.position !== "bottom") ||
+    (mode === "vertical" && resolved.position !== "left" && resolved.position !== "right")
+  ) {
+    if (!isClockBarBetweenPosition(resolved.position)) {
+      patch.position = mode === "horizontal" ? "top" : "left";
+    }
+  }
+  updateScreenClockBar(screenIndex, patch);
+};
+
+const setScreenClockBarPosition = (screenIndex, position) => {
+  const screen = dashboardScreens.value.screens[screenIndex];
+  const regionsCount = screen.layout.regions.length;
+  const normalized = normalizeClockBarPosition(position, regionsCount);
+  if (!normalized) return;
+  // If the override has no other fields and the new position matches the
+  // global already, leave the screen inheriting.
+  const wouldMatchGlobal =
+    normalized === globalClockBarSettings.value.position &&
+    !screen.clockBar?.mode &&
+    typeof screen.clockBar?.enabled !== "boolean";
+  if (wouldMatchGlobal) {
+    clearScreenClockBar(screenIndex);
+    return;
+  }
+  // Set position; also pin the mode so the position remains valid even if the
+  // global mode flips later.
+  const patch = { position: normalized };
+  const sideMode = CLOCK_BAR_PERIMETER_POSITIONS.includes(normalized)
+    ? normalized === "top" || normalized === "bottom"
+      ? "horizontal"
+      : "vertical"
+    : null;
+  if (sideMode) patch.mode = sideMode;
+  updateScreenClockBar(screenIndex, patch);
+};
+
+const setScreenClockBarEnabled = (screenIndex, enabled) => {
+  updateScreenClockBar(screenIndex, { enabled });
+};
 
 const dashboardScreens = computed(() => configValue.value.dashboardScreens);
 
@@ -1391,6 +1726,142 @@ onUnmounted(() => {
 
 .preview-subregion .preview-region-header {
   min-height: 1.75rem;
+}
+
+.screen-clock-bar-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--bg-primary);
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.clock-bar-row-label {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.clock-bar-control {
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 0.25rem 0.4rem;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.clock-bar-show-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  cursor: pointer;
+}
+
+.clock-bar-inherit {
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.clock-bar-inherit:hover,
+.clock-bar-inherit:focus {
+  border-color: var(--accent-primary);
+}
+
+.clock-bar-inherit-hint {
+  font-style: italic;
+  font-size: 0.8rem;
+}
+
+.clock-bar-summary {
+  margin-left: auto;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.screen-preview-frame {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.clock-bar-token {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent-primary);
+  color: #fff;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: grab;
+  user-select: none;
+  flex-shrink: 0;
+}
+
+.clock-bar-token:active {
+  cursor: grabbing;
+}
+
+.clock-bar-token-horizontal {
+  width: 100%;
+  height: 1.6rem;
+  padding: 0 0.5rem;
+}
+
+.clock-bar-token-vertical {
+  width: 1.6rem;
+  align-self: stretch;
+  writing-mode: vertical-rl;
+  padding: 0.5rem 0;
+}
+
+.clock-bar-token-label {
+  white-space: nowrap;
+}
+
+.clock-bar-drop-zone {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed var(--accent-primary);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.05);
+  color: var(--accent-primary);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+}
+
+.clock-bar-drop-zone-horizontal {
+  width: 100%;
+  height: 1.4rem;
+}
+
+.clock-bar-drop-zone-vertical {
+  width: 1.4rem;
+  align-self: stretch;
+  writing-mode: vertical-rl;
+}
+
+.clock-bar-drop-zone-between-horizontal {
+  width: 100%;
+  height: 1.4rem;
+}
+
+.clock-bar-drop-zone-between-vertical {
+  width: 1.4rem;
+  align-self: stretch;
+  writing-mode: vertical-rl;
 }
 
 .screen-add {

--- a/frontend/src/utils/layout.js
+++ b/frontend/src/utils/layout.js
@@ -180,13 +180,102 @@ export function normalizeDashboardScreen(screen) {
   const activeRegionId = leafIds.includes(screen?.activeRegionId)
     ? screen.activeRegionId
     : leafIds[0] || "region-1";
+  const clockBar = normalizeScreenClockBar(screen?.clockBar, layout.regions.length);
 
   return {
     id: screen?.id || createScreenId(),
     name: screen?.name || "Screen",
     layout,
     activeRegionId,
+    clockBar,
   };
+}
+
+export const CLOCK_BAR_PERIMETER_POSITIONS = ["top", "bottom", "left", "right"];
+
+/**
+ * Normalize a per-screen clock bar override. Returns `null` if no fields are
+ * set (the screen inherits the global settings entirely). Position values:
+ *   - 'top' | 'bottom' (horizontal mode)
+ *   - 'left' | 'right' (vertical mode)
+ *   - 'between'         (== between:0; the first gap between top-level regions)
+ *   - `between:${i}`    (the i-th gap; clamped to [0, regionsCount - 2])
+ */
+export function normalizeScreenClockBar(value, regionsCount) {
+  if (!value || typeof value !== "object") return null;
+  const out = {};
+  if (typeof value.enabled === "boolean") out.enabled = value.enabled;
+  if (value.mode === "horizontal" || value.mode === "vertical") out.mode = value.mode;
+  const position = normalizeClockBarPosition(value.position, regionsCount);
+  if (position) out.position = position;
+  return Object.keys(out).length ? out : null;
+}
+
+export function normalizeClockBarPosition(value, regionsCount) {
+  if (CLOCK_BAR_PERIMETER_POSITIONS.includes(value)) return value;
+  if (value === "between") return clampBetweenPosition(0, regionsCount);
+  if (typeof value === "string") {
+    const match = value.match(/^between:(\d+)$/);
+    if (match) {
+      return clampBetweenPosition(parseInt(match[1], 10), regionsCount);
+    }
+  }
+  return null;
+}
+
+function clampBetweenPosition(index, regionsCount) {
+  const count = Number.isFinite(regionsCount) ? regionsCount : 0;
+  if (count < 2) return "between";
+  const maxIndex = count - 2;
+  const clamped = Math.max(0, Math.min(maxIndex, Number.isFinite(index) ? index : 0));
+  return clamped === 0 ? "between" : `between:${clamped}`;
+}
+
+export function getClockBarBetweenIndex(position) {
+  if (position === "between") return 0;
+  if (typeof position === "string") {
+    const match = position.match(/^between:(\d+)$/);
+    if (match) return parseInt(match[1], 10);
+  }
+  return null;
+}
+
+export function isClockBarBetweenPosition(position) {
+  return getClockBarBetweenIndex(position) !== null;
+}
+
+/**
+ * Merge per-screen clock bar overrides with global settings, returning the
+ * effective `{ enabled, mode, position }` to use when rendering. Falls back to
+ * a sane perimeter position when the resolved (mode, position) pair is
+ * inconsistent (e.g. horizontal mode with a 'left' override).
+ */
+export function resolveClockBarForScreen(screen, globalSettings = {}) {
+  const override = screen?.clockBar || {};
+  const enabled =
+    typeof override.enabled === "boolean" ? override.enabled : Boolean(globalSettings.enabled);
+  const mode =
+    override.mode === "horizontal" || override.mode === "vertical"
+      ? override.mode
+      : globalSettings.mode === "vertical"
+        ? "vertical"
+        : "horizontal";
+  const requested = override.position ?? globalSettings.position ?? null;
+  const regionsCount = screen?.layout?.regions?.length || 0;
+  const position = coerceClockBarPosition(requested, mode, regionsCount);
+  return { enabled, mode, position };
+}
+
+function coerceClockBarPosition(position, mode, regionsCount) {
+  const betweenIndex = getClockBarBetweenIndex(position);
+  if (betweenIndex !== null) {
+    if (regionsCount < 2) return mode === "vertical" ? "left" : "top";
+    return clampBetweenPosition(betweenIndex, regionsCount);
+  }
+  if (mode === "horizontal") {
+    return position === "top" || position === "bottom" ? position : "top";
+  }
+  return position === "left" || position === "right" ? position : "left";
 }
 
 export function getLeafRegions(layout) {

--- a/frontend/src/utils/layout.js
+++ b/frontend/src/utils/layout.js
@@ -278,6 +278,92 @@ function coerceClockBarPosition(position, mode, regionsCount) {
   return position === "left" || position === "right" ? position : "left";
 }
 
+/**
+ * Build the global clock bar settings object that screen overrides resolve
+ * against. Centralises the contract so callers don't hard-code `enabled: true`.
+ */
+export function getGlobalClockBarSettings(config = {}) {
+  return {
+    enabled: true,
+    mode: config.clockBarMode === "vertical" ? "vertical" : "horizontal",
+    position: config.clockBarPosition ?? "top",
+  };
+}
+
+/**
+ * Given a between-style position and a region count, return the gap index at
+ * which a between-bar should render, or `null` if the bar should not appear
+ * (non-between position, or fewer than 2 regions). The index is clamped to the
+ * last available gap so stale `between:N` values fall back gracefully.
+ */
+export function getClockBarPlacementGap(position, regionsCount) {
+  const idx = getClockBarBetweenIndex(position);
+  if (idx === null) return null;
+  if (!Number.isFinite(regionsCount) || regionsCount < 2) return null;
+  return Math.max(0, Math.min(idx, regionsCount - 2));
+}
+
+function inferModeForPerimeter(position) {
+  if (position === "top" || position === "bottom") return "horizontal";
+  if (position === "left" || position === "right") return "vertical";
+  return null;
+}
+
+/**
+ * Decide how a per-screen position change should be applied. Returns:
+ *   - `null` if the position is invalid
+ *   - `{ clear: true }` if the override should be removed (resolved value
+ *     would already match the globals exactly)
+ *   - `{ patch: {...} }` with the minimal patch to merge into `screen.clockBar`
+ *
+ * When the new position is a perimeter, the patch also pins `mode` so the
+ * screen owns its orientation and stays valid if global mode flips later.
+ */
+export function computeClockBarPositionUpdate(screen, position, globalSettings = {}) {
+  const regionsCount = screen?.layout?.regions?.length || 0;
+  const normalized = normalizeClockBarPosition(position, regionsCount);
+  if (!normalized) return null;
+
+  const sideMode = inferModeForPerimeter(normalized);
+  const override = screen?.clockBar || {};
+  const overrideHasMode = override.mode === "horizontal" || override.mode === "vertical";
+  const overrideHasEnabled = typeof override.enabled === "boolean";
+
+  // Clear the override only when the resolved value would already match the
+  // globals on every dimension — otherwise we'd silently change orientation
+  // (e.g. dropping on 'top' while global mode is 'vertical').
+  const positionMatchesGlobal = normalized === globalSettings.position;
+  const modeMatchesGlobal = sideMode === null || sideMode === globalSettings.mode;
+  if (positionMatchesGlobal && modeMatchesGlobal && !overrideHasMode && !overrideHasEnabled) {
+    return { clear: true };
+  }
+
+  const patch = { position: normalized };
+  if (sideMode) patch.mode = sideMode;
+  return { patch };
+}
+
+/**
+ * Decide how a per-screen mode change should be applied. Returns the minimal
+ * patch to merge into `screen.clockBar`. If the resolved position no longer
+ * matches the new mode (and isn't a between gap, which is mode-agnostic), the
+ * patch flips the position to a default perimeter for the new mode.
+ */
+export function computeClockBarModeUpdate(screen, mode, globalSettings = {}) {
+  if (mode !== "horizontal" && mode !== "vertical") return null;
+  const resolved = resolveClockBarForScreen(screen, globalSettings);
+  const patch = { mode };
+  const isPerimeter = CLOCK_BAR_PERIMETER_POSITIONS.includes(resolved.position);
+  const wrongSide =
+    isPerimeter &&
+    ((mode === "horizontal" && resolved.position !== "top" && resolved.position !== "bottom") ||
+      (mode === "vertical" && resolved.position !== "left" && resolved.position !== "right"));
+  if (wrongSide) {
+    patch.position = mode === "horizontal" ? "top" : "left";
+  }
+  return { patch };
+}
+
 export function getLeafRegions(layout) {
   if (!layout?.regions) return [];
   return layout.regions.flatMap(region =>

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -122,7 +122,8 @@ import { useModeStore } from "../stores/mode";
 import { useRoute } from "vue-router";
 import {
   getActiveDashboardScreen,
-  getClockBarBetweenIndex,
+  getClockBarPlacementGap,
+  getGlobalClockBarSettings,
   getLayoutDirection,
   getRegionAxisStyle,
   normalizeDashboardScreens,
@@ -149,18 +150,22 @@ const dashboardScreens = computed(() => normalizeDashboardScreens(configStore.da
 const activeScreen = computed(() => getActiveDashboardScreen(dashboardScreens.value));
 
 const effectiveClockBar = computed(() =>
-  resolveClockBarForScreen(activeScreen.value, {
-    enabled: true,
-    mode: configStore.clockBarMode,
-    position: configStore.clockBarPosition,
-  })
+  resolveClockBarForScreen(
+    activeScreen.value,
+    getGlobalClockBarSettings({
+      clockBarMode: configStore.clockBarMode,
+      clockBarPosition: configStore.clockBarPosition,
+    })
+  )
 );
 
 const clockBarActive = computed(() => effectiveClockBar.value.enabled && barVisible.value);
 const isHorizontalMode = computed(() => effectiveClockBar.value.mode === "horizontal");
 const isVerticalMode = computed(() => effectiveClockBar.value.mode === "vertical");
 const clockBarPosition = computed(() => effectiveClockBar.value.position);
-const clockBarBetweenIndex = computed(() => getClockBarBetweenIndex(clockBarPosition.value));
+const clockBarPlacementGap = computed(() =>
+  getClockBarPlacementGap(clockBarPosition.value, activeScreen.value?.layout?.regions?.length || 0)
+);
 
 const showHorizontalBarTop = computed(
   () => clockBarActive.value && isHorizontalMode.value && clockBarPosition.value === "top"
@@ -174,7 +179,7 @@ const showHorizontalBarBetween = computed(
   () =>
     clockBarActive.value &&
     isHorizontalMode.value &&
-    clockBarBetweenIndex.value !== null &&
+    clockBarPlacementGap.value !== null &&
     layoutDirection.value === "column"
 );
 
@@ -190,7 +195,7 @@ const showVerticalBarBetween = computed(
   () =>
     clockBarActive.value &&
     isVerticalMode.value &&
-    clockBarBetweenIndex.value !== null &&
+    clockBarPlacementGap.value !== null &&
     layoutDirection.value === "row"
 );
 
@@ -201,9 +206,7 @@ const layoutOrder = computed(() => {
     return withOuterClockBars(regionElements);
   }
 
-  const betweenIndex = clockBarBetweenIndex.value;
-  const maxBetween = regionElements.length - 2;
-  const placedBetween = betweenIndex === null ? null : Math.min(betweenIndex, maxBetween);
+  const placedBetween = clockBarPlacementGap.value;
 
   const elements = [];
   if (showVerticalBarLeft.value) elements.push("verticalBarLeft");

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -122,9 +122,11 @@ import { useModeStore } from "../stores/mode";
 import { useRoute } from "vue-router";
 import {
   getActiveDashboardScreen,
+  getClockBarBetweenIndex,
   getLayoutDirection,
   getRegionAxisStyle,
   normalizeDashboardScreens,
+  resolveClockBarForScreen,
 } from "../utils/layout";
 
 const configStore = useConfigStore();
@@ -143,40 +145,53 @@ const mainLayoutClass = computed(() => {
 
 const barVisible = computed(() => configStore.shouldShowUI || configStore.clockBarShowInKiosk);
 
-const shouldShowHorizontalBar = computed(() => configStore.clockBarMode === "horizontal");
-const shouldShowVerticalBar = computed(() => configStore.clockBarMode === "vertical");
+const dashboardScreens = computed(() => normalizeDashboardScreens(configStore.dashboardScreens));
+const activeScreen = computed(() => getActiveDashboardScreen(dashboardScreens.value));
+
+const effectiveClockBar = computed(() =>
+  resolveClockBarForScreen(activeScreen.value, {
+    enabled: true,
+    mode: configStore.clockBarMode,
+    position: configStore.clockBarPosition,
+  })
+);
+
+const clockBarActive = computed(() => effectiveClockBar.value.enabled && barVisible.value);
+const isHorizontalMode = computed(() => effectiveClockBar.value.mode === "horizontal");
+const isVerticalMode = computed(() => effectiveClockBar.value.mode === "vertical");
+const clockBarPosition = computed(() => effectiveClockBar.value.position);
+const clockBarBetweenIndex = computed(() => getClockBarBetweenIndex(clockBarPosition.value));
 
 const showHorizontalBarTop = computed(
-  () => shouldShowHorizontalBar.value && configStore.clockBarPosition === "top" && barVisible.value
+  () => clockBarActive.value && isHorizontalMode.value && clockBarPosition.value === "top"
 );
 
 const showHorizontalBarBottom = computed(
-  () =>
-    shouldShowHorizontalBar.value && configStore.clockBarPosition === "bottom" && barVisible.value
+  () => clockBarActive.value && isHorizontalMode.value && clockBarPosition.value === "bottom"
 );
 
 const showHorizontalBarBetween = computed(
   () =>
-    shouldShowHorizontalBar.value &&
-    configStore.clockBarPosition === "between" &&
-    layoutDirection.value === "column" &&
-    barVisible.value
+    clockBarActive.value &&
+    isHorizontalMode.value &&
+    clockBarBetweenIndex.value !== null &&
+    layoutDirection.value === "column"
 );
 
 const showVerticalBarLeft = computed(
-  () => shouldShowVerticalBar.value && configStore.clockBarPosition === "left" && barVisible.value
+  () => clockBarActive.value && isVerticalMode.value && clockBarPosition.value === "left"
 );
 
 const showVerticalBarRight = computed(
-  () => shouldShowVerticalBar.value && configStore.clockBarPosition === "right" && barVisible.value
+  () => clockBarActive.value && isVerticalMode.value && clockBarPosition.value === "right"
 );
 
 const showVerticalBarBetween = computed(
   () =>
-    shouldShowVerticalBar.value &&
-    configStore.clockBarPosition === "between" &&
-    layoutDirection.value === "row" &&
-    barVisible.value
+    clockBarActive.value &&
+    isVerticalMode.value &&
+    clockBarBetweenIndex.value !== null &&
+    layoutDirection.value === "row"
 );
 
 // Computed layout order - determines the order elements should be rendered
@@ -186,19 +201,22 @@ const layoutOrder = computed(() => {
     return withOuterClockBars(regionElements);
   }
 
+  const betweenIndex = clockBarBetweenIndex.value;
+  const maxBetween = regionElements.length - 2;
+  const placedBetween = betweenIndex === null ? null : Math.min(betweenIndex, maxBetween);
+
   const elements = [];
   if (showVerticalBarLeft.value) elements.push("verticalBarLeft");
   regionElements.forEach((regionElement, index) => {
-    if (index > 0 && showVerticalBarBetween.value) elements.push("verticalBarBetween");
-    if (index > 0 && showHorizontalBarBetween.value) elements.push("horizontalBarBetween");
+    if (index > 0 && index - 1 === placedBetween) {
+      if (showVerticalBarBetween.value) elements.push("verticalBarBetween");
+      else if (showHorizontalBarBetween.value) elements.push("horizontalBarBetween");
+    }
     elements.push(regionElement);
   });
   if (showVerticalBarRight.value) elements.push("verticalBarRight");
   return elements;
 });
-
-const dashboardScreens = computed(() => normalizeDashboardScreens(configStore.dashboardScreens));
-const activeScreen = computed(() => getActiveDashboardScreen(dashboardScreens.value));
 
 const withOuterClockBars = regionElements => {
   const elements = [];

--- a/frontend/tests/unit/utils/layout.spec.js
+++ b/frontend/tests/unit/utils/layout.spec.js
@@ -10,19 +10,24 @@ import {
   cycleDashboardScreen,
   getActiveDashboardRegion,
   getActiveDashboardScreen,
+  getClockBarBetweenIndex,
   getDashboardRegionOrder,
   getLayoutDirection,
   getLayoutOrder,
   getLeafRegions,
   getRegionAxisStyle,
   getSplitDirection,
+  isClockBarBetweenPosition,
+  normalizeClockBarPosition,
   normalizeDashboardLayout,
   normalizeDashboardScreens,
+  normalizeScreenClockBar,
   removeSubRegion,
   removeTopRegion,
   resizeAdjacentRegions,
   resizeSubRegion,
   resizeSubRegionPair,
+  resolveClockBarForScreen,
   setLayoutDirection,
   setSplitDirection,
   setSubRegionContent,
@@ -492,6 +497,172 @@ describe("Layout Utilities", () => {
       expect(cycled.screens[0].activeRegionId).toBe("region-2");
       cycled = cycleActiveDashboardRegion(cycled, 1);
       expect(cycled.screens[0].activeRegionId).toBe("region-1-a");
+    });
+  });
+
+  describe("clock bar per-screen settings", () => {
+    const screenWith = (regionsCount, clockBar) => ({
+      id: "screen-1",
+      name: "Test",
+      layout: {
+        version: 1,
+        preset: "split_two",
+        direction: null,
+        regions: Array.from({ length: regionsCount }, (_, i) => ({
+          id: `region-${i + 1}`,
+          kind: "calendar",
+          instanceIds: [],
+          size: Math.floor(100 / regionsCount),
+          split: null,
+        })),
+      },
+      activeRegionId: "region-1",
+      clockBar: clockBar ?? null,
+    });
+
+    describe("normalizeClockBarPosition", () => {
+      it("returns perimeter values unchanged", () => {
+        expect(normalizeClockBarPosition("top", 2)).toBe("top");
+        expect(normalizeClockBarPosition("bottom", 2)).toBe("bottom");
+        expect(normalizeClockBarPosition("left", 2)).toBe("left");
+        expect(normalizeClockBarPosition("right", 2)).toBe("right");
+      });
+
+      it("normalizes 'between' to canonical first-gap form", () => {
+        expect(normalizeClockBarPosition("between", 3)).toBe("between");
+        expect(normalizeClockBarPosition("between:0", 3)).toBe("between");
+      });
+
+      it("preserves valid between:N for higher gaps", () => {
+        expect(normalizeClockBarPosition("between:1", 3)).toBe("between:1");
+        expect(normalizeClockBarPosition("between:2", 4)).toBe("between:2");
+      });
+
+      it("clamps between:N to the last available gap", () => {
+        expect(normalizeClockBarPosition("between:5", 3)).toBe("between:1");
+        expect(normalizeClockBarPosition("between:1", 2)).toBe("between");
+      });
+
+      it("rejects unknown values", () => {
+        expect(normalizeClockBarPosition("nope", 2)).toBeNull();
+        expect(normalizeClockBarPosition(null, 2)).toBeNull();
+        expect(normalizeClockBarPosition(undefined, 2)).toBeNull();
+      });
+    });
+
+    describe("getClockBarBetweenIndex / isClockBarBetweenPosition", () => {
+      it("returns 0 for 'between' and the parsed index for 'between:N'", () => {
+        expect(getClockBarBetweenIndex("between")).toBe(0);
+        expect(getClockBarBetweenIndex("between:2")).toBe(2);
+      });
+
+      it("returns null for non-between positions", () => {
+        expect(getClockBarBetweenIndex("top")).toBeNull();
+        expect(getClockBarBetweenIndex("right")).toBeNull();
+        expect(getClockBarBetweenIndex(null)).toBeNull();
+      });
+
+      it("isClockBarBetweenPosition mirrors the index check", () => {
+        expect(isClockBarBetweenPosition("between")).toBe(true);
+        expect(isClockBarBetweenPosition("between:3")).toBe(true);
+        expect(isClockBarBetweenPosition("top")).toBe(false);
+      });
+    });
+
+    describe("normalizeScreenClockBar", () => {
+      it("returns null for empty/invalid input", () => {
+        expect(normalizeScreenClockBar(null, 2)).toBeNull();
+        expect(normalizeScreenClockBar({}, 2)).toBeNull();
+        expect(normalizeScreenClockBar({ enabled: "yes" }, 2)).toBeNull();
+      });
+
+      it("keeps recognized fields and drops unknown ones", () => {
+        expect(
+          normalizeScreenClockBar(
+            { enabled: false, mode: "vertical", position: "left", junk: 42 },
+            2
+          )
+        ).toEqual({ enabled: false, mode: "vertical", position: "left" });
+      });
+
+      it("clamps stale between indices", () => {
+        expect(normalizeScreenClockBar({ position: "between:5" }, 3)).toEqual({
+          position: "between:1",
+        });
+      });
+    });
+
+    describe("normalizeDashboardScreen with clockBar", () => {
+      it("populates clockBar=null when no override provided", () => {
+        const screens = normalizeDashboardScreens({
+          version: 2,
+          activeScreenId: "screen-1",
+          screens: [{ id: "screen-1", name: "Home" }],
+        });
+        expect(screens.screens[0].clockBar).toBeNull();
+      });
+
+      it("preserves a valid override", () => {
+        const screens = normalizeDashboardScreens({
+          version: 2,
+          activeScreenId: "screen-1",
+          screens: [
+            {
+              id: "screen-1",
+              name: "Home",
+              clockBar: { enabled: false, mode: "vertical", position: "right" },
+            },
+          ],
+        });
+        expect(screens.screens[0].clockBar).toEqual({
+          enabled: false,
+          mode: "vertical",
+          position: "right",
+        });
+      });
+    });
+
+    describe("resolveClockBarForScreen", () => {
+      const globals = { enabled: true, mode: "horizontal", position: "top" };
+
+      it("falls back to globals when no override exists", () => {
+        const screen = screenWith(2, null);
+        expect(resolveClockBarForScreen(screen, globals)).toEqual({
+          enabled: true,
+          mode: "horizontal",
+          position: "top",
+        });
+      });
+
+      it("merges per-screen overrides on top of globals", () => {
+        const screen = screenWith(2, { mode: "vertical", position: "left" });
+        expect(resolveClockBarForScreen(screen, globals)).toEqual({
+          enabled: true,
+          mode: "vertical",
+          position: "left",
+        });
+      });
+
+      it("coerces an inconsistent (mode, position) pair to a sane perimeter", () => {
+        const screen = screenWith(2, { mode: "horizontal", position: "left" });
+        expect(resolveClockBarForScreen(screen, globals).position).toBe("top");
+      });
+
+      it("falls back to a perimeter when 'between' is requested with <2 regions", () => {
+        const screen = screenWith(1, { position: "between" });
+        const resolved = resolveClockBarForScreen(screen, globals);
+        expect(resolved.position).toBe("top");
+      });
+
+      it("clamps a stale between index against the screen's region count", () => {
+        const screen = screenWith(3, { position: "between:9" });
+        expect(resolveClockBarForScreen(screen, globals).position).toBe("between:1");
+      });
+
+      it("honors per-screen enabled=false override", () => {
+        const screen = screenWith(2, { enabled: false });
+        expect(resolveClockBarForScreen(screen, globals).enabled).toBe(false);
+      });
     });
   });
 });

--- a/frontend/tests/unit/utils/layout.spec.js
+++ b/frontend/tests/unit/utils/layout.spec.js
@@ -5,13 +5,17 @@ import {
   MAX_TOP_REGIONS,
   addSubRegion,
   addTopRegion,
+  computeClockBarModeUpdate,
+  computeClockBarPositionUpdate,
   createDashboardLayoutFromPreset,
   cycleActiveDashboardRegion,
   cycleDashboardScreen,
   getActiveDashboardRegion,
   getActiveDashboardScreen,
   getClockBarBetweenIndex,
+  getClockBarPlacementGap,
   getDashboardRegionOrder,
+  getGlobalClockBarSettings,
   getLayoutDirection,
   getLayoutOrder,
   getLeafRegions,
@@ -662,6 +666,148 @@ describe("Layout Utilities", () => {
       it("honors per-screen enabled=false override", () => {
         const screen = screenWith(2, { enabled: false });
         expect(resolveClockBarForScreen(screen, globals).enabled).toBe(false);
+      });
+    });
+
+    describe("getGlobalClockBarSettings", () => {
+      it("defaults to enabled horizontal/top when config is empty", () => {
+        expect(getGlobalClockBarSettings({})).toEqual({
+          enabled: true,
+          mode: "horizontal",
+          position: "top",
+        });
+      });
+
+      it("reads mode and position from config", () => {
+        expect(
+          getGlobalClockBarSettings({ clockBarMode: "vertical", clockBarPosition: "right" })
+        ).toEqual({ enabled: true, mode: "vertical", position: "right" });
+      });
+
+      it("coerces unknown mode to horizontal", () => {
+        expect(getGlobalClockBarSettings({ clockBarMode: "diagonal" }).mode).toBe("horizontal");
+      });
+    });
+
+    describe("getClockBarPlacementGap", () => {
+      it("returns null for non-between positions", () => {
+        expect(getClockBarPlacementGap("top", 3)).toBeNull();
+        expect(getClockBarPlacementGap("right", 3)).toBeNull();
+        expect(getClockBarPlacementGap(null, 3)).toBeNull();
+      });
+
+      it("returns null when there are fewer than 2 regions", () => {
+        expect(getClockBarPlacementGap("between", 0)).toBeNull();
+        expect(getClockBarPlacementGap("between", 1)).toBeNull();
+        expect(getClockBarPlacementGap("between:2", 1)).toBeNull();
+      });
+
+      it("returns the parsed gap index for valid between:N", () => {
+        expect(getClockBarPlacementGap("between", 3)).toBe(0);
+        expect(getClockBarPlacementGap("between:1", 3)).toBe(1);
+        expect(getClockBarPlacementGap("between:2", 4)).toBe(2);
+      });
+
+      it("clamps stale between:N to the last available gap (regression for #34)", () => {
+        // 3 regions => gaps 0..1; between:9 should fall to gap 1.
+        expect(getClockBarPlacementGap("between:9", 3)).toBe(1);
+        // 2 regions => only gap 0.
+        expect(getClockBarPlacementGap("between:5", 2)).toBe(0);
+      });
+
+      it("clamps negative-ish indices to 0", () => {
+        expect(getClockBarPlacementGap("between:0", 5)).toBe(0);
+      });
+    });
+
+    describe("computeClockBarPositionUpdate", () => {
+      const globals = { enabled: true, mode: "horizontal", position: "top" };
+
+      it("returns null for an invalid position", () => {
+        const screen = screenWith(2, null);
+        expect(computeClockBarPositionUpdate(screen, "nope", globals)).toBeNull();
+      });
+
+      it("clears the override when the new position matches global on every dimension", () => {
+        const screen = screenWith(2, null);
+        expect(computeClockBarPositionUpdate(screen, "top", globals)).toEqual({ clear: true });
+      });
+
+      it("does NOT clear when the inferred mode differs from global mode", () => {
+        // Global is vertical/right; user drops onto 'top'. Position 'top' implies
+        // horizontal mode, so we must keep an override that pins mode=horizontal —
+        // otherwise resolution would coerce back to a vertical perimeter.
+        const verticalGlobals = { enabled: true, mode: "vertical", position: "top" };
+        const screen = screenWith(2, null);
+        const result = computeClockBarPositionUpdate(screen, "top", verticalGlobals);
+        expect(result).toEqual({ patch: { position: "top", mode: "horizontal" } });
+      });
+
+      it("does NOT clear when the screen has an enabled override", () => {
+        const screen = screenWith(2, { enabled: false });
+        const result = computeClockBarPositionUpdate(screen, "top", globals);
+        expect(result).toEqual({ patch: { position: "top", mode: "horizontal" } });
+      });
+
+      it("does NOT clear when the screen has a mode override", () => {
+        const screen = screenWith(2, { mode: "vertical" });
+        const result = computeClockBarPositionUpdate(screen, "top", globals);
+        expect(result).toEqual({ patch: { position: "top", mode: "horizontal" } });
+      });
+
+      it("pins mode for perimeter positions so screen owns its orientation", () => {
+        const screen = screenWith(2, null);
+        expect(computeClockBarPositionUpdate(screen, "left", globals)).toEqual({
+          patch: { position: "left", mode: "vertical" },
+        });
+        expect(computeClockBarPositionUpdate(screen, "bottom", globals)).toEqual({
+          patch: { position: "bottom", mode: "horizontal" },
+        });
+      });
+
+      it("does not pin mode for between positions (mode-agnostic)", () => {
+        const screen = screenWith(3, null);
+        expect(computeClockBarPositionUpdate(screen, "between:1", globals)).toEqual({
+          patch: { position: "between:1" },
+        });
+      });
+
+      it("clamps stale between:N before patching", () => {
+        const screen = screenWith(3, null);
+        expect(computeClockBarPositionUpdate(screen, "between:9", globals)).toEqual({
+          patch: { position: "between:1" },
+        });
+      });
+    });
+
+    describe("computeClockBarModeUpdate", () => {
+      const globals = { enabled: true, mode: "horizontal", position: "top" };
+
+      it("returns null for an invalid mode", () => {
+        const screen = screenWith(2, null);
+        expect(computeClockBarModeUpdate(screen, "diagonal", globals)).toBeNull();
+      });
+
+      it("flips position to a default perimeter when the new mode invalidates it", () => {
+        // Resolved is vertical/left, switching to horizontal -> default 'top'.
+        const screen = screenWith(2, { mode: "vertical", position: "left" });
+        expect(computeClockBarModeUpdate(screen, "horizontal", globals)).toEqual({
+          patch: { mode: "horizontal", position: "top" },
+        });
+      });
+
+      it("keeps a between position untouched (mode-agnostic)", () => {
+        const screen = screenWith(3, { position: "between:1" });
+        expect(computeClockBarModeUpdate(screen, "vertical", globals)).toEqual({
+          patch: { mode: "vertical" },
+        });
+      });
+
+      it("only patches mode when the resolved perimeter already matches", () => {
+        const screen = screenWith(2, { position: "bottom" });
+        expect(computeClockBarModeUpdate(screen, "horizontal", globals)).toEqual({
+          patch: { mode: "horizontal" },
+        });
       });
     });
   });


### PR DESCRIPTION
## Summary
- Each dashboard screen can now override the clock bar's enabled state, mode, and position. Position supports any specific gap between top-level regions via a new `between:N` syntax — pickable via dropdown or by dragging the bar token in the screen preview onto labelled drop zones.
- Fixes the bug from #34 where global `between` rendered a clock bar at *every* inter-region gap; it now renders at exactly one gap (the configured one, or gap 0 globally).
- Reworks the global Clock Bar settings into four grouped sections — **Clock display**, **Default position**, **Appearance**, **Visibility** — with a hint that points users to per-screen overrides in Screens settings.
- Polishes the Bar Items tab: dropped the implementation-leaking copy, added a "*N* of *M* tiles shown" summary, dimmed hidden rows, replaced the text-only checkbox with a proper switch.

## Schema
- New per-screen field `clockBar: { enabled?, mode?, position? } | null` on each dashboard screen. Any field omitted inherits the global. Position values: `top`/`bottom`/`left`/`right`/`between`/`between:N` (clamped to valid gap indices on normalize).
- Helpers added: `normalizeScreenClockBar`, `normalizeClockBarPosition`, `getClockBarBetweenIndex`, `isClockBarBetweenPosition`, `resolveClockBarForScreen`.

## Test plan
- [x] `npm run test` — 579/579 pass (23 new)
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [ ] Manually verify in dev server: per-screen override + drag-drop to perimeter sides and inter-region gaps; confirm screen with `enabled: false` hides the bar; confirm clearing override falls back to globals.