### PR TITLE
Consolidate stdlib logging bridge into app.main (closes #44)

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,31 +1,13 @@
 """Database configuration and session management."""
 
-import logging
-import os
-
 import databases
 from loguru import logger
 from sqlalchemy import MetaData
 
 from app.config import settings
 
-# CALVIN_SQL_ECHO=1 turns on SQL statement logging without editing this file.
-#
-# Runtime queries go Ormar -> `databases` lib -> aiosqlite (NOT through a SQLAlchemy
-# engine), so the useful logger is `databases`. We also flip the SQLAlchemy loggers
-# because metadata.create_all() in init/tests does run through a sync SA engine.
-# All emitted records flow through loguru via InterceptHandler in app.main.
-_SQL_ECHO = os.environ.get("CALVIN_SQL_ECHO") == "1"
-_sql_log_level = logging.DEBUG if _SQL_ECHO else logging.WARNING
-
-# Runtime queries — Ormar/databases lib
-logging.getLogger("databases").setLevel(_sql_log_level)
-
-# Schema/init — SQLAlchemy core (metadata.create_all, sync engine in init_db)
-for _name in ("sqlalchemy.engine", "sqlalchemy.pool", "sqlalchemy.dialects"):
-    _lg = logging.getLogger(_name)
-    _lg.setLevel(_sql_log_level)
-    _lg.propagate = True
+# SQL logger configuration (CALVIN_SQL_ECHO) lives in app.main alongside the
+# rest of the loguru/InterceptHandler bridge.
 
 # Create database connection for Ormar
 # Use absolute path to avoid path resolution issues

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -96,16 +96,20 @@ class InterceptHandler(logging.Handler):
 # Set up standard logging interception for compatibility
 logging.basicConfig(handlers=[InterceptHandler()], level=0, force=True)
 
-# Reduce SQLAlchemy verbosity by setting its loggers to WARNING
-# This must be done BEFORE database.py is imported (which creates the engine)
-sqlalchemy_loggers = [
+# Configure SQL-related stdlib loggers to flow through InterceptHandler.
+# CALVIN_SQL_ECHO=1 turns on SQL statement logging without editing this file.
+# Runtime queries go Ormar -> `databases` lib -> aiosqlite, so `databases` is
+# the useful logger; SQLAlchemy loggers cover metadata.create_all() in init.
+# Must be done BEFORE database.py is imported (which creates the engine).
+_sql_log_level = logging.DEBUG if os.environ.get("CALVIN_SQL_ECHO") == "1" else logging.WARNING
+for sql_logger_name in (
+    "databases",
     "sqlalchemy.engine",
     "sqlalchemy.pool",
     "sqlalchemy.dialects",
-]
-for sql_logger_name in sqlalchemy_loggers:
+):
     sql_logger = logging.getLogger(sql_logger_name)
-    sql_logger.setLevel(logging.WARNING)
+    sql_logger.setLevel(_sql_log_level)
     sql_logger.handlers = [InterceptHandler()]
     sql_logger.propagate = False
 


### PR DESCRIPTION
## Summary
- Moves `CALVIN_SQL_ECHO`-aware SQL logger configuration out of `database.py` and into `main.py`, alongside the existing `InterceptHandler` setup.
- `main.py` is now the only `import logging` site in `backend/app/`, satisfying the bridge-only contract called out in CLAUDE.md and issue #44's acceptance criteria.
- The originally-listed migration targets in #44 (`plugin_installer.py`, `instance_manager.py`, `instances.py`, `db_retry.py`) were already on loguru — this PR is the final tidy-up.

## Test plan
- [x] `uv run pytest -x -q` — 682 passed, 16 skipped
- [ ] Manually verify `CALVIN_SQL_ECHO=1` still surfaces SQL queries through loguru

Closes #44.