### PR TITLE
Fix per-screen clock bar runtime + UX regressions

### DIFF
--- a/frontend/src/components/ClockBarVertical.vue
+++ b/frontend/src/components/ClockBarVertical.vue
@@ -10,7 +10,9 @@
   >
     <div class="clock-bar-top">
       <BarLogo v-if="showLogo" />
+    </div>
 
+    <div class="clock-bar-middle">
       <div
         class="clock-bar-content"
         :class="{
@@ -117,8 +119,7 @@ const showLogo = computed(() => configStore.clockBarShowLogo !== false);
   border-right: 1px solid var(--border-color);
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: space-between;
+  align-items: stretch;
   gap: 0.75rem;
   z-index: 100;
   user-select: none;
@@ -137,30 +138,48 @@ const showLogo = computed(() => configStore.clockBarShowLogo !== false);
   border-radius: 4px;
 }
 
-.clock-bar-content {
+.clock-bar-top {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 0 0 auto;
+}
+
+.clock-bar-middle {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
+  gap: 0.75rem;
+  min-height: 0;
+}
+
+.clock-bar-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
   font-family: "Courier New", monospace;
-  writing-mode: vertical-rl;
-  text-orientation: upright;
   white-space: nowrap;
+  text-align: center;
 }
 
 .clock-bar-content.layout-two-lines {
-  flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.15rem;
 }
 
 .clock-time {
   font-weight: 600;
   color: var(--text-primary);
+  line-height: 1.1;
 }
 
 .clock-date {
   color: var(--text-secondary);
+  line-height: 1.1;
 }
 
 .clock-bar-vertical.position-between .clock-time {
@@ -171,14 +190,8 @@ const showLogo = computed(() => configStore.clockBarShowLogo !== false);
   font-size: 0.75rem;
 }
 
-.clock-bar-top {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.75rem;
-}
-
 .clock-bar-actions {
   width: 100%;
+  flex: 0 0 auto;
 }
 </style>

--- a/frontend/src/components/settings/tabs/dashboard/DashboardLayoutTab.vue
+++ b/frontend/src/components/settings/tabs/dashboard/DashboardLayoutTab.vue
@@ -73,6 +73,26 @@
               @change="handleScreenNameChange(screenIndex, $event)"
             />
             <button
+              type="button"
+              class="screen-activate"
+              :class="{ 'screen-activate-active': isActiveScreen(screen) }"
+              :disabled="isActiveScreen(screen)"
+              :aria-pressed="isActiveScreen(screen)"
+              :aria-label="
+                isActiveScreen(screen)
+                  ? `Screen ${screenIndex + 1} is active`
+                  : `Activate screen ${screenIndex + 1}`
+              "
+              :title="
+                isActiveScreen(screen)
+                  ? 'This screen is currently shown on the dashboard'
+                  : 'Show this screen on the dashboard'
+              "
+              @click="activateScreen(screenIndex)"
+            >
+              {{ isActiveScreen(screen) ? "● Active" : "Activate" }}
+            </button>
+            <button
               :id="`add-region-${screen.id}`"
               type="button"
               class="add-region-button"
@@ -865,6 +885,16 @@ const setScreenClockBarEnabled = (screenIndex, enabled) => {
   updateScreenClockBar(screenIndex, { enabled });
 };
 
+const isActiveScreen = screen => screen?.id === dashboardScreens.value.activeScreenId;
+
+const activateScreen = screenIndex => {
+  const screens = cloneScreens();
+  const target = screens.screens[screenIndex];
+  if (!target) return;
+  screens.activeScreenId = target.id;
+  emitScreensUpdate(screens);
+};
+
 const dashboardScreens = computed(() => configValue.value.dashboardScreens);
 
 const expandedScreens = reactive(new Set([dashboardScreens.value.activeScreenId]));
