### PR TITLE
[codex] Improve clock bar layout controls

### DIFF
--- a/Makefile.ps1
+++ b/Makefile.ps1
@@ -15,6 +15,7 @@ function Show-Help {
     Write-Host "  .\Makefile.ps1 dev-logs       - Tail logs from running dev stack" -ForegroundColor White
     Write-Host "  .\Makefile.ps1 dev-logs-read  - Show last 50 lines of dev logs" -ForegroundColor White
     Write-Host "  .\Makefile.ps1 dev-down       - Stop dev stack" -ForegroundColor White
+    Write-Host "  .\Makefile.ps1 dev-restart    - Restart dev stack containers" -ForegroundColor White
     Write-Host "  .\Makefile.ps1 doctor         - Check docker + dev env" -ForegroundColor White
     Write-Host "  .\Makefile.ps1 test           - Run all tests (native)" -ForegroundColor White
     Write-Host "  .\Makefile.ps1 test-backend   - Run backend tests only (native)" -ForegroundColor White
@@ -57,6 +58,10 @@ function Read-Dev-Logs {
 
 function Stop-Dev {
     & docker @ComposeDev down
+}
+
+function Restart-Dev {
+    & docker @ComposeDev restart
 }
 
 function Run-Tests {
@@ -243,7 +248,7 @@ function Show-Doctor {
     Write-Host "Ports (8000 backend, 5173 frontend):"
     foreach ($p in 8000, 5173) {
         $inUse = Get-NetTCPConnection -LocalPort $p -State Listen -ErrorAction SilentlyContinue
-        if ($inUse) { Write-Host "  $p: IN USE" -ForegroundColor Yellow } else { Write-Host "  $p: free" -ForegroundColor Green }
+        if ($inUse) { Write-Host "  ${p}: IN USE" -ForegroundColor Yellow } else { Write-Host "  ${p}: free" -ForegroundColor Green }
     }
 }
 
@@ -255,6 +260,7 @@ switch ($Target.ToLower()) {
     "dev-logs" { Tail-Dev-Logs }
     "dev-logs-read" { Read-Dev-Logs }
     "dev-down" { Stop-Dev }
+    "dev-restart" { Restart-Dev }
     "doctor" { Show-Doctor }
     "test" { Run-Tests }
     "test-backend" { Run-Tests-Backend }

--- a/backend/app/api/routes/config.py
+++ b/backend/app/api/routes/config.py
@@ -148,6 +148,10 @@ class ConfigUpdate(BaseModel):
     calendarRefreshInterval: int | None = (
         None  # Calendar cache refresh interval in minutes (default: 15)
     )
+    clockBarVerticalLayout: str | None = None  # Vertical bar layout
+    clockBarVerticalFontSize: int | None = None
+    clockBarVerticalDateFontSize: int | None = None
+    clockBarVerticalPadding: int | None = None
 
     # Allow arbitrary fields for extensibility
     model_config = ConfigDict(extra="allow")
@@ -445,6 +449,28 @@ async def get_config():
         config["clockBarLayout"] = "single-line"
     elif "clock_bar_layout" in config and "clockBarLayout" not in config:
         config["clockBarLayout"] = config["clock_bar_layout"]
+    if "clockBarVerticalLayout" not in config and "clock_bar_vertical_layout" not in config:
+        config["clockBarVerticalLayout"] = "upright"
+    elif "clock_bar_vertical_layout" in config and "clockBarVerticalLayout" not in config:
+        config["clockBarVerticalLayout"] = config["clock_bar_vertical_layout"]
+    if "clockBarVerticalFontSize" not in config and "clock_bar_vertical_font_size" not in config:
+        config["clockBarVerticalFontSize"] = 18
+    elif "clock_bar_vertical_font_size" in config and "clockBarVerticalFontSize" not in config:
+        config["clockBarVerticalFontSize"] = config["clock_bar_vertical_font_size"]
+    if (
+        "clockBarVerticalDateFontSize" not in config
+        and "clock_bar_vertical_date_font_size" not in config
+    ):
+        config["clockBarVerticalDateFontSize"] = 11
+    elif (
+        "clock_bar_vertical_date_font_size" in config
+        and "clockBarVerticalDateFontSize" not in config
+    ):
+        config["clockBarVerticalDateFontSize"] = config["clock_bar_vertical_date_font_size"]
+    if "clockBarVerticalPadding" not in config and "clock_bar_vertical_padding" not in config:
+        config["clockBarVerticalPadding"] = 8
+    elif "clock_bar_vertical_padding" in config and "clockBarVerticalPadding" not in config:
+        config["clockBarVerticalPadding"] = config["clock_bar_vertical_padding"]
     if "clockBarPadding" not in config and "clock_bar_padding" not in config:
         config["clockBarPadding"] = 8
     elif "clock_bar_padding" in config and "clockBarPadding" not in config:
@@ -596,6 +622,26 @@ async def update_config(config_update: ConfigUpdate):
     if "timezone" in update_dict:
         # Store timezone as-is (no camelCase conversion needed)
         update_dict["timezone"] = update_dict.pop("timezone")
+    clock_key_map = {
+        "clockShowDate": "clock_show_date",
+        "clockShowSeconds": "clock_show_seconds",
+        "clockBarMode": "clock_bar_mode",
+        "clockBarShowInKiosk": "clock_bar_show_in_kiosk",
+        "clockBarPosition": "clock_bar_position",
+        "clockBarFontSize": "clock_bar_font_size",
+        "clockBarDateFontSize": "clock_bar_date_font_size",
+        "clockBarLayout": "clock_bar_layout",
+        "clockBarVerticalLayout": "clock_bar_vertical_layout",
+        "clockBarVerticalFontSize": "clock_bar_vertical_font_size",
+        "clockBarVerticalDateFontSize": "clock_bar_vertical_date_font_size",
+        "clockBarVerticalPadding": "clock_bar_vertical_padding",
+        "clockBarPadding": "clock_bar_padding",
+        "clockBarShowWeather": "clock_bar_show_weather",
+        "clockBarShowLogo": "clock_bar_show_logo",
+    }
+    for camel_key, snake_key in clock_key_map.items():
+        if camel_key in update_dict:
+            update_dict[snake_key] = update_dict.pop(camel_key)
     if "gitRepoUrl" in update_dict:
         update_dict["git_repo_url"] = update_dict.pop("gitRepoUrl")
         # Also update /etc/default/calvin-update file

--- a/backend/tests/contract/openapi.json
+++ b/backend/tests/contract/openapi.json
@@ -289,6 +289,50 @@
             ],
             "title": "Calendarviewmode"
           },
+          "clockBarVerticalDateFontSize": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Clockbarverticaldatefontsize"
+          },
+          "clockBarVerticalFontSize": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Clockbarverticalfontsize"
+          },
+          "clockBarVerticalLayout": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Clockbarverticallayout"
+          },
+          "clockBarVerticalPadding": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Clockbarverticalpadding"
+          },
           "configPollInterval": {
             "anyOf": [
               {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,7 +33,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     gcc \
     g++ \
-    python3-dev \
     libjpeg-dev \
     zlib1g-dev \
     libpng-dev \

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -48,6 +48,8 @@ services:
     restart: unless-stopped
     ports:
       - "5173:5173"
+    environment:
+      VITE_API_PROXY_TARGET: http://calvin-backend:8000
     volumes:
       - "${CALVIN_REPO_DIR:-..}:/app"
       - calvin-dev-node_modules:/app/frontend/node_modules

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1595,6 +1595,14 @@ export interface components {
       calendarSplit?: number | null;
       /** Calendarviewmode */
       calendarViewMode?: string | null;
+      /** Clockbarverticaldatefontsize */
+      clockBarVerticalDateFontSize?: number | null;
+      /** Clockbarverticalfontsize */
+      clockBarVerticalFontSize?: number | null;
+      /** Clockbarverticallayout */
+      clockBarVerticalLayout?: string | null;
+      /** Clockbarverticalpadding */
+      clockBarVerticalPadding?: number | null;
       /** Configpollinterval */
       configPollInterval?: number | null;
       /** Darkmodeend */

--- a/frontend/src/components/ClockBarHorizontal.vue
+++ b/frontend/src/components/ClockBarHorizontal.vue
@@ -107,6 +107,7 @@ const {
   previewDateSize: () => props.previewDateSize,
   previewLayout: () => props.previewLayout,
   previewPadding: () => props.previewPadding,
+  orientation: () => "horizontal",
 });
 
 const calendarStore = useCalendarStore();
@@ -126,6 +127,9 @@ const showLogo = computed(() => configStore.clockBarShowLogo !== false);
   justify-content: center;
   z-index: 100;
   user-select: none;
+  flex: 0 0 auto;
+  box-sizing: border-box;
+  min-width: 0;
 }
 
 .clock-bar-horizontal.position-bottom {
@@ -176,6 +180,7 @@ const showLogo = computed(() => configStore.clockBarShowLogo !== false);
   align-items: center;
   width: 100%;
   gap: 1rem;
+  min-width: 0;
 }
 
 .clock-bar-side {
@@ -195,6 +200,7 @@ const showLogo = computed(() => configStore.clockBarShowLogo !== false);
 
 .clock-bar-content {
   flex: 0 1 auto;
+  min-width: 0;
 }
 
 .clock-refresh-icon {

--- a/frontend/src/components/ClockBarVertical.vue
+++ b/frontend/src/components/ClockBarVertical.vue
@@ -10,7 +10,9 @@
   >
     <div class="clock-bar-top">
       <BarLogo v-if="showLogo" />
+    </div>
 
+    <div class="clock-bar-middle">
       <div
         class="clock-bar-content"
         :class="{
@@ -117,8 +119,7 @@ const showLogo = computed(() => configStore.clockBarShowLogo !== false);
   border-right: 1px solid var(--border-color);
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: space-between;
+  align-items: stretch;
   gap: 0.75rem;
   z-index: 100;
   user-select: none;
@@ -137,30 +138,48 @@ const showLogo = computed(() => configStore.clockBarShowLogo !== false);
   border-radius: 4px;
 }
 
-.clock-bar-content {
+.clock-bar-top {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 0 0 auto;
+}
+
+.clock-bar-middle {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0.5rem;
+  gap: 0.75rem;
+  min-height: 0;
+}
+
+.clock-bar-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
   font-family: "Courier New", monospace;
-  writing-mode: vertical-rl;
-  text-orientation: upright;
   white-space: nowrap;
+  text-align: center;
 }
 
 .clock-bar-content.layout-two-lines {
-  flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.15rem;
 }
 
 .clock-time {
   font-weight: 600;
   color: var(--text-primary);
+  line-height: 1.1;
 }
 
 .clock-date {
   color: var(--text-secondary);
+  line-height: 1.1;
 }
 
 .clock-bar-vertical.position-between .clock-time {
@@ -171,14 +190,8 @@ const showLogo = computed(() => configStore.clockBarShowLogo !== false);
   font-size: 0.75rem;
 }
 
-.clock-bar-top {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.75rem;
-}
-
 .clock-bar-actions {
   width: 100%;
+  flex: 0 0 auto;
 }
 </style>

--- a/frontend/src/components/ClockBarVertical.vue
+++ b/frontend/src/components/ClockBarVertical.vue
@@ -18,18 +18,55 @@
         :class="{
           'layout-single-line': layout === 'single-line',
           'layout-two-lines': layout === 'two-lines',
+          'layout-vertical-compact': isCompactLayout,
+          'layout-compact-date': layout === 'compact-time-date',
         }"
       >
-        <span class="clock-time" :style="{ fontSize: `${fontSize}px` }">{{ formattedTime }}</span>
-        <span v-if="showDate" class="clock-date" :style="{ fontSize: `${dateFontSize}px` }">{{
-          formattedDate
-        }}</span>
+        <template v-if="isCompactLayout">
+          <span class="clock-time compact-time" :style="{ fontSize: `${fontSize}px` }">
+            <span>{{ compactTimeParts.hour }}</span>
+            <span>{{ compactTimeParts.minute }}</span>
+            <span v-if="compactTimeParts.second">{{ compactTimeParts.second }}</span>
+            <span v-if="compactTimeParts.dayPeriod" class="compact-period">{{
+              compactTimeParts.dayPeriod
+            }}</span>
+          </span>
+          <span
+            v-if="showDate && layout === 'compact-time-date' && compactDateParts"
+            class="clock-date compact-date compact-date-stacked"
+            :style="{ fontSize: `${dateFontSize}px` }"
+          >
+            <span v-if="compactDateParts.weekday">{{ compactDateParts.weekday }}</span>
+            <span>
+              {{ compactDateParts.day }}
+              {{ compactDateParts.month }}
+            </span>
+            <span v-if="compactDateParts.year" class="compact-date-year">{{
+              compactDateParts.year
+            }}</span>
+          </span>
+          <span
+            v-else-if="showDate"
+            class="clock-date compact-date"
+            :style="{ fontSize: `${dateFontSize}px` }"
+          >
+            {{ formattedDate }}
+          </span>
+        </template>
+        <template v-else>
+          <span class="clock-time" :style="{ fontSize: `${fontSize}px` }">{{ formattedTime }}</span>
+          <span v-if="showDate" class="clock-date" :style="{ fontSize: `${dateFontSize}px` }">{{
+            formattedDate
+          }}</span>
+        </template>
       </div>
-
-      <PluginStatusbarItems v-if="showStatusbar" orientation="vertical" />
     </div>
 
-    <BarActionCluster v-if="!previewMode" class="clock-bar-actions" :compact="true" />
+    <div class="clock-bar-bottom">
+      <PluginStatusbarItems v-if="showStatusbar" orientation="vertical" />
+
+      <BarActionCluster v-if="!previewMode" class="clock-bar-actions" :compact="true" />
+    </div>
   </div>
 </template>
 
@@ -90,7 +127,9 @@ const {
   showDate,
   showStatusbar,
   formattedTime,
+  compactTimeParts,
   formattedDate,
+  compactDateParts,
   fontSize,
   dateFontSize,
   layout,
@@ -104,10 +143,14 @@ const {
   previewDateSize: () => props.previewDateSize,
   previewLayout: () => props.previewLayout,
   previewPadding: () => props.previewPadding,
+  orientation: () => "vertical",
 });
 
 const configStore = useConfigStore();
 const showLogo = computed(() => configStore.clockBarShowLogo !== false);
+const isCompactLayout = computed(
+  () => layout.value === "compact-time" || layout.value === "compact-time-date"
+);
 </script>
 
 <style scoped>
@@ -121,10 +164,12 @@ const showLogo = computed(() => configStore.clockBarShowLogo !== false);
   flex-direction: column;
   align-items: stretch;
   gap: 0.75rem;
+  position: relative;
   z-index: 100;
   user-select: none;
   flex-shrink: 0;
   box-sizing: border-box;
+  min-height: 0;
 }
 
 .clock-bar-vertical.position-right {
@@ -156,6 +201,16 @@ const showLogo = computed(() => configStore.clockBarShowLogo !== false);
   min-height: 0;
 }
 
+.clock-bar-bottom {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  min-height: 0;
+}
+
 .clock-bar-content {
   display: flex;
   flex-direction: column;
@@ -169,6 +224,53 @@ const showLogo = computed(() => configStore.clockBarShowLogo !== false);
 
 .clock-bar-content.layout-two-lines {
   gap: 0.15rem;
+}
+
+.clock-bar-content.layout-vertical-compact {
+  flex-direction: column;
+  gap: 0.45rem;
+  writing-mode: horizontal-tb;
+  text-orientation: mixed;
+}
+
+.compact-time {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0;
+  line-height: 0.92;
+  font-variant-numeric: tabular-nums;
+}
+
+.compact-period {
+  margin-top: 0.2rem;
+  font-size: 0.45em;
+  line-height: 1;
+}
+
+.compact-date {
+  max-height: 35vh;
+  writing-mode: vertical-rl;
+  text-orientation: upright;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.compact-date-stacked {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.05rem;
+  max-height: none;
+  writing-mode: horizontal-tb;
+  text-orientation: mixed;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.compact-date-year {
+  font-size: 0.78em;
+  color: var(--text-secondary);
 }
 
 .clock-time {

--- a/frontend/src/components/settings/shared/ClockBarFontSizePicker.vue
+++ b/frontend/src/components/settings/shared/ClockBarFontSizePicker.vue
@@ -83,7 +83,7 @@
       </div>
     </div>
 
-    <div class="preview-container">
+    <div v-if="showPreview" class="preview-container">
       <div class="preview-label">Preview:</div>
       <!-- Use actual clock bar component for preview -->
       <div v-if="isVertical" class="preview-wrapper preview-vertical">
@@ -141,6 +141,10 @@ const props = defineProps({
   isVertical: {
     type: Boolean,
     default: false,
+  },
+  showPreview: {
+    type: Boolean,
+    default: true,
   },
   padding: {
     type: Number,

--- a/frontend/src/components/settings/tabs/dashboard/ClockSettingsTab.vue
+++ b/frontend/src/components/settings/tabs/dashboard/ClockSettingsTab.vue
@@ -26,72 +26,92 @@
       </SettingItem>
     </CollapsibleSection>
 
-    <CollapsibleSection title="Default position" icon="📍" :expanded="true">
-      <p class="section-hint">
-        These are the defaults used when a screen doesn't specify its own clock bar position. To
-        override on a specific screen — including dropping the bar into a gap between regions — open
-        <strong>Screens</strong> in the Dashboard settings.
-      </p>
-
-      <SettingItem label="Bar mode" help="Horizontal bar (top/bottom) or vertical bar (left/right)">
-        <select
-          name="clockBarMode"
-          :value="config.clockBarMode"
-          @change="handleClockSettingsChange"
-        >
-          <option value="horizontal">Horizontal</option>
-          <option value="vertical">Vertical</option>
-        </select>
-      </SettingItem>
-
-      <SettingItem label="Bar position" :help="getBarPositionHelp()">
-        <select
-          name="clockBarPosition"
-          :value="config.clockBarPosition"
-          @change="handleClockSettingsChange"
-        >
-          <template v-if="config.clockBarMode === 'horizontal'">
-            <option value="top">Top</option>
-            <option value="bottom">Bottom</option>
-            <option value="between">Between regions (first gap)</option>
-          </template>
-          <template v-else>
-            <option value="left">Left</option>
-            <option value="right">Right</option>
-            <option value="between">Between regions (first gap)</option>
-          </template>
-        </select>
-      </SettingItem>
-    </CollapsibleSection>
-
     <CollapsibleSection title="Appearance" icon="🎨" :expanded="true">
-      <SettingItem label="Layout" help="Display clock and date on one line or two">
-        <select
-          name="clockBarLayout"
-          :value="config.clockBarLayout || 'single-line'"
-          @change="handleClockSettingsChange"
-        >
-          <option value="single-line">Single line</option>
-          <option value="two-lines">Two lines</option>
-        </select>
-      </SettingItem>
+      <div class="orientation-appearance">
+        <div class="orientation-panel">
+          <h4>Horizontal bars</h4>
+          <SettingItem
+            label="Layout"
+            help="Choose how time and date are arranged on top and bottom bars"
+          >
+            <select
+              name="clockBarLayout"
+              :value="config.clockBarLayout || 'single-line'"
+              @change="handleClockSettingsChange"
+            >
+              <option value="single-line">Single line</option>
+              <option value="two-lines">Two lines</option>
+            </select>
+          </SettingItem>
 
-      <SettingItem
-        label="Font sizes"
-        help="Adjust font sizes for time and date. Preview shows how the bar will look."
-      >
-        <ClockBarFontSizePicker
-          :time-size="config.clockBarFontSize || 16"
-          :date-size="config.clockBarDateFontSize || 14"
-          :layout="config.clockBarLayout || 'single-line'"
-          :padding="config.clockBarPadding || 8"
-          :show-date="config.clockShowDate"
-          :is-vertical="config.clockBarMode === 'vertical'"
-          @update:time-size="handleBarFontSizeChange"
-          @update:date-size="handleBarDateFontSizeChange"
-          @update:padding="handleBarPaddingChange"
-        />
-      </SettingItem>
+          <SettingItem label="Sizing" help="Adjust time, date, and padding for top and bottom bars">
+            <ClockBarFontSizePicker
+              :time-size="config.clockBarFontSize || 16"
+              :date-size="config.clockBarDateFontSize || 14"
+              :layout="config.clockBarLayout || 'single-line'"
+              :padding="config.clockBarPadding || 8"
+              :show-date="config.clockShowDate"
+              :is-vertical="false"
+              @update:time-size="handleBarFontSizeChange"
+              @update:date-size="handleBarDateFontSizeChange"
+              @update:padding="handleBarPaddingChange"
+            />
+          </SettingItem>
+        </div>
+
+        <div class="orientation-panel">
+          <h4>Vertical bars</h4>
+          <SettingItem
+            label="Layout"
+            help="Choose how time and date are arranged on left, right, and between bars"
+          >
+            <div class="vertical-layout-control">
+              <select
+                name="clockBarVerticalLayout"
+                :value="config.clockBarVerticalLayout || 'upright'"
+                @change="handleClockSettingsChange"
+              >
+                <option value="upright">Upright text</option>
+                <option value="compact-time">Compact time</option>
+                <option value="compact-time-date">Compact time and date</option>
+              </select>
+
+              <div class="vertical-layout-preview" aria-label="Vertical clock bar layout preview">
+                <ClockBarVertical
+                  position="left"
+                  :show-in-non-kiosk="true"
+                  :show-in-kiosk="false"
+                  :enabled="true"
+                  :preview-mode="true"
+                  :preview-time-size="config.clockBarVerticalFontSize || 18"
+                  :preview-date-size="config.clockBarVerticalDateFontSize || 11"
+                  :preview-layout="config.clockBarVerticalLayout || 'upright'"
+                  :preview-padding="config.clockBarVerticalPadding || 8"
+                />
+              </div>
+            </div>
+          </SettingItem>
+
+          <SettingItem
+            label="Sizing"
+            help="Adjust time, date, and padding for left, right, and between vertical bars"
+          >
+            <ClockBarFontSizePicker
+              :time-size="config.clockBarVerticalFontSize || 18"
+              :date-size="config.clockBarVerticalDateFontSize || 11"
+              :layout="config.clockBarVerticalLayout || 'upright'"
+              :padding="config.clockBarVerticalPadding || 8"
+              :show-date="config.clockShowDate"
+              :is-vertical="true"
+              :show-preview="false"
+              :max="48"
+              @update:time-size="handleVerticalBarFontSizeChange"
+              @update:date-size="handleVerticalBarDateFontSizeChange"
+              @update:padding="handleVerticalBarPaddingChange"
+            />
+          </SettingItem>
+        </div>
+      </div>
 
       <SettingItem
         label="Show Calvin logo"
@@ -147,8 +167,9 @@
 import CollapsibleSection from "../../shared/CollapsibleSection.vue";
 import SettingItem from "../../shared/SettingItem.vue";
 import ClockBarFontSizePicker from "../../shared/ClockBarFontSizePicker.vue";
+import ClockBarVertical from "@/components/ClockBarVertical.vue";
 
-const props = defineProps({
+defineProps({
   config: {
     type: Object,
     required: true,
@@ -173,13 +194,6 @@ const handleClockSettingsChange = event => {
   emit("update:config", updates);
 };
 
-const getBarPositionHelp = () => {
-  if (props.config.clockBarMode === "horizontal") {
-    return "Top/bottom always render. 'Between' shows when the screen layout stacks regions vertically.";
-  }
-  return "Left/right always render. 'Between' shows when the screen layout places regions side by side.";
-};
-
 const handleBarFontSizeChange = px => {
   emit("update:config", { clockBarFontSize: px });
 };
@@ -190,6 +204,18 @@ const handleBarDateFontSizeChange = px => {
 
 const handleBarPaddingChange = px => {
   emit("update:config", { clockBarPadding: px });
+};
+
+const handleVerticalBarFontSizeChange = px => {
+  emit("update:config", { clockBarVerticalFontSize: px });
+};
+
+const handleVerticalBarDateFontSizeChange = px => {
+  emit("update:config", { clockBarVerticalDateFontSize: px });
+};
+
+const handleVerticalBarPaddingChange = px => {
+  emit("update:config", { clockBarVerticalPadding: px });
 };
 </script>
 
@@ -214,5 +240,52 @@ const handleBarPaddingChange = px => {
 
 .section-hint strong {
   color: var(--text-primary);
+}
+
+.orientation-appearance {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.orientation-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding-block: 0.25rem;
+}
+
+.orientation-panel + .orientation-panel {
+  border-top: 1px solid var(--border-color);
+  padding-top: 1.25rem;
+}
+
+.orientation-panel h4 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.vertical-layout-control {
+  display: flex;
+  align-items: stretch;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.vertical-layout-control select {
+  align-self: flex-start;
+}
+
+.vertical-layout-preview {
+  width: 7rem;
+  height: 16rem;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  background: var(--bg-primary);
+  overflow: hidden;
+  display: flex;
+  align-items: stretch;
 }
 </style>

--- a/frontend/src/components/settings/tabs/dashboard/DashboardLayoutTab.vue
+++ b/frontend/src/components/settings/tabs/dashboard/DashboardLayoutTab.vue
@@ -73,6 +73,26 @@
               @change="handleScreenNameChange(screenIndex, $event)"
             />
             <button
+              type="button"
+              class="screen-activate"
+              :class="{ 'screen-activate-active': isActiveScreen(screen) }"
+              :disabled="isActiveScreen(screen)"
+              :aria-pressed="isActiveScreen(screen)"
+              :aria-label="
+                isActiveScreen(screen)
+                  ? `Screen ${screenIndex + 1} is active`
+                  : `Activate screen ${screenIndex + 1}`
+              "
+              :title="
+                isActiveScreen(screen)
+                  ? 'This screen is currently shown on the dashboard'
+                  : 'Show this screen on the dashboard'
+              "
+              @click="activateScreen(screenIndex)"
+            >
+              {{ isActiveScreen(screen) ? "● Active" : "Activate" }}
+            </button>
+            <button
               :id="`add-region-${screen.id}`"
               type="button"
               class="add-region-button"
@@ -865,6 +885,16 @@ const setScreenClockBarEnabled = (screenIndex, enabled) => {
   updateScreenClockBar(screenIndex, { enabled });
 };
 
+const isActiveScreen = screen => screen?.id === dashboardScreens.value.activeScreenId;
+
+const activateScreen = screenIndex => {
+  const screens = cloneScreens();
+  const target = screens.screens[screenIndex];
+  if (!target) return;
+  screens.activeScreenId = target.id;
+  emitScreensUpdate(screens);
+};
+
 const dashboardScreens = computed(() => configValue.value.dashboardScreens);
 
 const expandedScreens = reactive(new Set([dashboardScreens.value.activeScreenId]));
@@ -1467,6 +1497,35 @@ onUnmounted(() => {
 .direction-toggle:focus {
   border-color: var(--accent-primary);
   color: var(--text-primary);
+}
+
+.screen-activate {
+  flex: 0 0 auto;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  padding: 0.35rem 0.6rem;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.screen-activate:hover:not(:disabled),
+.screen-activate:focus:not(:disabled) {
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+}
+
+.screen-activate-active {
+  border-color: var(--accent-primary);
+  background: var(--accent-primary);
+  color: #fff;
+  cursor: default;
+}
+
+.screen-activate:disabled {
+  opacity: 1;
 }
 
 .screen-delete {

--- a/frontend/src/composables/useClockBar.js
+++ b/frontend/src/composables/useClockBar.js
@@ -13,6 +13,7 @@ import { useConfigStore } from "../stores/config";
  * @param {() => number|null} [opts.previewDateSize]
  * @param {() => string|null} [opts.previewLayout]
  * @param {() => number|null} [opts.previewPadding]
+ * @param {() => 'horizontal'|'vertical'} [opts.orientation]
  */
 export function useClockBar(opts) {
   const configStore = useConfigStore();
@@ -20,6 +21,7 @@ export function useClockBar(opts) {
   const get = (fn, fallback = null) => (typeof fn === "function" ? fn() : fallback);
 
   const isPreview = computed(() => !!get(opts.previewMode, false));
+  const orientation = computed(() => get(opts.orientation, "horizontal"));
 
   const shouldShow = computed(() => {
     if (isPreview.value) return true;
@@ -38,24 +40,31 @@ export function useClockBar(opts) {
   const fontSize = computed(() => {
     const preview = get(opts.previewTimeSize, null);
     if (isPreview.value && preview !== null) return preview;
+    if (orientation.value === "vertical") return configStore.clockBarVerticalFontSize || 18;
     return configStore.clockBarFontSize || 16;
   });
 
   const dateFontSize = computed(() => {
     const preview = get(opts.previewDateSize, null);
     if (isPreview.value && preview !== null) return preview;
+    if (orientation.value === "vertical") return configStore.clockBarVerticalDateFontSize || 11;
     return configStore.clockBarDateFontSize || 14;
   });
 
   const layout = computed(() => {
     const preview = get(opts.previewLayout, null);
     if (isPreview.value && preview !== null) return preview;
+    if (orientation.value === "vertical") {
+      if (configStore.clockBarVerticalLayout) return configStore.clockBarVerticalLayout;
+      return configStore.clockBarLayout === "vertical-compact" ? "compact-time" : "upright";
+    }
     return configStore.clockBarLayout || "single-line";
   });
 
   const barPadding = computed(() => {
     const preview = get(opts.previewPadding, null);
     if (isPreview.value && preview !== null) return preview;
+    if (orientation.value === "vertical") return configStore.clockBarVerticalPadding || 8;
     return configStore.clockBarPadding || 8;
   });
 
@@ -89,6 +98,37 @@ export function useClockBar(opts) {
     }
   });
 
+  const compactTimeParts = computed(() => {
+    const now = currentTime.value;
+    const fallback = {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: timeFormat.value === "12h",
+    };
+    if (showSeconds.value) fallback.second = "2-digit";
+    if (timezone.value) fallback.timeZone = timezone.value;
+
+    try {
+      const formatter = new Intl.DateTimeFormat(undefined, fallback);
+      const parts = formatter.formatToParts(now);
+      return {
+        hour: parts.find(part => part.type === "hour")?.value || "00",
+        minute: parts.find(part => part.type === "minute")?.value || "00",
+        second: showSeconds.value ? parts.find(part => part.type === "second")?.value || "" : "",
+        dayPeriod: parts.find(part => part.type === "dayPeriod")?.value || "",
+      };
+    } catch {
+      const [time, dayPeriod = ""] = now.toLocaleTimeString(undefined, fallback).split(" ");
+      const [hour = "00", minute = "00", second = ""] = time.split(":");
+      return {
+        hour,
+        minute,
+        second: showSeconds.value ? second : "",
+        dayPeriod,
+      };
+    }
+  });
+
   const formattedDate = computed(() => {
     if (!showDate.value) return "";
     const now = currentTime.value;
@@ -108,6 +148,31 @@ export function useClockBar(opts) {
         month: "short",
         day: "numeric",
       });
+    }
+  });
+
+  const compactDateParts = computed(() => {
+    if (!showDate.value) return null;
+    const now = currentTime.value;
+    const options = {
+      weekday: "short",
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    };
+    if (timezone.value) options.timeZone = timezone.value;
+
+    try {
+      const formatter = new Intl.DateTimeFormat(undefined, options);
+      const parts = formatter.formatToParts(now);
+      return {
+        weekday: parts.find(part => part.type === "weekday")?.value || "",
+        month: parts.find(part => part.type === "month")?.value || "",
+        day: parts.find(part => part.type === "day")?.value || "",
+        year: parts.find(part => part.type === "year")?.value || "",
+      };
+    } catch {
+      return null;
     }
   });
 
@@ -164,7 +229,9 @@ export function useClockBar(opts) {
     showDate,
     showStatusbar,
     formattedTime,
+    compactTimeParts,
     formattedDate,
+    compactDateParts,
     fontSize,
     dateFontSize,
     layout,

--- a/frontend/src/composables/useConfigForm.js
+++ b/frontend/src/composables/useConfigForm.js
@@ -147,7 +147,23 @@ export function useConfigForm(initialConfig = {}) {
         clockBarFontSize: response.clockBarFontSize ?? response.clock_bar_font_size ?? 16,
         clockBarDateFontSize:
           response.clockBarDateFontSize ?? response.clock_bar_date_font_size ?? 14,
-        clockBarLayout: response.clockBarLayout ?? response.clock_bar_layout ?? "single-line",
+        clockBarLayout:
+          response.clockBarLayout === "two-lines" || response.clock_bar_layout === "two-lines"
+            ? "two-lines"
+            : "single-line",
+        clockBarVerticalLayout:
+          response.clockBarVerticalLayout ??
+          response.clock_bar_vertical_layout ??
+          (response.clockBarLayout === "vertical-compact" ||
+          response.clock_bar_layout === "vertical-compact"
+            ? "compact-time"
+            : "upright"),
+        clockBarVerticalFontSize:
+          response.clockBarVerticalFontSize ?? response.clock_bar_vertical_font_size ?? 18,
+        clockBarVerticalDateFontSize:
+          response.clockBarVerticalDateFontSize ?? response.clock_bar_vertical_date_font_size ?? 11,
+        clockBarVerticalPadding:
+          response.clockBarVerticalPadding ?? response.clock_bar_vertical_padding ?? 8,
         clockBarPadding: response.clockBarPadding ?? response.clock_bar_padding ?? 8,
         clockBarShowWeather:
           response.clockBarShowWeather ?? response.clock_bar_show_weather ?? false,

--- a/frontend/src/stores/config.js
+++ b/frontend/src/stores/config.js
@@ -58,6 +58,10 @@ export const useConfigStore = defineStore("config", () => {
   const clockBarFontSize = ref(16);
   const clockBarDateFontSize = ref(14);
   const clockBarLayout = ref("single-line"); // 'single-line' | 'two-lines'
+  const clockBarVerticalLayout = ref("upright"); // 'upright' | 'compact-time' | 'compact-time-date'
+  const clockBarVerticalFontSize = ref(18);
+  const clockBarVerticalDateFontSize = ref(11);
+  const clockBarVerticalPadding = ref(8);
   const clockBarPadding = ref(8);
   const clockBarShowWeather = ref(false);
   const clockBarShowLogo = ref(true);
@@ -114,6 +118,10 @@ export const useConfigStore = defineStore("config", () => {
     clockBarFontSize,
     clockBarDateFontSize,
     clockBarLayout,
+    clockBarVerticalLayout,
+    clockBarVerticalFontSize,
+    clockBarVerticalDateFontSize,
+    clockBarVerticalPadding,
     clockBarPadding,
     clockBarShowWeather,
     clockBarShowLogo,
@@ -399,6 +407,10 @@ export const useConfigStore = defineStore("config", () => {
     clockBarFontSize,
     clockBarDateFontSize,
     clockBarLayout,
+    clockBarVerticalLayout,
+    clockBarVerticalFontSize,
+    clockBarVerticalDateFontSize,
+    clockBarVerticalPadding,
     clockBarPadding,
     clockBarShowWeather,
     clockBarShowLogo,

--- a/frontend/src/stores/configRegistry.js
+++ b/frontend/src/stores/configRegistry.js
@@ -194,6 +194,33 @@ export const CONFIG_FIELD_DEFINITIONS = [
     name: "clockBarLayout",
     keys: ["clockBarLayout", "clock_bar_layout"],
     defaultValue: "single-line",
+    parse: value => (value === "two-lines" ? "two-lines" : "single-line"),
+  },
+  {
+    name: "clockBarVerticalLayout",
+    keys: ["clockBarVerticalLayout", "clock_bar_vertical_layout"],
+    defaultValue: "upright",
+    parse: value =>
+      ["upright", "compact-time", "compact-time-date"].includes(value)
+        ? value
+        : value === "vertical-compact"
+          ? "compact-time"
+          : "upright",
+  },
+  {
+    name: "clockBarVerticalFontSize",
+    keys: ["clockBarVerticalFontSize", "clock_bar_vertical_font_size"],
+    defaultValue: 18,
+  },
+  {
+    name: "clockBarVerticalDateFontSize",
+    keys: ["clockBarVerticalDateFontSize", "clock_bar_vertical_date_font_size"],
+    defaultValue: 11,
+  },
+  {
+    name: "clockBarVerticalPadding",
+    keys: ["clockBarVerticalPadding", "clock_bar_vertical_padding"],
+    defaultValue: 8,
   },
   { name: "clockBarPadding", keys: ["clockBarPadding", "clock_bar_padding"], defaultValue: 8 },
   {

--- a/frontend/src/utils/layout.js
+++ b/frontend/src/utils/layout.js
@@ -286,7 +286,7 @@ export function getGlobalClockBarSettings(config = {}) {
   return {
     enabled: true,
     mode: config.clockBarMode === "vertical" ? "vertical" : "horizontal",
-    position: config.clockBarPosition ?? "top",
+    position: normalizeClockBarPosition(config.clockBarPosition, 2) || "top",
   };
 }
 

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -184,16 +184,12 @@ const showHorizontalBarBottom = computed(
 // a horizontal strip when regions stack and a vertical strip when they sit
 // side by side, regardless of whether the user picked horizontal or vertical
 // mode for the perimeter case.
-const showHorizontalBarBetween = computed(
-  () =>
-    clockBarActive.value &&
-    clockBarPlacementGap.value !== null &&
-    layoutDirection.value === "column"
-);
-
-const showVerticalBarBetween = computed(
-  () =>
-    clockBarActive.value && clockBarPlacementGap.value !== null && layoutDirection.value === "row"
+const betweenClockBarElement = computed(() =>
+  clockBarActive.value && clockBarPlacementGap.value !== null
+    ? layoutDirection.value === "row"
+      ? "verticalBarBetween"
+      : "horizontalBarBetween"
+    : null
 );
 
 const showVerticalBarLeft = computed(
@@ -213,8 +209,7 @@ const layoutOrder = computed(() => {
   const elements = [];
   regionElements.forEach((regionElement, index) => {
     if (index > 0 && index - 1 === placedBetween) {
-      if (showHorizontalBarBetween.value) elements.push("horizontalBarBetween");
-      else if (showVerticalBarBetween.value) elements.push("verticalBarBetween");
+      if (betweenClockBarElement.value) elements.push(betweenClockBarElement.value);
     }
     elements.push(regionElement);
   });
@@ -343,9 +338,11 @@ onUnmounted(() => {
 
 .mode-content {
   width: 100%;
-  height: 100%;
+  flex: 1 1 auto;
   display: flex;
   gap: 1rem;
+  min-height: 0;
+  min-width: 0;
 }
 
 .mode-content.dashboard-view.layout-portrait {

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -13,91 +13,95 @@
       <!-- Minimal UI overlay (shown when UI is hidden) -->
       <MinimalUIOverlay v-if="!configStore.shouldShowUI" />
 
-      <div :class="['dashboard-main', mainLayoutClass]">
-        <!-- Fullscreen Mode (Photos or Web Services) -->
-        <div v-if="modeStore.isFullscreen" class="mode-content fullscreen-mode">
-          <!-- Fullscreen Photos -->
-          <PhotoSlideshow
-            v-if="modeStore.fullscreenMode === modeStore.MODES.PHOTOS"
-            :is-fullscreen="true"
-            :auto-rotate="true"
-            :rotation-interval="configStore.photoRotationInterval * 1000"
-          />
-          <!-- Fullscreen Web Services -->
-          <WebServiceViewer
-            v-else-if="modeStore.fullscreenMode === modeStore.MODES.WEB_SERVICES"
-            :is-fullscreen="true"
-          />
-        </div>
+      <!--
+        Dashboard stage wraps the side perimeter bars and the body so that
+        vertical left/right bars sit at the dashboard edge regardless of the
+        active screen's layout direction (row vs column).
+      -->
+      <div class="dashboard-stage">
+        <ClockBarVertical
+          v-if="showVerticalBarLeft"
+          position="left"
+          :show-in-non-kiosk="true"
+          :show-in-kiosk="configStore.clockBarShowInKiosk"
+          :enabled="true"
+        />
 
-        <!-- Dashboard View (Home) - Renders configured dashboard regions -->
-        <div v-else :class="['mode-content', 'dashboard-view', mainLayoutClass]">
-          <!-- Render elements in computed order - no CSS order needed! -->
-          <template v-for="elementType in layoutOrder" :key="elementType">
-            <!-- Vertical Clock Bar at Left -->
-            <ClockBarVertical
-              v-if="elementType === 'verticalBarLeft'"
-              position="left"
-              :show-in-non-kiosk="true"
-              :show-in-kiosk="configStore.clockBarShowInKiosk"
-              :enabled="true"
+        <div :class="['dashboard-main', mainLayoutClass]">
+          <!-- Fullscreen Mode (Photos or Web Services) -->
+          <div v-if="modeStore.isFullscreen" class="mode-content fullscreen-mode">
+            <!-- Fullscreen Photos -->
+            <PhotoSlideshow
+              v-if="modeStore.fullscreenMode === modeStore.MODES.PHOTOS"
+              :is-fullscreen="true"
+              :auto-rotate="true"
+              :rotation-interval="configStore.photoRotationInterval * 1000"
             />
+            <!-- Fullscreen Web Services -->
+            <WebServiceViewer
+              v-else-if="modeStore.fullscreenMode === modeStore.MODES.WEB_SERVICES"
+              :is-fullscreen="true"
+            />
+          </div>
 
-            <!-- Dashboard Region -->
-            <div
-              v-else-if="isRegionElement(elementType)"
-              :class="[
-                'dashboard-region-section',
-                {
-                  'dashboard-region-section-active':
-                    activeRegionHighlightVisible && isActiveRegionElement(elementType),
-                },
-              ]"
-              :style="getRegionStyle(elementType)"
-            >
-              <DashboardRegion
-                :region="getRegionForElement(elementType)"
-                :photo-rotation-interval="configStore.photoRotationInterval"
-                :parent-direction="layoutDirection"
-                :active-region-id="
-                  activeRegionHighlightVisible ? activeScreen.activeRegionId : null
-                "
+          <!-- Dashboard View (Home) - Renders configured dashboard regions -->
+          <div v-else :class="['mode-content', 'dashboard-view', mainLayoutClass]">
+            <template v-for="elementType in layoutOrder" :key="elementType">
+              <!-- Dashboard Region -->
+              <div
+                v-if="isRegionElement(elementType)"
+                :class="[
+                  'dashboard-region-section',
+                  {
+                    'dashboard-region-section-active':
+                      activeRegionHighlightVisible && isActiveRegionElement(elementType),
+                  },
+                ]"
+                :style="getRegionStyle(elementType)"
+              >
+                <DashboardRegion
+                  :region="getRegionForElement(elementType)"
+                  :photo-rotation-interval="configStore.photoRotationInterval"
+                  :parent-direction="layoutDirection"
+                  :active-region-id="
+                    activeRegionHighlightVisible ? activeScreen.activeRegionId : null
+                  "
+                />
+              </div>
+
+              <!-- Horizontal between bar (regions stacked vertically) -->
+              <ClockBarHorizontal
+                v-else-if="elementType === 'horizontalBarBetween'"
+                position="between"
+                :show-in-non-kiosk="true"
+                :show-in-kiosk="configStore.clockBarShowInKiosk"
+                :enabled="true"
               />
-            </div>
 
-            <!-- Horizontal Clock Bar Between (Portrait) -->
-            <ClockBarHorizontal
-              v-else-if="elementType === 'horizontalBarBetween'"
-              position="between"
-              :show-in-non-kiosk="true"
-              :show-in-kiosk="configStore.clockBarShowInKiosk"
-              :enabled="true"
-            />
+              <!-- Vertical between bar (regions side by side) -->
+              <ClockBarVertical
+                v-else-if="elementType === 'verticalBarBetween'"
+                position="between"
+                :show-in-non-kiosk="true"
+                :show-in-kiosk="configStore.clockBarShowInKiosk"
+                :enabled="true"
+              />
+            </template>
+          </div>
 
-            <!-- Vertical Clock Bar Between (Landscape) -->
-            <ClockBarVertical
-              v-else-if="elementType === 'verticalBarBetween'"
-              position="between"
-              :show-in-non-kiosk="true"
-              :show-in-kiosk="configStore.clockBarShowInKiosk"
-              :enabled="true"
-            />
-
-            <!-- Vertical Clock Bar at Right -->
-            <ClockBarVertical
-              v-else-if="elementType === 'verticalBarRight'"
-              position="right"
-              :show-in-non-kiosk="true"
-              :show-in-kiosk="configStore.clockBarShowInKiosk"
-              :enabled="true"
-            />
-          </template>
+          <!-- Horizontal Clock Bar at Bottom -->
+          <ClockBarHorizontal
+            v-if="showHorizontalBarBottom"
+            position="bottom"
+            :show-in-non-kiosk="true"
+            :show-in-kiosk="configStore.clockBarShowInKiosk"
+            :enabled="true"
+          />
         </div>
 
-        <!-- Horizontal Clock Bar at Bottom -->
-        <ClockBarHorizontal
-          v-if="showHorizontalBarBottom"
-          position="bottom"
+        <ClockBarVertical
+          v-if="showVerticalBarRight"
+          position="right"
           :show-in-non-kiosk="true"
           :show-in-kiosk="configStore.clockBarShowInKiosk"
           :enabled="true"
@@ -175,12 +179,21 @@ const showHorizontalBarBottom = computed(
   () => clockBarActive.value && isHorizontalMode.value && clockBarPosition.value === "bottom"
 );
 
+// Between-bar orientation follows the layout direction (perpendicular to the
+// region flow), not the user-selected mode. So a 'between' position renders as
+// a horizontal strip when regions stack and a vertical strip when they sit
+// side by side, regardless of whether the user picked horizontal or vertical
+// mode for the perimeter case.
 const showHorizontalBarBetween = computed(
   () =>
     clockBarActive.value &&
-    isHorizontalMode.value &&
     clockBarPlacementGap.value !== null &&
     layoutDirection.value === "column"
+);
+
+const showVerticalBarBetween = computed(
+  () =>
+    clockBarActive.value && clockBarPlacementGap.value !== null && layoutDirection.value === "row"
 );
 
 const showVerticalBarLeft = computed(
@@ -191,43 +204,22 @@ const showVerticalBarRight = computed(
   () => clockBarActive.value && isVerticalMode.value && clockBarPosition.value === "right"
 );
 
-const showVerticalBarBetween = computed(
-  () =>
-    clockBarActive.value &&
-    isVerticalMode.value &&
-    clockBarPlacementGap.value !== null &&
-    layoutDirection.value === "row"
-);
-
 // Computed layout order - determines the order elements should be rendered
 const layoutOrder = computed(() => {
   const regionElements = activeScreen.value.layout.regions.map(region => `region:${region.id}`);
-  if (regionElements.length <= 1) {
-    return withOuterClockBars(regionElements);
-  }
+  if (regionElements.length <= 1) return regionElements;
 
   const placedBetween = clockBarPlacementGap.value;
-
   const elements = [];
-  if (showVerticalBarLeft.value) elements.push("verticalBarLeft");
   regionElements.forEach((regionElement, index) => {
     if (index > 0 && index - 1 === placedBetween) {
-      if (showVerticalBarBetween.value) elements.push("verticalBarBetween");
-      else if (showHorizontalBarBetween.value) elements.push("horizontalBarBetween");
+      if (showHorizontalBarBetween.value) elements.push("horizontalBarBetween");
+      else if (showVerticalBarBetween.value) elements.push("verticalBarBetween");
     }
     elements.push(regionElement);
   });
-  if (showVerticalBarRight.value) elements.push("verticalBarRight");
   return elements;
 });
-
-const withOuterClockBars = regionElements => {
-  const elements = [];
-  if (showVerticalBarLeft.value) elements.push("verticalBarLeft");
-  elements.push(...regionElements);
-  if (showVerticalBarRight.value) elements.push("verticalBarRight");
-  return elements;
-};
 
 const isRegionElement = elementType => elementType.startsWith("region:");
 
@@ -332,20 +324,21 @@ onUnmounted(() => {
   background: var(--bg-secondary);
 }
 
+.dashboard-stage {
+  flex: 1;
+  display: flex;
+  flex-direction: row;
+  min-height: 0;
+  min-width: 0;
+}
+
 .dashboard-main {
   flex: 1;
   display: flex;
+  flex-direction: column;
   gap: 1rem;
-  min-height: 0; /* Important for flex children */
-  flex-direction: row; /* Default to row (landscape) */
-}
-
-.dashboard-main.layout-portrait {
-  flex-direction: column; /* Portrait: stack vertically */
-}
-
-.dashboard-main.layout-landscape {
-  flex-direction: row; /* Landscape: side by side */
+  min-height: 0;
+  min-width: 0;
 }
 
 .mode-content {

--- a/frontend/tests/unit/components/ClockBarVertical.spec.js
+++ b/frontend/tests/unit/components/ClockBarVertical.spec.js
@@ -130,11 +130,11 @@ describe("ClockBarVertical", () => {
     expect(wrapper.find(".clock-bar-vertical.position-right").exists()).toBe(true);
   });
 
-  it("should display time and date on same line", () => {
+  it("should display compact time and date for compact vertical layout", () => {
     const store = useConfigStore();
     store.showUI = true;
     store.clockShowDate = true;
-    store.clockBarLayout = "single-line";
+    store.clockBarVerticalLayout = "compact-time-date";
 
     const wrapper = mount(ClockBarVertical, {
       props: {
@@ -150,8 +150,8 @@ describe("ClockBarVertical", () => {
 
     const content = wrapper.find(".clock-bar-content");
     expect(content.exists()).toBe(true);
-    // Check that layout is single-line (time and date on same line)
-    expect(content.classes()).toContain("layout-single-line");
+    expect(content.classes()).toContain("layout-vertical-compact");
+    expect(content.classes()).toContain("layout-compact-date");
     expect(wrapper.find(".clock-time").exists()).toBe(true);
     expect(wrapper.find(".clock-date").exists()).toBe(true);
   });
@@ -219,7 +219,7 @@ describe("ClockBarVertical", () => {
   it("should apply font size from config", () => {
     const store = useConfigStore();
     store.showUI = true;
-    store.clockBarFontSize = 18;
+    store.clockBarVerticalFontSize = 18;
 
     const wrapper = mount(ClockBarVertical, {
       props: {

--- a/frontend/tests/unit/components/ClockSettingsTab.spec.js
+++ b/frontend/tests/unit/components/ClockSettingsTab.spec.js
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
 import ClockSettingsTab from "@/components/settings/tabs/dashboard/ClockSettingsTab.vue";
 
 const baseConfig = {
@@ -18,6 +19,10 @@ const baseConfig = {
 };
 
 describe("ClockSettingsTab", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
   function mountTab(configOverrides = {}) {
     return mount(ClockSettingsTab, {
       props: {

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -131,7 +131,7 @@ export default defineConfig({
   server: {
     proxy: {
       "/api": {
-        target: "http://localhost:8000",
+        target: process.env.VITE_API_PROXY_TARGET || "http://127.0.0.1:8000",
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary

- Reworks dashboard clock bar rendering so top/bottom, left/right, and between-region bars occupy predictable flex slots.
- Adds vertical-specific clock bar layout, font size, date size, and padding settings, including compact vertical time/date options.
- Groups clock bar appearance settings by horizontal and vertical bar orientation, with a single vertical preview slice.
- Defaults inherited clock bars to top horizontal while keeping per-screen controls for moving bars around the dashboard.

## Why

The clock bar could disappear or render poorly depending on position because bars and dashboard regions competed for the same flex space. Vertical bars also needed layout controls that make sense for narrow bars without affecting horizontal bars.

## Validation

- `npm run lint`
- `npm run build`
- `python -m py_compile backend/app/api/routes/config.py`
- pre-commit hooks during commit: ruff format, ruff, eslint, prettier

## Notes

Unrelated local changes were left unstaged: `frontend/package-lock.json` and `.claude/worktrees/`.