@@ -1467,6 +1497,35 @@ onUnmounted(() => {
 .direction-toggle:focus {
   border-color: var(--accent-primary);
   color: var(--text-primary);
+}
+
+.screen-activate {
+  flex: 0 0 auto;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 0.35rem 0.6rem;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.screen-activate:hover:not(:disabled),
+.screen-activate:focus:not(:disabled) {
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+}
+
+.screen-activate-active {
+  border-color: var(--accent-primary);
+  background: var(--accent-primary);
+  color: #fff;
+  cursor: default;
+}
+
+.screen-activate:disabled {
+  opacity: 1;
 }
 
 .screen-delete {

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -13,91 +13,95 @@
       <!-- Minimal UI overlay (shown when UI is hidden) -->
       <MinimalUIOverlay v-if="!configStore.shouldShowUI" />
 
-      <div :class="['dashboard-main', mainLayoutClass]">
-        <!-- Fullscreen Mode (Photos or Web Services) -->
-        <div v-if="modeStore.isFullscreen" class="mode-content fullscreen-mode">
-          <!-- Fullscreen Photos -->
-          <PhotoSlideshow
-            v-if="modeStore.fullscreenMode === modeStore.MODES.PHOTOS"
-            :is-fullscreen="true"
-            :auto-rotate="true"
-            :rotation-interval="configStore.photoRotationInterval * 1000"
-          />
-          <!-- Fullscreen Web Services -->
-          <WebServiceViewer
-            v-else-if="modeStore.fullscreenMode === modeStore.MODES.WEB_SERVICES"
-            :is-fullscreen="true"
-          />
-        </div>
+      <!--
+        Dashboard stage wraps the side perimeter bars and the body so that
+        vertical left/right bars sit at the dashboard edge regardless of the
+        active screen's layout direction (row vs column).
+      -->
+      <div class="dashboard-stage">
+        <ClockBarVertical
+          v-if="showVerticalBarLeft"
+          position="left"
+          :show-in-non-kiosk="true"
+          :show-in-kiosk="configStore.clockBarShowInKiosk"
+          :enabled="true"
+        />
 
-        <!-- Dashboard View (Home) - Renders configured dashboard regions -->
-        <div v-else :class="['mode-content', 'dashboard-view', mainLayoutClass]">
-          <!-- Render elements in computed order - no CSS order needed! -->
-          <template v-for="elementType in layoutOrder" :key="elementType">
-            <!-- Vertical Clock Bar at Left -->
-            <ClockBarVertical
-              v-if="elementType === 'verticalBarLeft'"
-              position="left"
-              :show-in-non-kiosk="true"
-              :show-in-kiosk="configStore.clockBarShowInKiosk"
-              :enabled="true"
+        <div :class="['dashboard-main', mainLayoutClass]">
+          <!-- Fullscreen Mode (Photos or Web Services) -->
+          <div v-if="modeStore.isFullscreen" class="mode-content fullscreen-mode">
+            <!-- Fullscreen Photos -->
+            <PhotoSlideshow
+              v-if="modeStore.fullscreenMode === modeStore.MODES.PHOTOS"
+              :is-fullscreen="true"
+              :auto-rotate="true"
+              :rotation-interval="configStore.photoRotationInterval * 1000"
             />
+            <!-- Fullscreen Web Services -->
+            <WebServiceViewer
+              v-else-if="modeStore.fullscreenMode === modeStore.MODES.WEB_SERVICES"
+              :is-fullscreen="true"
+            />
+          </div>
 
-            <!-- Dashboard Region -->
-            <div
-              v-else-if="isRegionElement(elementType)"
-              :class="[
-                'dashboard-region-section',
-                {
-                  'dashboard-region-section-active':
-                    activeRegionHighlightVisible && isActiveRegionElement(elementType),
-                },
-              ]"
-              :style="getRegionStyle(elementType)"
-            >
-              <DashboardRegion
-                :region="getRegionForElement(elementType)"
-                :photo-rotation-interval="configStore.photoRotationInterval"
-                :parent-direction="layoutDirection"
-                :active-region-id="
-                  activeRegionHighlightVisible ? activeScreen.activeRegionId : null
-                "
+          <!-- Dashboard View (Home) - Renders configured dashboard regions -->
+          <div v-else :class="['mode-content', 'dashboard-view', mainLayoutClass]">
+            <template v-for="elementType in layoutOrder" :key="elementType">
+              <!-- Dashboard Region -->
+              <div
+                v-if="isRegionElement(elementType)"
+                :class="[
+                  'dashboard-region-section',
+                  {
+                    'dashboard-region-section-active':
+                      activeRegionHighlightVisible && isActiveRegionElement(elementType),
+                  },
+                ]"
+                :style="getRegionStyle(elementType)"
+              >
+                <DashboardRegion
+                  :region="getRegionForElement(elementType)"
+                  :photo-rotation-interval="configStore.photoRotationInterval"
+                  :parent-direction="layoutDirection"
+                  :active-region-id="
+                    activeRegionHighlightVisible ? activeScreen.activeRegionId : null
+                  "
+                />
+              </div>
+
+              <!-- Horizontal between bar (regions stacked vertically) -->
+              <ClockBarHorizontal
+                v-else-if="elementType === 'horizontalBarBetween'"
+                position="between"
+                :show-in-non-kiosk="true"
+                :show-in-kiosk="configStore.clockBarShowInKiosk"
+                :enabled="true"
               />
-            </div>
 
-            <!-- Horizontal Clock Bar Between (Portrait) -->
-            <ClockBarHorizontal
-              v-else-if="elementType === 'horizontalBarBetween'"
-              position="between"
-              :show-in-non-kiosk="true"
-              :show-in-kiosk="configStore.clockBarShowInKiosk"
-              :enabled="true"
-            />
+              <!-- Vertical between bar (regions side by side) -->
+              <ClockBarVertical
+                v-else-if="elementType === 'verticalBarBetween'"
+                position="between"
+                :show-in-non-kiosk="true"
+                :show-in-kiosk="configStore.clockBarShowInKiosk"
+                :enabled="true"
+              />
+            </template>
+          </div>
 
-            <!-- Vertical Clock Bar Between (Landscape) -->
-            <ClockBarVertical
-              v-else-if="elementType === 'verticalBarBetween'"
-              position="between"
-              :show-in-non-kiosk="true"
-              :show-in-kiosk="configStore.clockBarShowInKiosk"
-              :enabled="true"
-            />
-
-            <!-- Vertical Clock Bar at Right -->
-            <ClockBarVertical
-              v-else-if="elementType === 'verticalBarRight'"
-              position="right"
-              :show-in-non-kiosk="true"
-              :show-in-kiosk="configStore.clockBarShowInKiosk"
-              :enabled="true"
-            />
-          </template>
+          <!-- Horizontal Clock Bar at Bottom -->
+          <ClockBarHorizontal
+            v-if="showHorizontalBarBottom"
+            position="bottom"
+            :show-in-non-kiosk="true"
+            :show-in-kiosk="configStore.clockBarShowInKiosk"
+            :enabled="true"
+          />
         </div>
 
-        <!-- Horizontal Clock Bar at Bottom -->
-        <ClockBarHorizontal
-          v-if="showHorizontalBarBottom"
-          position="bottom"
+        <ClockBarVertical
+          v-if="showVerticalBarRight"
+          position="right"
           :show-in-non-kiosk="true"
           :show-in-kiosk="configStore.clockBarShowInKiosk"
           :enabled="true"
@@ -175,12 +179,21 @@ const showHorizontalBarBottom = computed(
   () => clockBarActive.value && isHorizontalMode.value && clockBarPosition.value === "bottom"
 );
 
+// Between-bar orientation follows the layout direction (perpendicular to the
+// region flow), not the user-selected mode. So a 'between' position renders as
+// a horizontal strip when regions stack and a vertical strip when they sit
+// side by side, regardless of whether the user picked horizontal or vertical
+// mode for the perimeter case.
 const showHorizontalBarBetween = computed(
   () =>
     clockBarActive.value &&
-    isHorizontalMode.value &&
     clockBarPlacementGap.value !== null &&
     layoutDirection.value === "column"
+);
+
+const showVerticalBarBetween = computed(
+  () =>
+    clockBarActive.value && clockBarPlacementGap.value !== null && layoutDirection.value === "row"
 );
 
 const showVerticalBarLeft = computed(
@@ -191,43 +204,22 @@ const showVerticalBarRight = computed(
   () => clockBarActive.value && isVerticalMode.value && clockBarPosition.value === "right"
 );
 
-const showVerticalBarBetween = computed(
-  () =>
-    clockBarActive.value &&
-    isVerticalMode.value &&
-    clockBarPlacementGap.value !== null &&
-    layoutDirection.value === "row"
-);
-
 // Computed layout order - determines the order elements should be rendered
 const layoutOrder = computed(() => {
   const regionElements = activeScreen.value.layout.regions.map(region => `region:${region.id}`);
-  if (regionElements.length <= 1) {
-    return withOuterClockBars(regionElements);
-  }
+  if (regionElements.length <= 1) return regionElements;
 
   const placedBetween = clockBarPlacementGap.value;
-
   const elements = [];
-  if (showVerticalBarLeft.value) elements.push("verticalBarLeft");
   regionElements.forEach((regionElement, index) => {
     if (index > 0 && index - 1 === placedBetween) {
-      if (showVerticalBarBetween.value) elements.push("verticalBarBetween");
-      else if (showHorizontalBarBetween.value) elements.push("horizontalBarBetween");
+      if (showHorizontalBarBetween.value) elements.push("horizontalBarBetween");
+      else if (showVerticalBarBetween.value) elements.push("verticalBarBetween");
     }
     elements.push(regionElement);
   });
-  if (showVerticalBarRight.value) elements.push("verticalBarRight");
   return elements;
 });
-
-const withOuterClockBars = regionElements => {
-  const elements = [];
-  if (showVerticalBarLeft.value) elements.push("verticalBarLeft");
-  elements.push(...regionElements);
-  if (showVerticalBarRight.value) elements.push("verticalBarRight");
-  return elements;
-};
 
 const isRegionElement = elementType => elementType.startsWith("region:");
 
@@ -332,20 +324,21 @@ onUnmounted(() => {
   background: var(--bg-secondary);
 }
 
+.dashboard-stage {
+  flex: 1;
+  display: flex;
+  flex-direction: row;
+  min-height: 0;
+  min-width: 0;
+}
+
 .dashboard-main {
   flex: 1;
   display: flex;
+  flex-direction: column;
   gap: 1rem;
-  min-height: 0; /* Important for flex children */
-  flex-direction: row; /* Default to row (landscape) */
-}
-
-.dashboard-main.layout-portrait {
-  flex-direction: column; /* Portrait: stack vertically */
-}
-
-.dashboard-main.layout-landscape {
-  flex-direction: row; /* Landscape: side by side */
+  min-height: 0;
+  min-width: 0;
 }
 
 .mode-content {


### PR DESCRIPTION
Follow-up fixes to #53.

## Bugs fixed
1. **Vertical bar text crammed at top, almost unreadable.** `writing-mode: vertical-rl` was stacking "12:34" as a column of upright glyphs and the whole content group was glued to the top via `justify-content: space-between`. Restored horizontal text inside a 3-section vertical layout — logo top, time/date middle (centered), actions bottom.
2. **"Between" position disappeared in some layouts.** The runtime required the bar's `mode` to match the layout direction (horizontal mode + column layout, vertical mode + row layout). Between-bar orientation now follows the layout direction (perpendicular to the region flow) regardless of mode, so dropping the bar at any gap always renders.
3. **Vertical perimeter bars wouldn't show in column-direction layouts.** They were rendered as siblings of regions inside `mode-content`, which collapsed them when the regions flex was column. Moved them into a new `.dashboard-stage` row wrapper so they always sit at the dashboard edge.
4. **Active-screen switching was keyboard-only.** Added an "Activate" button to each screen card in the screen builder; the current active screen shows a solid-accent "● Active" pill.

## Test plan
- [x] `npm run test` — 599/599 pass
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [ ] Manually verify on a real screen: vertical bar centered + readable; between renders for any mode/layout combination; vertical perimeter bars visible with both row and column screen layouts; Activate button switches the live dashboard.